### PR TITLE
Use LinkIndex instead of Link obj in Route, Neigh

### DIFF
--- a/neigh.go
+++ b/neigh.go
@@ -7,7 +7,7 @@ import (
 
 // Neigh represents a link layer neighbor from netlink.
 type Neigh struct {
-	Link         Link
+	LinkIndex    int
 	Family       int
 	State        int
 	Type         int

--- a/neigh_linux.go
+++ b/neigh_linux.go
@@ -104,7 +104,7 @@ func neighHandle(neigh *Neigh, req *nl.NetlinkRequest) error {
 
 	msg := Ndmsg{
 		Family: uint8(family),
-		Index:  uint32(neigh.Link.Attrs().Index),
+		Index:  uint32(neigh.LinkIndex),
 		State:  uint16(neigh.State),
 		Type:   uint8(neigh.Type),
 		Flags:  uint8(neigh.Flags),
@@ -163,17 +163,12 @@ func NeighList(linkIndex, family int) ([]Neigh, error) {
 func NeighDeserialize(m []byte) (*Neigh, error) {
 	msg := deserializeNdmsg(m)
 
-	link, err := LinkByIndex(int(msg.Index))
-	if err != nil {
-		return nil, err
-	}
-
 	neigh := Neigh{
-		Family: int(msg.Family),
-		State:  int(msg.State),
-		Type:   int(msg.Type),
-		Flags:  int(msg.Flags),
-		Link:   link,
+		LinkIndex: int(msg.Index),
+		Family:    int(msg.Family),
+		State:     int(msg.State),
+		Type:      int(msg.Type),
+		Flags:     int(msg.Flags),
 	}
 
 

--- a/neigh_test.go
+++ b/neigh_test.go
@@ -46,7 +46,7 @@ func TestNeighAddDel(t *testing.T) {
 	// Add the arpTable
 	for _, entry := range arpTable {
 		err := NeighAdd(&Neigh{
-			Link:         &dummy,
+			LinkIndex:    dummy.Index,
 			State:        NUD_REACHABLE,
 			IP:           entry.ip,
 			HardwareAddr: entry.mac,
@@ -74,7 +74,7 @@ func TestNeighAddDel(t *testing.T) {
 	// Delete the arpTable
 	for _, entry := range arpTable {
 		err := NeighDel(&Neigh{
-			Link:         &dummy,
+			LinkIndex:    dummy.Index,
 			IP:           entry.ip,
 			HardwareAddr: entry.mac,
 		})

--- a/route.go
+++ b/route.go
@@ -22,15 +22,14 @@ const (
 // gateway. Advanced route parameters and non-main routing tables are
 // currently not supported.
 type Route struct {
-	Link  Link
-	Scope Scope
-	Dst   *net.IPNet
-	Src   net.IP
-	Gw    net.IP
+	LinkIndex int
+	Scope     Scope
+	Dst       *net.IPNet
+	Src       net.IP
+	Gw        net.IP
 }
 
 func (r Route) String() string {
-	base := r.Link.Attrs()
-	return fmt.Sprintf("{%s Dst: %s Src: %s Gw: %s}", base.Name, r.Dst.String(),
+	return fmt.Sprintf("{Ifindex: %d Dst: %s Src: %s Gw: %s}", r.LinkIndex, r.Dst.String(),
 		r.Src, r.Gw)
 }

--- a/route_linux.go
+++ b/route_linux.go
@@ -90,8 +90,7 @@ func routeHandle(route *Route, req *nl.NetlinkRequest) error {
 		b      = make([]byte, 4)
 		native = nl.NativeEndian()
 	)
-	base := route.Link.Attrs()
-	native.PutUint32(b, uint32(base.Index))
+	native.PutUint32(b, uint32(route.LinkIndex))
 
 	req.AddData(nl.NewRtAttr(syscall.RTA_OIF, b))
 
@@ -157,8 +156,7 @@ func RouteList(link Link, family int) ([]Route, error) {
 					// Ignore routes from other interfaces
 					continue
 				}
-				resLink, _ := LinkByIndex(routeIndex)
-				route.Link = resLink
+				route.LinkIndex = routeIndex
 			}
 		}
 		res = append(res, route)

--- a/route_test.go
+++ b/route_test.go
@@ -24,7 +24,7 @@ func TestRouteAddDel(t *testing.T) {
 	_, dst, err := net.ParseCIDR("192.168.0.0/24")
 
 	ip := net.ParseIP("127.1.1.1")
-	route := Route{Link: link, Dst: dst, Src: ip}
+	route := Route{LinkIndex: link.Attrs().Index, Dst: dst, Src: ip}
 	err = RouteAdd(&route)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Having object composition causes both client and library to
do potentially unecessary work to retrieve Link attributes
when only index is often sufficient.
