### PR TITLE
Async updates on links and routes

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -585,6 +585,46 @@ func LinkList() ([]Link, error) {
 	return res, nil
 }
 
+// LinkUpdate is used to pass information back from LinkSubscribe()
+type LinkUpdate struct {
+	nl.IfInfomsg
+	Link
+}
+
+// LinkSubscribe takes a chan down which notifications will be sent
+// when links change.  Close the 'done' chan to stop subscription.
+func LinkSubscribe(ch chan<- LinkUpdate, done <-chan struct{}) error {
+	s, err := nl.Subscribe(syscall.NETLINK_ROUTE, syscall.RTNLGRP_LINK)
+	if err != nil {
+		return err
+	}
+	if done != nil {
+		go func() {
+			<-done
+			s.Close()
+		}()
+	}
+	go func() {
+		defer close(ch)
+		for {
+			msgs, err := s.Receive()
+			if err != nil {
+				return
+			}
+			for _, m := range msgs {
+				ifmsg := nl.DeserializeIfInfomsg(m.Data)
+				link, err := linkDeserialize(m.Data)
+				if err != nil {
+					return
+				}
+				ch <- LinkUpdate{IfInfomsg: *ifmsg, Link: link}
+			}
+		}
+	}()
+
+	return nil
+}
+
 func LinkSetHairpin(link Link, mode bool) error {
 	return setProtinfoAttr(link, mode, nl.IFLA_BRPORT_MODE)
 }

--- a/link_test.go
+++ b/link_test.go
@@ -3,7 +3,9 @@ package netlink
 import (
 	"bytes"
 	"net"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/vishvananda/netns"
 )
@@ -660,5 +662,56 @@ func TestLinkSet(t *testing.T) {
 
 	if !bytes.Equal(link.Attrs().HardwareAddr, addr) {
 		t.Fatalf("hardware address not changed!")
+	}
+}
+
+func expectLinkUpdate(ch <-chan LinkUpdate, ifaceName string, up bool) bool {
+	for {
+		timeout := time.After(time.Minute)
+		select {
+		case update := <-ch:
+			if ifaceName == update.Link.Attrs().Name && (update.IfInfomsg.Flags&syscall.IFF_UP != 0) == up {
+				return true
+			}
+		case <-timeout:
+			return false
+		}
+	}
+}
+
+func TestLinkSubscribe(t *testing.T) {
+	tearDown := setUpNetlinkTest(t)
+	defer tearDown()
+
+	ch := make(chan LinkUpdate)
+	done := make(chan struct{})
+	defer close(done)
+	if err := LinkSubscribe(ch, done); err != nil {
+		t.Fatal(err)
+	}
+
+	link := &Veth{LinkAttrs{Name: "foo", TxQLen: testTxQLen, MTU: 1400}, "bar"}
+	if err := LinkAdd(link); err != nil {
+		t.Fatal(err)
+	}
+
+	if !expectLinkUpdate(ch, "foo", false) {
+		t.Fatal("Add update not received as expected")
+	}
+
+	if err := LinkSetUp(link); err != nil {
+		t.Fatal(err)
+	}
+
+	if !expectLinkUpdate(ch, "foo", true) {
+		t.Fatal("Link Up update not received as expected")
+	}
+
+	if err := LinkDel(link); err != nil {
+		t.Fatal(err)
+	}
+
+	if !expectLinkUpdate(ch, "foo", false) {
+		t.Fatal("Del update not received as expected")
 	}
 }

--- a/route.go
+++ b/route.go
@@ -33,3 +33,9 @@ func (r Route) String() string {
 	return fmt.Sprintf("{Ifindex: %d Dst: %s Src: %s Gw: %s}", r.LinkIndex, r.Dst,
 		r.Src, r.Gw)
 }
+
+// RouteUpdate is sent when a route changes - type is RTM_NEWROUTE or RTM_DELROUTE
+type RouteUpdate struct {
+	Type uint16
+	Route
+}

--- a/route_linux.go
+++ b/route_linux.go
@@ -131,7 +131,7 @@ func RouteList(link Link, family int) ([]Route, error) {
 			continue
 		}
 
-		route, err := DeserializeRoute(m)
+		route, err := deserializeRoute(m)
 		if err != nil {
 			return nil, err
 		}
@@ -146,8 +146,8 @@ func RouteList(link Link, family int) ([]Route, error) {
 	return res, nil
 }
 
-// DeserializeRoute decodes a binary netlink message into a Route struct
-func DeserializeRoute(m []byte) (Route, error) {
+// deserializeRoute decodes a binary netlink message into a Route struct
+func deserializeRoute(m []byte) (Route, error) {
 	route := Route{}
 	msg := nl.DeserializeRtMsg(m)
 	attrs, err := nl.ParseRouteAttr(m[msg.Len():])
@@ -205,7 +205,7 @@ func RouteGet(destination net.IP) ([]Route, error) {
 
 	var res []Route
 	for _, m := range msgs {
-		route, err := DeserializeRoute(m)
+		route, err := deserializeRoute(m)
 		if err != nil {
 			return nil, err
 		}

--- a/route_test.go
+++ b/route_test.go
@@ -2,7 +2,9 @@ package netlink
 
 import (
 	"net"
+	"syscall"
 	"testing"
+	"time"
 )
 
 func TestRouteAddDel(t *testing.T) {
@@ -80,5 +82,65 @@ func TestRouteAddIncomplete(t *testing.T) {
 	route := Route{LinkIndex: link.Attrs().Index}
 	if err := RouteAdd(&route); err == nil {
 		t.Fatal("Adding incomplete route should fail")
+	}
+}
+
+func expectRouteUpdate(ch <-chan RouteUpdate, t uint16, dst net.IP) bool {
+	for {
+		timeout := time.After(time.Minute)
+		select {
+		case update := <-ch:
+			if update.Type == t && update.Route.Dst.IP.Equal(dst) {
+				return true
+			}
+		case <-timeout:
+			return false
+		}
+	}
+}
+
+func TestRouteSubscribe(t *testing.T) {
+	tearDown := setUpNetlinkTest(t)
+	defer tearDown()
+
+	ch := make(chan RouteUpdate)
+	done := make(chan struct{})
+	defer close(done)
+	if err := RouteSubscribe(ch, done); err != nil {
+		t.Fatal(err)
+	}
+
+	// get loopback interface
+	link, err := LinkByName("lo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// bring the interface up
+	if err = LinkSetUp(link); err != nil {
+		t.Fatal(err)
+	}
+
+	// add a gateway route
+	_, dst, err := net.ParseCIDR("192.168.0.0/24")
+
+	ip := net.ParseIP("127.1.1.1")
+	route := Route{LinkIndex: link.Attrs().Index, Dst: dst, Src: ip}
+	err = RouteAdd(&route)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !expectRouteUpdate(ch, syscall.RTM_NEWROUTE, dst.IP) {
+		t.Fatal("Add update not received as expected")
+	}
+
+	err = RouteDel(&route)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !expectRouteUpdate(ch, syscall.RTM_DELROUTE, dst.IP) {
+		t.Fatal("Del update not received as expected")
 	}
 }


### PR DESCRIPTION
Introduces `LinkSubscribe()` and `RouteSubscribe()` whereby the caller can receive updates over a Go `chan` when links or routes come and go.  Both functions start a goroutine which listens to Netlink, and take an optional `done` parameter which can be closed to terminate the subscription and its goroutine.

The object sent is a `LinkUpdate` or `RouteUpdate` struct that describes the thing that changed and also some information to know what happened to it.

This PR is the bigger change I alluded to in #45; if accepted I would not need #45 (the key difference being whether `deserializeRoute` is exposed).
