### PR TITLE
RFC: force AddList to get rid of unexpected information

### DIFF
--- a/addr_linux.go
+++ b/addr_linux.go
@@ -101,6 +101,10 @@ func AddrList(link Link, family int) ([]Addr, error) {
 			continue
 		}
 
+		if family != FAMILY_ALL && msg.Family != uint8(family) {
+			continue
+		}
+
 		attrs, err := nl.ParseRouteAttr(m[msg.Len():])
 		if err != nil {
 			return nil, err

--- a/addr_test.go
+++ b/addr_test.go
@@ -77,6 +77,25 @@ func TestAddr(t *testing.T) {
 			t.Fatalf("Address scope not set properly, got=%d, expected=%d", addrs[0].Scope, tt.expected.Scope)
 		}
 
+		// Pass FAMILY_V4, we should get the same results as FAMILY_ALL
+		addrs, err = AddrList(link, FAMILY_V4)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(addrs) != 1 {
+			t.Fatal("Address not added properly")
+		}
+
+		// Pass a wrong family number, we should get nil list
+		addrs, err = AddrList(link, 0x8)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(addrs) != 0 {
+			t.Fatal("Address not expected")
+		}
+
 		if err = AddrDel(link, tt.addr); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
#`AddList` returned all addresses when the protocol family is not supported. For example, With a kernel with IPV6 disabled. if I call `netlink.AddrList(link, netlink.FAMILY_V6)`., it will return all ips of this interface.  This behavior may confuse user. After this patch it will return []  instead.
 
When I ran docker daemon on a machine with ipv6 disabled, I encounterd the following error. And this patch made it workable.
```
FATA[0000] Error starting daemon: Error initializing network controller: Error creating default "bridge" network: Failed to setup IP tables, cannot acquire Interface address: Interface docker0 has no IPv4 addresses
```