### PR TITLE
Do not send nl request data in XfrmStateList

### DIFF
--- a/xfrm_state_linux.go
+++ b/xfrm_state_linux.go
@@ -110,9 +110,6 @@ func XfrmStateDel(state *XfrmState) error {
 func XfrmStateList(family int) ([]XfrmState, error) {
 	req := nl.NewNetlinkRequest(nl.XFRM_MSG_GETSA, syscall.NLM_F_DUMP)
 
-	msg := nl.NewIfInfomsg(family)
-	req.AddData(msg)
-
 	msgs, err := req.Execute(syscall.NETLINK_XFRM, nl.XFRM_MSG_NEWSA)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
I kept seeing `netlink: 16 bytes leftover after parsing attributes` messages when calling `XfrmStateList()` and from my (very naive) understanding of the kernel code it didn't seem like `XFRM_MSG_GETSA` w/ `NLM_F_DUMP` excepts any attributes.  The passed in `family` argument seems to be used by the go code and not the kernel itself.