### PR TITLE
Add support to replace/change qdisc

### DIFF
--- a/qdisc_linux.go
+++ b/qdisc_linux.go
@@ -27,10 +27,28 @@ func QdiscDel(qdisc Qdisc) error {
 	return err
 }
 
+// QdiscChanf will change a qdisc in place
+// Equivalent to: `tc qdisc change $qdisc`
+// The parent and handle MUST NOT be changed.
+func QdiscChange(qdisc Qdisc) error {
+	return qdiscModify(qdisc, 0)
+}
+
+// QdiscReplace will replace a qdisc to the system.
+// Equivalent to: `tc qdisc replace $qdisc`
+// The handle MUST change.
+func QdiscReplace(qdisc Qdisc) error {
+	return qdiscModify(qdisc, syscall.NLM_F_CREATE|syscall.NLM_F_REPLACE)
+}
+
 // QdiscAdd will add a qdisc to the system.
 // Equivalent to: `tc qdisc add $qdisc`
 func QdiscAdd(qdisc Qdisc) error {
-	req := nl.NewNetlinkRequest(syscall.RTM_NEWQDISC, syscall.NLM_F_CREATE|syscall.NLM_F_EXCL|syscall.NLM_F_ACK)
+	return qdiscModify(qdisc, syscall.NLM_F_CREATE|syscall.NLM_F_EXCL)
+}
+
+func qdiscModify(qdisc Qdisc, flags int) error {
+	req := nl.NewNetlinkRequest(syscall.RTM_NEWQDISC, flags|syscall.NLM_F_ACK)
 	base := qdisc.Attrs()
 	msg := &nl.TcMsg{
 		Family:  nl.FAMILY_ALL,

--- a/qdisc_test.go
+++ b/qdisc_test.go
@@ -163,3 +163,183 @@ func TestPrioAddDel(t *testing.T) {
 		t.Fatal("Failed to remove qdisc")
 	}
 }
+
+func TestTbfAddHtbReplaceDel(t *testing.T) {
+	tearDown := setUpNetlinkTest(t)
+	defer tearDown()
+	if err := LinkAdd(&Ifb{LinkAttrs{Name: "foo"}}); err != nil {
+		t.Fatal(err)
+	}
+	link, err := LinkByName("foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := LinkSetUp(link); err != nil {
+		t.Fatal(err)
+	}
+
+	// Add
+	attrs := QdiscAttrs{
+		LinkIndex: link.Attrs().Index,
+		Handle:    MakeHandle(1, 0),
+		Parent:    HANDLE_ROOT,
+	}
+	qdisc := &Tbf{
+		QdiscAttrs: attrs,
+		Rate:       131072,
+		Limit:      1220703,
+		Buffer:     16793,
+	}
+	if err := QdiscAdd(qdisc); err != nil {
+		t.Fatal(err)
+	}
+	qdiscs, err := QdiscList(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(qdiscs) != 1 {
+		t.Fatal("Failed to add qdisc")
+	}
+	tbf, ok := qdiscs[0].(*Tbf)
+	if !ok {
+		t.Fatal("Qdisc is the wrong type")
+	}
+	if tbf.Rate != qdisc.Rate {
+		t.Fatal("Rate doesn't match")
+	}
+	if tbf.Limit != qdisc.Limit {
+		t.Fatal("Limit doesn't match")
+	}
+	if tbf.Buffer != qdisc.Buffer {
+		t.Fatal("Buffer doesn't match")
+	}
+	// Replace
+	// For replace to work, the handle MUST be different that the running one
+	attrs.Handle = MakeHandle(2, 0)
+	qdisc2 := NewHtb(attrs)
+	qdisc2.Rate2Quantum = 5
+	if err := QdiscReplace(qdisc2); err != nil {
+		t.Fatal(err)
+	}
+
+	qdiscs, err = QdiscList(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(qdiscs) != 1 {
+		t.Fatal("Failed to add qdisc")
+	}
+	htb, ok := qdiscs[0].(*Htb)
+	if !ok {
+		t.Fatal("Qdisc is the wrong type")
+	}
+	if htb.Defcls != qdisc2.Defcls {
+		t.Fatal("Defcls doesn't match")
+	}
+	if htb.Rate2Quantum != qdisc2.Rate2Quantum {
+		t.Fatal("Rate2Quantum doesn't match")
+	}
+	if htb.Debug != qdisc2.Debug {
+		t.Fatal("Debug doesn't match")
+	}
+
+	if err := QdiscDel(qdisc2); err != nil {
+		t.Fatal(err)
+	}
+	qdiscs, err = QdiscList(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(qdiscs) != 0 {
+		t.Fatal("Failed to remove qdisc")
+	}
+}
+
+func TestTbfAddTbfChangeDel(t *testing.T) {
+	tearDown := setUpNetlinkTest(t)
+	defer tearDown()
+	if err := LinkAdd(&Ifb{LinkAttrs{Name: "foo"}}); err != nil {
+		t.Fatal(err)
+	}
+	link, err := LinkByName("foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := LinkSetUp(link); err != nil {
+		t.Fatal(err)
+	}
+
+	// Add
+	attrs := QdiscAttrs{
+		LinkIndex: link.Attrs().Index,
+		Handle:    MakeHandle(1, 0),
+		Parent:    HANDLE_ROOT,
+	}
+	qdisc := &Tbf{
+		QdiscAttrs: attrs,
+		Rate:       131072,
+		Limit:      1220703,
+		Buffer:     16793,
+	}
+	if err := QdiscAdd(qdisc); err != nil {
+		t.Fatal(err)
+	}
+	qdiscs, err := QdiscList(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(qdiscs) != 1 {
+		t.Fatal("Failed to add qdisc")
+	}
+	tbf, ok := qdiscs[0].(*Tbf)
+	if !ok {
+		t.Fatal("Qdisc is the wrong type")
+	}
+	if tbf.Rate != qdisc.Rate {
+		t.Fatal("Rate doesn't match")
+	}
+	if tbf.Limit != qdisc.Limit {
+		t.Fatal("Limit doesn't match")
+	}
+	if tbf.Buffer != qdisc.Buffer {
+		t.Fatal("Buffer doesn't match")
+	}
+	// Change
+	// For change to work, the handle MUST not change
+	qdisc.Rate = 23456
+	if err := QdiscChange(qdisc); err != nil {
+		t.Fatal(err)
+	}
+
+	qdiscs, err = QdiscList(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(qdiscs) != 1 {
+		t.Fatal("Failed to add qdisc")
+	}
+	tbf, ok = qdiscs[0].(*Tbf)
+	if !ok {
+		t.Fatal("Qdisc is the wrong type")
+	}
+	if tbf.Rate != qdisc.Rate {
+		t.Fatal("Rate doesn't match")
+	}
+	if tbf.Limit != qdisc.Limit {
+		t.Fatal("Limit doesn't match")
+	}
+	if tbf.Buffer != qdisc.Buffer {
+		t.Fatal("Buffer doesn't match")
+	}
+
+	if err := QdiscDel(qdisc); err != nil {
+		t.Fatal(err)
+	}
+	qdiscs, err = QdiscList(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(qdiscs) != 0 {
+		t.Fatal("Failed to remove qdisc")
+	}
+}


### PR DESCRIPTION
Also refactor the Qdisc{Cmd} to use a common qdiscModify function which will act according to the cmd/flags passed as arguments.