### PR TITLE
Use sync.Pool instead of each time allocation

### DIFF
--- a/link_test.go
+++ b/link_test.go
@@ -542,3 +542,43 @@ func TestLinkSet(t *testing.T) {
 		t.Fatalf("hardware address not changed!")
 	}
 }
+
+func BenchmarkLinkAddDel(b *testing.B) {
+	tearDown := setUpNetlinkTest(b)
+	defer tearDown()
+
+	for i := 0; i < b.N; i++ {
+		link := &Veth{LinkAttrs{Name: "foo"}, "bar"}
+		if err := LinkAdd(link); err != nil {
+			b.Fatal(err)
+		}
+
+		if _, err := LinkByName("foo"); err != nil {
+			b.Fatal(err)
+		}
+
+		peer, err := LinkByName("bar")
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		if err := LinkDel(peer); err != nil {
+			b.Fatal(err)
+		}
+
+		if _, err = LinkByName("foo"); err == nil {
+			b.Fatal("Other half of veth pair not deleted")
+		}
+	}
+}
+
+func BenchmarkLinkList(b *testing.B) {
+	tearDown := setUpNetlinkTest(b)
+	defer tearDown()
+
+	for i := 0; i < b.N; i++ {
+		if _, err := LinkList(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/netlink_test.go
+++ b/netlink_test.go
@@ -11,7 +11,7 @@ import (
 
 type tearDownNetlinkTest func()
 
-func setUpNetlinkTest(t *testing.T) tearDownNetlinkTest {
+func setUpNetlinkTest(t testing.TB) tearDownNetlinkTest {
 	if os.Getuid() != 0 {
 		msg := "Skipped test because it requires root privileges."
 		log.Printf(msg)


### PR DESCRIPTION
We allocate 4kb of space each time and this space won't be collected by GC until we remove references to syscall.NetlinkMessages, because it stores parts of original slice. Also allocation of 4kb is unneeded every time and in common cases makes call slower.
This patch though makes receiving big netlink messages slightly slower(because of copying answer to new slice), but allows to save significant amount of memory.
Here results of comparing benchmarks:
```
benchmark                 old ns/op     new ns/op     delta
BenchmarkLinkAddDel-4     6860622       7510755       +9.48%
BenchmarkLinkList-4       59623         52799         -11.45%

benchmark                 old allocs     new allocs     delta
BenchmarkLinkAddDel-4     138            144            +4.35%
BenchmarkLinkList-4       39             41             +5.13%

benchmark                 old bytes     new bytes     delta
BenchmarkLinkAddDel-4     34632         14237         -58.89%
BenchmarkLinkList-4       13824         8301          -39.95%
```