### PR TITLE
[nl] Fix RtAttr.Serialize to serialize both Data and Children

### DIFF
--- a/nl/nl_linux.go
+++ b/nl/nl_linux.go
@@ -149,10 +149,12 @@ func (a *RtAttr) Serialize() []byte {
 	length := a.Len()
 	buf := make([]byte, rtaAlignOf(length))
 
+	next := 4
 	if a.Data != nil {
-		copy(buf[4:], a.Data)
-	} else {
-		next := 4
+		copy(buf[next:], a.Data)
+		next += rtaAlignOf(len(a.Data))
+	}
+	if len(a.children) > 0 {
 		for _, child := range a.children {
 			childBuf := child.Serialize()
 			copy(buf[next:], childBuf)


### PR DESCRIPTION
The function was only serializing the Data if it was not nil.
It was correctly setting the size of the payload as RtAttr.Len correctly
accounted for it. This resulted in the children payload being zeroed.

Fixes #57