### PR TITLE
macvtap support

### DIFF
--- a/link.go
+++ b/link.go
@@ -114,6 +114,15 @@ func (macvlan *Macvlan) Type() string {
 	return "macvlan"
 }
 
+// Macvtap - macvtap is a virtual interfaces based on macvlan
+type Macvtap struct {
+	Macvlan
+}
+
+func (macvtap Macvtap) Type() string {
+	return "macvtap"
+}
+
 // Veth devices must specify PeerName on create
 type Veth struct {
 	LinkAttrs

--- a/link_test.go
+++ b/link_test.go
@@ -222,6 +222,27 @@ func TestLinkAddDelMacvlan(t *testing.T) {
 	}
 }
 
+func TestLinkAddDelMacvtap(t *testing.T) {
+	tearDown := setUpNetlinkTest(t)
+	defer tearDown()
+
+	parent := &Dummy{LinkAttrs{Name: "foo"}}
+	if err := LinkAdd(parent); err != nil {
+		t.Fatal(err)
+	}
+
+	testLinkAddDel(t, &Macvtap{
+		Macvlan: Macvlan{
+			LinkAttrs: LinkAttrs{Name: "bar", ParentIndex: parent.Attrs().Index},
+			Mode:      MACVLAN_MODE_PRIVATE,
+		},
+	})
+
+	if err := LinkDel(parent); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestLinkAddDelVeth(t *testing.T) {
 	tearDown := setUpNetlinkTest(t)
 	defer tearDown()


### PR DESCRIPTION
example 

```go
package main

import (
    "fmt"

    "github.com/vishvananda/netlink"
)

func main() {

    m, err := netlink.LinkByName("p2p1")
    if err != nil {
        panic(err)
    }
    fmt.Printf("m = %+v\n", m)

    mv := &netlink.Macvtap{
        Macvlan: netlink.Macvlan{
            LinkAttrs: netlink.LinkAttrs{
                MTU:         m.Attrs().MTU,
                Name:        "foobar",
                ParentIndex: m.Attrs().Index,
            },
            Mode: netlink.MACVLAN_MODE_PRIVATE,
        },
    }

    err = netlink.LinkAdd(mv)
    if err != nil {
        panic(err)
    }

}
```
and then 

```sh
$ sudo ./macvtaptest
m = &{LinkAttrs:{Index:2 MTU:1500 TxQLen:1000 Name:p2p1 HardwareAddr:74:d4:35:e8:3d:42 Flags:broadcast|multicast ParentIndex:0 MasterIndex:0 Namespace:<nil>}}
```

I got:
```
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00 promiscuity 0
2: p2p1: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN mode DEFAULT group default qlen 1000
    link/ether 74:d4:35:e8:3d:42 brd ff:ff:ff:ff:ff:ff promiscuity 0
100: foobar@p2p1: <BROADCAST,MULTICAST,M-DOWN> mtu 1500 qdisc noop state DOWN mode DEFAULT group default
    link/ether 8a:62:e5:a8:ba:4a brd ff:ff:ff:ff:ff:ff promiscuity 0
    macvtap  mode vepa
```


unittests included:
```
=== RUN TestLinkAddDelMacvtap
--- PASS: TestLinkAddDelMacvtap (0.09s)
```