### PR TITLE
Add an accessor to the fd of the netlink socket

### DIFF
--- a/nl/nl_linux.go
+++ b/nl/nl_linux.go
@@ -323,6 +323,10 @@ func (s *NetlinkSocket) Close() {
 	syscall.Close(s.fd)
 }
 
+func (s *NetlinkSocket) GetFd() int {
+	return s.fd
+}
+
 func (s *NetlinkSocket) Send(request *NetlinkRequest) error {
 	if err := syscall.Sendto(s.fd, request.Serialize(), 0, &s.lsa); err != nil {
 		return err


### PR DESCRIPTION
Giving a such access could be usefull in order to use
the socket in a non-blocking way. This is especially useful
when using it in a network namespace since the namespace can be
deleted and one can be blocked in a Receive operation.