### PR TITLE
addr_linux: copy family from msg in parseAddr

### DIFF
--- a/addr_linux.go
+++ b/addr_linux.go
@@ -128,6 +128,7 @@ func parseAddr(m []byte) (addr Addr, family, index int, err error) {
 	}
 
 	index = int(msg.Index)
+	family = int(msg.Family)
 
 	var local, dst *net.IPNet
 	for _, attr := range attrs {


### PR DESCRIPTION
A recent refactoring of the code has broken this. This PR makes parseAddr not return family=-1 all the time. This change fixes AddrList().

I've investigated this issue together with @mapuri.