### PR TITLE
Typo: fix a typo in comment of LinkAdd method

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -434,7 +434,7 @@ func addBondAttrs(bond *Bond, linkInfo *nl.RtAttr) {
 }
 
 // LinkAdd adds a new link device. The type and features of the device
-// are taken fromt the parameters in the link object.
+// are taken from the parameters in the link object.
 // Equivalent to: `ip link add $link`
 func LinkAdd(link Link) error {
 	// TODO: set mtu and hardware address


### PR DESCRIPTION
the `fromt` should be `from`
Signed-off-by: Lei Jitang <leijitang@huawei.com>