### PR TITLE
Allow to program L4 fields in policy selector

### DIFF
--- a/xfrm_policy.go
+++ b/xfrm_policy.go
@@ -52,6 +52,9 @@ type XfrmPolicyTmpl struct {
 type XfrmPolicy struct {
 	Dst      *net.IPNet
 	Src      *net.IPNet
+	Proto    Proto
+	DstPort  int
+	SrcPort  int
 	Dir      Dir
 	Priority int
 	Index    int

--- a/xfrm_policy_linux.go
+++ b/xfrm_policy_linux.go
@@ -14,6 +14,11 @@ func selFromPolicy(sel *nl.XfrmSelector, policy *XfrmPolicy) {
 	sel.PrefixlenD = uint8(prefixlenD)
 	prefixlenS, _ := policy.Src.Mask.Size()
 	sel.PrefixlenS = uint8(prefixlenS)
+	sel.Proto = uint8(policy.Proto)
+	sel.Dport = nl.Swap16(uint16(policy.DstPort))
+	sel.Sport = nl.Swap16(uint16(policy.SrcPort))
+	sel.DportMask = ^uint16(0)
+	sel.SportMask = ^uint16(0)
 }
 
 // XfrmPolicyAdd will add an xfrm policy to the system.
@@ -160,6 +165,9 @@ func (h *Handle) XfrmPolicyList(family int) ([]XfrmPolicy, error) {
 
 		policy.Dst = msg.Sel.Daddr.ToIPNet(msg.Sel.PrefixlenD)
 		policy.Src = msg.Sel.Saddr.ToIPNet(msg.Sel.PrefixlenS)
+		policy.Proto = Proto(msg.Sel.Proto)
+		policy.DstPort = int(nl.Swap16(msg.Sel.Dport))
+		policy.SrcPort = int(nl.Swap16(msg.Sel.Sport))
 		policy.Priority = int(msg.Priority)
 		policy.Index = int(msg.Index)
 		policy.Dir = Dir(msg.Dir)

--- a/xfrm_policy_test.go
+++ b/xfrm_policy_test.go
@@ -1,6 +1,7 @@
 package netlink
 
 import (
+	"bytes"
 	"net"
 	"testing"
 )
@@ -12,9 +13,12 @@ func TestXfrmPolicyAddUpdateDel(t *testing.T) {
 	src, _ := ParseIPNet("127.1.1.1/32")
 	dst, _ := ParseIPNet("127.1.1.2/32")
 	policy := XfrmPolicy{
-		Src: src,
-		Dst: dst,
-		Dir: XFRM_DIR_OUT,
+		Src:     src,
+		Dst:     dst,
+		Proto:   17,
+		DstPort: 1234,
+		SrcPort: 5678,
+		Dir:     XFRM_DIR_OUT,
 		Mark: &XfrmMark{
 			Value: 0xabff22,
 			Mask:  0xffffffff,
@@ -38,6 +42,16 @@ func TestXfrmPolicyAddUpdateDel(t *testing.T) {
 
 	if len(policies) != 1 {
 		t.Fatal("Policy not added properly")
+	}
+
+	// Verify Selector fields
+	if !compareIPNet(policies[0].Dst, policy.Dst) ||
+		!compareIPNet(policies[0].Src, policy.Src) ||
+		policies[0].Proto != policy.Proto ||
+		policies[0].DstPort != policy.DstPort ||
+		policies[0].SrcPort != policy.SrcPort {
+		t.Fatalf("Incorrect policy data retrieved. Expected %v. Got %v.",
+			policy, policies[0])
 	}
 
 	// Modify the policy
@@ -64,4 +78,14 @@ func TestXfrmPolicyAddUpdateDel(t *testing.T) {
 	if len(policies) != 0 {
 		t.Fatal("Policy not removed properly")
 	}
+}
+
+func compareIPNet(a, b *net.IPNet) bool {
+	if a == b {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return a.IP.Equal(b.IP) && bytes.Equal(a.Mask, b.Mask)
 }

--- a/xfrm_state_linux.go
+++ b/xfrm_state_linux.go
@@ -40,7 +40,7 @@ func writeMark(m *XfrmMark) []byte {
 		Mask:  m.Mask,
 	}
 	if mark.Mask == 0 {
-		mark.Mask = 0xfffffff
+		mark.Mask = ^uint32(0)
 	}
 	return mark.Serialize()
 }


### PR DESCRIPTION
Tested on Ubuntu Linux 3.13, 3.19, 4.4

Signed-off-by: Alessandro Boch <aboch@docker.com>