### PR TITLE
FIx panic when adding an incomplete route

### DIFF
--- a/route_linux.go
+++ b/route_linux.go
@@ -25,7 +25,7 @@ func RouteDel(route *Route) error {
 }
 
 func routeHandle(route *Route, req *nl.NetlinkRequest) error {
-	if route.Dst.IP == nil && route.Src == nil && route.Gw == nil {
+	if (route.Dst == nil || route.Dst.IP == nil) && route.Src == nil && route.Gw == nil {
 		return fmt.Errorf("one of Dst.IP, Src, or Gw must not be nil")
 	}
 
@@ -34,7 +34,7 @@ func routeHandle(route *Route, req *nl.NetlinkRequest) error {
 	family := -1
 	var rtAttrs []*nl.RtAttr
 
-	if route.Dst.IP != nil {
+	if route.Dst != nil && route.Dst.IP != nil {
 		dstLen, _ := route.Dst.Mask.Size()
 		msg.Dst_len = uint8(dstLen)
 		dstFamily := nl.GetIPFamily(route.Dst.IP)

--- a/route_test.go
+++ b/route_test.go
@@ -61,3 +61,24 @@ func TestRouteAddDel(t *testing.T) {
 	}
 
 }
+
+func TestRouteAddIncomplete(t *testing.T) {
+	tearDown := setUpNetlinkTest(t)
+	defer tearDown()
+
+	// get loopback interface
+	link, err := LinkByName("lo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// bring the interface up
+	if err = LinkSetUp(link); err != nil {
+		t.Fatal(err)
+	}
+
+	route := Route{LinkIndex: link.Attrs().Index}
+	if err := RouteAdd(&route); err == nil {
+		t.Fatal("Adding incomplete route should fail")
+	}
+}


### PR DESCRIPTION
`RouteAdd` expects at least `Dst.IP`, `Src`, or `Gw` to be set, but accesses the destination IP without testing for `Dst` being nil in the first place.

Signed-off-by: Arnaud Porterie \<arnaud.porterie@docker.com\>