### PR TITLE
Add String() method to user structures

### DIFF
--- a/xfrm_policy.go
+++ b/xfrm_policy.go
@@ -46,6 +46,11 @@ type XfrmPolicyTmpl struct {
 	Reqid int
 }
 
+func (t XfrmPolicyTmpl) String() string {
+	return fmt.Sprintf("{Dst: %v, Src: %v, Proto: %s, Mode: %s, Reqid: 0x%x}",
+		t.Dst, t.Src, t.Proto, t.Mode, t.Reqid)
+}
+
 // XfrmPolicy represents an ipsec policy. It represents the overlay network
 // and has a list of XfrmPolicyTmpls representing the base addresses of
 // the policy.
@@ -60,4 +65,9 @@ type XfrmPolicy struct {
 	Index    int
 	Mark     *XfrmMark
 	Tmpls    []XfrmPolicyTmpl
+}
+
+func (p XfrmPolicy) String() string {
+	return fmt.Sprintf("{Dst: %v, Src: %v, Proto: %s, DstPort: %d, SrcPort: %d, Dir: %s, Priority: %d, Index: %d, Mark: %s, Tmpls: %s}",
+		p.Dst, p.Src, p.Proto, p.DstPort, p.SrcPort, p.Dir, p.Priority, p.Index, p.Mark, p.Tmpls)
 }

--- a/xfrm_state.go
+++ b/xfrm_state.go
@@ -1,6 +1,7 @@
 package netlink
 
 import (
+	"fmt"
 	"net"
 )
 
@@ -9,6 +10,10 @@ type XfrmStateAlgo struct {
 	Name        string
 	Key         []byte
 	TruncateLen int // Auth only
+}
+
+func (a XfrmStateAlgo) String() string {
+	return fmt.Sprintf("{Name: %s, Key: 0x%x, TruncateLen: %d}", a.Name, a.Key, a.TruncateLen)
 }
 
 // EncapType is an enum representing an ipsec template direction.
@@ -37,6 +42,11 @@ type XfrmStateEncap struct {
 	OriginalAddress net.IP
 }
 
+func (e XfrmStateEncap) String() string {
+	return fmt.Sprintf("{Type: %s, Srcport: %d, DstPort: %d, OriginalAddress: %v}",
+		e.Type, e.SrcPort, e.DstPort, e.OriginalAddress)
+}
+
 // XfrmState represents the state of an ipsec policy. It optionally
 // contains an XfrmStateAlgo for encryption and one for authentication.
 type XfrmState struct {
@@ -51,4 +61,9 @@ type XfrmState struct {
 	Auth         *XfrmStateAlgo
 	Crypt        *XfrmStateAlgo
 	Encap        *XfrmStateEncap
+}
+
+func (sa XfrmState) String() string {
+	return fmt.Sprintf("Dst: %v, Src: %v, Proto: %s, Mode: %s, SPI: 0x%x, ReqID: 0x%x, ReplayWindow: %d, Mark: %v, Auth: %v, Crypt: %v, Encap: %v",
+		sa.Dst, sa.Src, sa.Proto, sa.Mode, sa.Spi, sa.Reqid, sa.ReplayWindow, sa.Mark, sa.Auth, sa.Crypt, sa.Encap)
 }


### PR DESCRIPTION
This has turned very useful while debugging a feature that uses xfrm.

It would print as below:
```
$ sudo ./xfrm state ls
States:
Dst: 192.168.100.156, Src: 192.168.100.124, Proto: esp, Mode: transport, SPI: 0x1, ReqID: 0x64, ReplayWindow: 0, Mark: (0x7d0,0xffffffff), Auth: {Name: hmac(sha256), Key: 0x6162636465666768696a6b6c6d6e6f70717273747576777a797a414243444546, TruncateLen: 96}, Crypt: {Name: cbc(aes), Key: 0x6162636465666768696a6b6c6d6e6f70717273747576777a797a414243444546, TruncateLen: 0}, Encap: {Type: espinudp, Srcport: 200, DstPort: 400, OriginalAddress: 192.168.100.124}
$
$ sudo ./xfrm policy ls
Policies:
{Dst: 10.0.0.0/24, Src: 10.0.0.0/24, Proto: 17, DstPort: 4789, SrcPort: 1234, Dir: dir out, Priority: 0, Index: 185, Mark: (0x1388,0xffffffff), Tmpls: [{Dst: 192.168.100.156, Src: 192.168.100.124, Proto: esp, Mode: transport, Reqid: 0x0}]}
$
```


Signed-off-by: Alessandro Boch <aboch@docker.com>