### PR TITLE
Added ability to specify net ns at link creation

### DIFF
--- a/link.go
+++ b/link.go
@@ -10,6 +10,11 @@ type Link interface {
 	Type() string
 }
 
+type (
+	NsPid int
+	NsFd  int
+)
+
 // LinkAttrs represents data shared by most link types
 type LinkAttrs struct {
 	Index        int
@@ -18,8 +23,9 @@ type LinkAttrs struct {
 	Name         string
 	HardwareAddr net.HardwareAddr
 	Flags        net.Flags
-	ParentIndex  int // index of the parent link device
-	MasterIndex  int // must be the index of a bridge
+	ParentIndex  int         // index of the parent link device
+	MasterIndex  int         // must be the index of a bridge
+	Namespace    interface{} // nil | NsPid | NsFd
 }
 
 // Device links cannot be created via netlink. These links

--- a/link_linux.go
+++ b/link_linux.go
@@ -312,6 +312,20 @@ func LinkAdd(link Link) error {
 		req.AddData(mtu)
 	}
 
+	if base.Namespace != nil {
+		var attr *nl.RtAttr
+		switch base.Namespace.(type) {
+		case NsPid:
+			val := nl.Uint32Attr(uint32(base.Namespace.(NsPid)))
+			attr = nl.NewRtAttr(syscall.IFLA_NET_NS_PID, val)
+		case NsFd:
+			val := nl.Uint32Attr(uint32(base.Namespace.(NsFd)))
+			attr = nl.NewRtAttr(nl.IFLA_NET_NS_FD, val)
+		}
+
+		req.AddData(attr)
+	}
+
 	linkInfo := nl.NewRtAttr(syscall.IFLA_LINKINFO, nil)
 	nl.NewRtAttrChild(linkInfo, nl.IFLA_INFO_KIND, nl.NonZeroTerminated(link.Type()))
 


### PR DESCRIPTION
Creating a link in one namespace and then moving can
be problematic since there could be an iface name conflict.
However, it is not always possible to switch into the target
namespace either -- e.g. creating a macvlan interface must
be done in the namespace of the parent interface.