### PR TITLE
Use tristate(negative/0/positive) fields for Protinfo

### DIFF
--- a/protinfo_test.go
+++ b/protinfo_test.go
@@ -23,17 +23,25 @@ func TestProtinfo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pi1 := Protinfo{
-		Hairpin:   true,
-		RootBlock: true,
+	pi1 := NewProtinfo()
+	pi1.Hairpin = 1
+	pi1.RootBlock = 1
+
+	oldpi1, err := LinkGetProtinfo(iface1)
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	pi2 := Protinfo{
-		Guard:    true,
-		Learning: false,
+	pi2 := NewProtinfo()
+	pi2.Guard = 1
+	pi2.Learning = 0
+
+	oldpi2, err := LinkGetProtinfo(iface2)
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	pi3 := Protinfo{}
+	pi3 := NewProtinfo()
 
 	if err := LinkSetProtinfo(iface1, pi1); err != nil {
 		t.Fatal(err)
@@ -43,12 +51,25 @@ func TestProtinfo(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !gpi1.Hairpin {
+	if gpi1.Hairpin != 1 {
 		t.Fatalf("Hairpin mode is not enabled for %s, but should", iface1.Name)
 	}
 
-	if !gpi1.RootBlock {
+	if gpi1.RootBlock != 1 {
 		t.Fatalf("RootBlock is not enabled for %s, but should", iface1.Name)
+	}
+
+	if gpi1.Guard != oldpi1.Guard {
+		t.Fatalf("Guard field was changed for %s but shouldn't", iface1.Name)
+	}
+	if gpi1.FastLeave != oldpi1.FastLeave {
+		t.Fatalf("FastLeave field was changed for %s but shouldn't", iface1.Name)
+	}
+	if gpi1.Learning != oldpi1.Learning {
+		t.Fatalf("Learning field was changed for %s but shouldn't", iface1.Name)
+	}
+	if gpi1.Flood != oldpi1.Flood {
+		t.Fatalf("Flood field was changed for %s but shouldn't", iface1.Name)
 	}
 
 	if err := LinkSetProtinfo(iface2, pi2); err != nil {
@@ -58,16 +79,25 @@ func TestProtinfo(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if gpi2.Hairpin {
+	if gpi2.Hairpin != 0 {
 		t.Fatalf("Hairpin mode is enabled for %s, but shouldn't", iface2.Name)
 	}
 
-	if !gpi2.Guard {
+	if gpi2.Guard != 1 {
 		t.Fatalf("Guard is not enabled for %s, but should", iface2.Name)
 	}
 
-	if gpi2.Learning {
+	if gpi2.Learning != 0 {
 		t.Fatalf("Learning is enabled for %s, but shouldn't", iface2.Name)
+	}
+	if gpi2.RootBlock != oldpi2.RootBlock {
+		t.Fatalf("RootBlock field was changed for %s but shouldn't", iface2.Name)
+	}
+	if gpi2.FastLeave != oldpi2.FastLeave {
+		t.Fatalf("FastLeave field was changed for %s but shouldn't", iface2.Name)
+	}
+	if gpi2.Flood != oldpi2.Flood {
+		t.Fatalf("Flood field was changed for %s but shouldn't", iface2.Name)
 	}
 
 	if err := LinkSetProtinfo(iface3, pi3); err == nil || err.Error() != "operation not supported" {


### PR DESCRIPTION
I noticed that it is not very convenient to use default bool value,
because IFLA_PROTINFO fields is not always false by default.