### PR TITLE
Fix return of address family in parseAddr helper.

### DIFF
--- a/addr_linux.go
+++ b/addr_linux.go
@@ -127,6 +127,7 @@ func parseAddr(m []byte) (addr Addr, family, index int, err error) {
 		return
 	}
 
+	family = int(msg.Family)
 	index = int(msg.Index)
 
 	var local, dst *net.IPNet

--- a/addr_linux.go
+++ b/addr_linux.go
@@ -95,7 +95,7 @@ func AddrList(link Link, family int) ([]Addr, error) {
 
 	var res []Addr
 	for _, m := range msgs {
-		addr, family, ifindex, err := parseAddr(m)
+		addr, msgFamily, ifindex, err := parseAddr(m)
 		if err != nil {
 			return res, err
 		}
@@ -105,7 +105,7 @@ func AddrList(link Link, family int) ([]Addr, error) {
 			continue
 		}
 
-		if family != FAMILY_ALL && msg.Family != uint8(family) {
+		if family != FAMILY_ALL && msgFamily != family {
 			continue
 		}
 


### PR DESCRIPTION
I broke return of family in commit https://github.com/vishvananda/netlink/commit/9462941794a2fe8f0a0ed34ba8afcc3cf627cb77