### PR TITLE
Trim whitespace from Addr.String()

### DIFF
--- a/addr.go
+++ b/addr.go
@@ -15,7 +15,7 @@ type Addr struct {
 
 // String returns $ip/$netmask $label
 func (a Addr) String() string {
-	return fmt.Sprintf("%s %s", a.IPNet, a.Label)
+	return strings.TrimSpace(fmt.Sprintf("%s %s", a.IPNet, a.Label))
 }
 
 // ParseAddr parses the string representation of an address in the


### PR DESCRIPTION
If the address has no label, there's extra whitespace at the end.