### PR TITLE
Proposal to add multi queue support to tuntap

### DIFF
--- a/link.go
+++ b/link.go
@@ -3,6 +3,7 @@ package netlink
 import (
 	"fmt"
 	"net"
+	"os"
 	"syscall"
 )
 
@@ -151,7 +152,9 @@ const (
 // Tuntap links created via /dev/tun/tap, but can be destroyed via netlink
 type Tuntap struct {
 	LinkAttrs
-	Mode TuntapMode
+	Mode   TuntapMode
+	Queues int
+	Fds    []*os.File
 }
 
 func (tuntap *Tuntap) Attrs() *LinkAttrs {

--- a/link_test.go
+++ b/link_test.go
@@ -217,6 +217,25 @@ func TestLinkAddDelGretap(t *testing.T) {
 		Remote:    net.IPv4(127, 0, 0, 1)})
 }
 
+func TestLinkAddDelTuntap(t *testing.T) {
+	tearDown := setUpNetlinkTest(t)
+	defer tearDown()
+
+	testLinkAddDel(t, &Tuntap{
+		LinkAttrs: LinkAttrs{Name: "foo"},
+		Mode:      TUNTAP_MODE_TAP})
+}
+
+func TestLinkAddDelTuntapMq(t *testing.T) {
+	tearDown := setUpNetlinkTest(t)
+	defer tearDown()
+
+	testLinkAddDel(t, &Tuntap{
+		LinkAttrs: LinkAttrs{Name: "foo"},
+		Mode:      TUNTAP_MODE_TAP,
+		Queues:    4})
+}
+
 func TestLinkAddDelVlan(t *testing.T) {
 	tearDown := setUpNetlinkTest(t)
 	defer tearDown()


### PR DESCRIPTION
This is a draft proposal to add multi queue support to tuntap without breaking legacy users of tuntap (i.e. not leaking fds) based on [https://www.kernel.org/doc/Documentation/networking/tuntap.txt]

To be able to leverage multiqueue the caller needs to have the fds available. Adding the Queue attribute to Tuntap and passing the fds back only when the Queue attribute was explicitly set seems to be the least intrusive way to add this capability.

Please do not merge this. The multi-queue tap has not been tested.
