### PR TITLE
Use package empty handle for pkg methods

### DIFF
--- a/addr_linux.go
+++ b/addr_linux.go
@@ -16,12 +16,7 @@ const IFA_FLAGS = 0x8
 // AddrAdd will add an IP address to a link device.
 // Equivalent to: `ip addr add $addr dev $link`
 func AddrAdd(link Link, addr *Addr) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.AddrAdd(link, addr)
+	return pkgHandle.AddrAdd(link, addr)
 }
 
 // AddrAdd will add an IP address to a link device.
@@ -34,12 +29,7 @@ func (h *Handle) AddrAdd(link Link, addr *Addr) error {
 // AddrDel will delete an IP address from a link device.
 // Equivalent to: `ip addr del $addr dev $link`
 func AddrDel(link Link, addr *Addr) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.AddrDel(link, addr)
+	return pkgHandle.AddrDel(link, addr)
 }
 
 // AddrDel will delete an IP address from a link device.
@@ -98,12 +88,7 @@ func (h *Handle) addrHandle(link Link, addr *Addr, req *nl.NetlinkRequest) error
 // Equivalent to: `ip addr show`.
 // The list can be filtered by link and ip family.
 func AddrList(link Link, family int) ([]Addr, error) {
-	h, err := NewHandle()
-	if err != nil {
-		return nil, err
-	}
-	defer h.Delete()
-	return h.AddrList(link, family)
+	return pkgHandle.AddrList(link, family)
 }
 
 // AddrList gets a list of IP addresses in the system.

--- a/class_linux.go
+++ b/class_linux.go
@@ -10,12 +10,7 @@ import (
 // ClassDel will delete a class from the system.
 // Equivalent to: `tc class del $class`
 func ClassDel(class Class) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.ClassDel(class)
+	return pkgHandle.ClassDel(class)
 }
 
 // ClassDel will delete a class from the system.
@@ -28,12 +23,7 @@ func (h *Handle) ClassDel(class Class) error {
 // Equivalent to: `tc class change $class`
 // The parent and handle MUST NOT be changed.
 func ClassChange(class Class) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.ClassChange(class)
+	return pkgHandle.ClassChange(class)
 }
 
 // ClassChange will change a class in place
@@ -49,12 +39,7 @@ func (h *Handle) ClassChange(class Class) error {
 // If a class already exist with this parent/handle pair, the class is changed.
 // If a class does not already exist with this parent/handle, a new class is created.
 func ClassReplace(class Class) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.ClassReplace(class)
+	return pkgHandle.ClassReplace(class)
 }
 
 // ClassReplace will replace a class to the system.
@@ -69,12 +54,7 @@ func (h *Handle) ClassReplace(class Class) error {
 // ClassAdd will add a class to the system.
 // Equivalent to: `tc class add $class`
 func ClassAdd(class Class) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.ClassAdd(class)
+	return pkgHandle.ClassAdd(class)
 }
 
 // ClassAdd will add a class to the system.
@@ -148,12 +128,7 @@ func classPayload(req *nl.NetlinkRequest, class Class) error {
 // Equivalent to: `tc class show`.
 // Generally returns nothing if link and parent are not specified.
 func ClassList(link Link, parent uint32) ([]Class, error) {
-	h, err := NewHandle()
-	if err != nil {
-		return nil, err
-	}
-	defer h.Delete()
-	return h.ClassList(link, parent)
+	return pkgHandle.ClassList(link, parent)
 }
 
 // ClassList gets a list of classes in the system.

--- a/filter_linux.go
+++ b/filter_linux.go
@@ -12,12 +12,7 @@ import (
 // FilterDel will delete a filter from the system.
 // Equivalent to: `tc filter del $filter`
 func FilterDel(filter Filter) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.FilterDel(filter)
+	return pkgHandle.FilterDel(filter)
 }
 
 // FilterDel will delete a filter from the system.
@@ -41,12 +36,7 @@ func (h *Handle) FilterDel(filter Filter) error {
 // FilterAdd will add a filter to the system.
 // Equivalent to: `tc filter add $filter`
 func FilterAdd(filter Filter) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.FilterAdd(filter)
+	return pkgHandle.FilterAdd(filter)
 }
 
 // FilterAdd will add a filter to the system.
@@ -138,12 +128,7 @@ func (h *Handle) FilterAdd(filter Filter) error {
 // Equivalent to: `tc filter show`.
 // Generally retunrs nothing if link and parent are not specified.
 func FilterList(link Link, parent uint32) ([]Filter, error) {
-	h, err := NewHandle()
-	if err != nil {
-		return nil, err
-	}
-	defer h.Delete()
-	return h.FilterList(link, parent)
+	return pkgHandle.FilterList(link, parent)
 }
 
 // FilterList gets a list of filters in the system.

--- a/handle.go
+++ b/handle.go
@@ -8,6 +8,9 @@ import (
 	"github.com/vishvananda/netns"
 )
 
+// Empty handle used by the netlink package methods
+var pkgHandle = &Handle{}
+
 // Handle is an handle for the netlink requests
 // on a specific network namespace. All the requests
 // share the same netlink socket, which gets released

--- a/link_linux.go
+++ b/link_linux.go
@@ -45,12 +45,7 @@ func (h *Handle) ensureIndex(link *LinkAttrs) {
 // LinkSetUp enables the link device.
 // Equivalent to: `ip link set $link up`
 func LinkSetUp(link Link) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.LinkSetUp(link)
+	return pkgHandle.LinkSetUp(link)
 }
 
 // LinkSetUp enables the link device.
@@ -73,12 +68,7 @@ func (h *Handle) LinkSetUp(link Link) error {
 // LinkSetDown disables link device.
 // Equivalent to: `ip link set $link down`
 func LinkSetDown(link Link) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.LinkSetDown(link)
+	return pkgHandle.LinkSetDown(link)
 }
 
 // LinkSetDown disables link device.
@@ -101,12 +91,7 @@ func (h *Handle) LinkSetDown(link Link) error {
 // LinkSetMTU sets the mtu of the link device.
 // Equivalent to: `ip link set $link mtu $mtu`
 func LinkSetMTU(link Link, mtu int) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.LinkSetMTU(link, mtu)
+	return pkgHandle.LinkSetMTU(link, mtu)
 }
 
 // LinkSetMTU sets the mtu of the link device.
@@ -133,12 +118,7 @@ func (h *Handle) LinkSetMTU(link Link, mtu int) error {
 // LinkSetName sets the name of the link device.
 // Equivalent to: `ip link set $link name $name`
 func LinkSetName(link Link, name string) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.LinkSetName(link, name)
+	return pkgHandle.LinkSetName(link, name)
 }
 
 // LinkSetName sets the name of the link device.
@@ -162,12 +142,7 @@ func (h *Handle) LinkSetName(link Link, name string) error {
 // LinkSetAlias sets the alias of the link device.
 // Equivalent to: `ip link set dev $link alias $name`
 func LinkSetAlias(link Link, name string) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.LinkSetAlias(link, name)
+	return pkgHandle.LinkSetAlias(link, name)
 }
 
 // LinkSetAlias sets the alias of the link device.
@@ -191,12 +166,7 @@ func (h *Handle) LinkSetAlias(link Link, name string) error {
 // LinkSetHardwareAddr sets the hardware address of the link device.
 // Equivalent to: `ip link set $link address $hwaddr`
 func LinkSetHardwareAddr(link Link, hwaddr net.HardwareAddr) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.LinkSetHardwareAddr(link, hwaddr)
+	return pkgHandle.LinkSetHardwareAddr(link, hwaddr)
 }
 
 // LinkSetHardwareAddr sets the hardware address of the link device.
@@ -220,12 +190,7 @@ func (h *Handle) LinkSetHardwareAddr(link Link, hwaddr net.HardwareAddr) error {
 // LinkSetVfHardwareAddr sets the hardware address of a vf for the link.
 // Equivalent to: `ip link set $link vf $vf mac $hwaddr`
 func LinkSetVfHardwareAddr(link Link, vf int, hwaddr net.HardwareAddr) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.LinkSetVfHardwareAddr(link, vf, hwaddr)
+	return pkgHandle.LinkSetVfHardwareAddr(link, vf, hwaddr)
 }
 
 // LinkSetVfHardwareAddr sets the hardware address of a vf for the link.
@@ -255,12 +220,7 @@ func (h *Handle) LinkSetVfHardwareAddr(link Link, vf int, hwaddr net.HardwareAdd
 // LinkSetVfVlan sets the vlan of a vf for the link.
 // Equivalent to: `ip link set $link vf $vf vlan $vlan`
 func LinkSetVfVlan(link Link, vf, vlan int) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.LinkSetVfVlan(link, vf, vlan)
+	return pkgHandle.LinkSetVfVlan(link, vf, vlan)
 }
 
 // LinkSetVfVlan sets the vlan of a vf for the link.
@@ -290,12 +250,7 @@ func (h *Handle) LinkSetVfVlan(link Link, vf, vlan int) error {
 // LinkSetMaster sets the master of the link device.
 // Equivalent to: `ip link set $link master $master`
 func LinkSetMaster(link Link, master *Bridge) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.LinkSetMaster(link, master)
+	return pkgHandle.LinkSetMaster(link, master)
 }
 
 // LinkSetMaster sets the master of the link device.
@@ -316,12 +271,7 @@ func (h *Handle) LinkSetMaster(link Link, master *Bridge) error {
 // LinkSetNoMaster removes the master of the link device.
 // Equivalent to: `ip link set $link nomaster`
 func LinkSetNoMaster(link Link) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.LinkSetNoMaster(link)
+	return pkgHandle.LinkSetNoMaster(link)
 }
 
 // LinkSetNoMaster removes the master of the link device.
@@ -333,12 +283,7 @@ func (h *Handle) LinkSetNoMaster(link Link) error {
 // LinkSetMasterByIndex sets the master of the link device.
 // Equivalent to: `ip link set $link master $master`
 func LinkSetMasterByIndex(link Link, masterIndex int) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.LinkSetMasterByIndex(link, masterIndex)
+	return pkgHandle.LinkSetMasterByIndex(link, masterIndex)
 }
 
 // LinkSetMasterByIndex sets the master of the link device.
@@ -366,12 +311,7 @@ func (h *Handle) LinkSetMasterByIndex(link Link, masterIndex int) error {
 // pid must be a pid of a running process.
 // Equivalent to: `ip link set $link netns $pid`
 func LinkSetNsPid(link Link, nspid int) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.LinkSetNsPid(link, nspid)
+	return pkgHandle.LinkSetNsPid(link, nspid)
 }
 
 // LinkSetNsPid puts the device into a new network namespace. The
@@ -400,12 +340,7 @@ func (h *Handle) LinkSetNsPid(link Link, nspid int) error {
 // fd must be an open file descriptor to a network namespace.
 // Similar to: `ip link set $link netns $ns`
 func LinkSetNsFd(link Link, fd int) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.LinkSetNsFd(link, fd)
+	return pkgHandle.LinkSetNsFd(link, fd)
 }
 
 // LinkSetNsFd puts the device into a new network namespace. The
@@ -591,12 +526,7 @@ func addBondAttrs(bond *Bond, linkInfo *nl.RtAttr) {
 // are taken from the parameters in the link object.
 // Equivalent to: `ip link add $link`
 func LinkAdd(link Link) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.LinkAdd(link)
+	return pkgHandle.LinkAdd(link)
 }
 
 // LinkAdd adds a new link device. The type and features of the device
@@ -768,12 +698,7 @@ func (h *Handle) LinkAdd(link Link) error {
 // the link object for it to be deleted. The other values are ignored.
 // Equivalent to: `ip link del $link`
 func LinkDel(link Link) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.LinkDel(link)
+	return pkgHandle.LinkDel(link)
 }
 
 // LinkDel deletes link device. Either Index or Name must be set in
@@ -824,12 +749,7 @@ func (h *Handle) linkByAliasDump(alias string) (Link, error) {
 
 // LinkByName finds a link by name and returns a pointer to the object.
 func LinkByName(name string) (Link, error) {
-	h, err := NewHandle()
-	if err != nil {
-		return nil, err
-	}
-	defer h.Delete()
-	return h.LinkByName(name)
+	return pkgHandle.LinkByName(name)
 }
 
 // LinkByName finds a link by name and returns a pointer to the object.
@@ -860,12 +780,7 @@ func (h *Handle) LinkByName(name string) (Link, error) {
 // LinkByAlias finds a link by its alias and returns a pointer to the object.
 // If there are multiple links with the alias it returns the first one
 func LinkByAlias(alias string) (Link, error) {
-	h, err := NewHandle()
-	if err != nil {
-		return nil, err
-	}
-	defer h.Delete()
-	return h.LinkByAlias(alias)
+	return pkgHandle.LinkByAlias(alias)
 }
 
 // LinkByAlias finds a link by its alias and returns a pointer to the object.
@@ -896,12 +811,7 @@ func (h *Handle) LinkByAlias(alias string) (Link, error) {
 
 // LinkByIndex finds a link by index and returns a pointer to the object.
 func LinkByIndex(index int) (Link, error) {
-	h, err := NewHandle()
-	if err != nil {
-		return nil, err
-	}
-	defer h.Delete()
-	return h.LinkByIndex(index)
+	return pkgHandle.LinkByIndex(index)
 }
 
 // LinkByIndex finds a link by index and returns a pointer to the object.
@@ -1047,12 +957,7 @@ func linkDeserialize(m []byte) (Link, error) {
 // LinkList gets a list of link devices.
 // Equivalent to: `ip link show`
 func LinkList() ([]Link, error) {
-	h, err := NewHandle()
-	if err != nil {
-		return nil, err
-	}
-	defer h.Delete()
-	return h.LinkList()
+	return pkgHandle.LinkList()
 }
 
 // LinkList gets a list of link devices.
@@ -1124,12 +1029,7 @@ func LinkSubscribe(ch chan<- LinkUpdate, done <-chan struct{}) error {
 }
 
 func LinkSetHairpin(link Link, mode bool) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.LinkSetHairpin(link, mode)
+	return pkgHandle.LinkSetHairpin(link, mode)
 }
 
 func (h *Handle) LinkSetHairpin(link Link, mode bool) error {
@@ -1137,12 +1037,7 @@ func (h *Handle) LinkSetHairpin(link Link, mode bool) error {
 }
 
 func LinkSetGuard(link Link, mode bool) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.LinkSetGuard(link, mode)
+	return pkgHandle.LinkSetGuard(link, mode)
 }
 
 func (h *Handle) LinkSetGuard(link Link, mode bool) error {
@@ -1150,12 +1045,7 @@ func (h *Handle) LinkSetGuard(link Link, mode bool) error {
 }
 
 func LinkSetFastLeave(link Link, mode bool) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.LinkSetFastLeave(link, mode)
+	return pkgHandle.LinkSetFastLeave(link, mode)
 }
 
 func (h *Handle) LinkSetFastLeave(link Link, mode bool) error {
@@ -1163,12 +1053,7 @@ func (h *Handle) LinkSetFastLeave(link Link, mode bool) error {
 }
 
 func LinkSetLearning(link Link, mode bool) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.LinkSetLearning(link, mode)
+	return pkgHandle.LinkSetLearning(link, mode)
 }
 
 func (h *Handle) LinkSetLearning(link Link, mode bool) error {
@@ -1176,12 +1061,7 @@ func (h *Handle) LinkSetLearning(link Link, mode bool) error {
 }
 
 func LinkSetRootBlock(link Link, mode bool) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.LinkSetRootBlock(link, mode)
+	return pkgHandle.LinkSetRootBlock(link, mode)
 }
 
 func (h *Handle) LinkSetRootBlock(link Link, mode bool) error {
@@ -1189,12 +1069,7 @@ func (h *Handle) LinkSetRootBlock(link Link, mode bool) error {
 }
 
 func LinkSetFlood(link Link, mode bool) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.LinkSetFlood(link, mode)
+	return pkgHandle.LinkSetFlood(link, mode)
 }
 
 func (h *Handle) LinkSetFlood(link Link, mode bool) error {

--- a/neigh_linux.go
+++ b/neigh_linux.go
@@ -67,12 +67,7 @@ func (msg *Ndmsg) Len() int {
 // NeighAdd will add an IP to MAC mapping to the ARP table
 // Equivalent to: `ip neigh add ....`
 func NeighAdd(neigh *Neigh) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.NeighAdd(neigh)
+	return pkgHandle.NeighAdd(neigh)
 }
 
 // NeighAdd will add an IP to MAC mapping to the ARP table
@@ -84,12 +79,7 @@ func (h *Handle) NeighAdd(neigh *Neigh) error {
 // NeighSet will add or replace an IP to MAC mapping to the ARP table
 // Equivalent to: `ip neigh replace....`
 func NeighSet(neigh *Neigh) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.NeighSet(neigh)
+	return pkgHandle.NeighSet(neigh)
 }
 
 // NeighSet will add or replace an IP to MAC mapping to the ARP table
@@ -101,12 +91,7 @@ func (h *Handle) NeighSet(neigh *Neigh) error {
 // NeighAppend will append an entry to FDB
 // Equivalent to: `bridge fdb append...`
 func NeighAppend(neigh *Neigh) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.NeighAppend(neigh)
+	return pkgHandle.NeighAppend(neigh)
 }
 
 // NeighAppend will append an entry to FDB
@@ -118,12 +103,7 @@ func (h *Handle) NeighAppend(neigh *Neigh) error {
 // NeighAppend will append an entry to FDB
 // Equivalent to: `bridge fdb append...`
 func neighAdd(neigh *Neigh, mode int) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.neighAdd(neigh, mode)
+	return pkgHandle.neighAdd(neigh, mode)
 }
 
 // NeighAppend will append an entry to FDB
@@ -136,12 +116,7 @@ func (h *Handle) neighAdd(neigh *Neigh, mode int) error {
 // NeighDel will delete an IP address from a link device.
 // Equivalent to: `ip addr del $addr dev $link`
 func NeighDel(neigh *Neigh) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.NeighDel(neigh)
+	return pkgHandle.NeighDel(neigh)
 }
 
 // NeighDel will delete an IP address from a link device.
@@ -187,12 +162,7 @@ func neighHandle(neigh *Neigh, req *nl.NetlinkRequest) error {
 // Equivalent to: `ip neighbor show`.
 // The list can be filtered by link and ip family.
 func NeighList(linkIndex, family int) ([]Neigh, error) {
-	h, err := NewHandle()
-	if err != nil {
-		return nil, err
-	}
-	defer h.Delete()
-	return h.NeighList(linkIndex, family)
+	return pkgHandle.NeighList(linkIndex, family)
 }
 
 // NeighList gets a list of IP-MAC mappings in the system (ARP table).

--- a/protinfo_linux.go
+++ b/protinfo_linux.go
@@ -8,12 +8,7 @@ import (
 )
 
 func LinkGetProtinfo(link Link) (Protinfo, error) {
-	h, err := NewHandle()
-	if err != nil {
-		return Protinfo{}, err
-	}
-	defer h.Delete()
-	return h.LinkGetProtinfo(link)
+	return pkgHandle.LinkGetProtinfo(link)
 }
 
 func (h *Handle) LinkGetProtinfo(link Link) (Protinfo, error) {

--- a/qdisc_linux.go
+++ b/qdisc_linux.go
@@ -13,12 +13,7 @@ import (
 // QdiscDel will delete a qdisc from the system.
 // Equivalent to: `tc qdisc del $qdisc`
 func QdiscDel(qdisc Qdisc) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.QdiscDel(qdisc)
+	return pkgHandle.QdiscDel(qdisc)
 }
 
 // QdiscDel will delete a qdisc from the system.
@@ -31,12 +26,7 @@ func (h *Handle) QdiscDel(qdisc Qdisc) error {
 // Equivalent to: `tc qdisc change $qdisc`
 // The parent and handle MUST NOT be changed.
 func QdiscChange(qdisc Qdisc) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.QdiscChange(qdisc)
+	return pkgHandle.QdiscChange(qdisc)
 }
 
 // QdiscChange will change a qdisc in place
@@ -50,12 +40,7 @@ func (h *Handle) QdiscChange(qdisc Qdisc) error {
 // Equivalent to: `tc qdisc replace $qdisc`
 // The handle MUST change.
 func QdiscReplace(qdisc Qdisc) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.QdiscReplace(qdisc)
+	return pkgHandle.QdiscReplace(qdisc)
 }
 
 // QdiscReplace will replace a qdisc to the system.
@@ -71,12 +56,7 @@ func (h *Handle) QdiscReplace(qdisc Qdisc) error {
 // QdiscAdd will add a qdisc to the system.
 // Equivalent to: `tc qdisc add $qdisc`
 func QdiscAdd(qdisc Qdisc) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.QdiscAdd(qdisc)
+	return pkgHandle.QdiscAdd(qdisc)
 }
 
 // QdiscAdd will add a qdisc to the system.
@@ -185,12 +165,7 @@ func qdiscPayload(req *nl.NetlinkRequest, qdisc Qdisc) error {
 // Equivalent to: `tc qdisc show`.
 // The list can be filtered by link.
 func QdiscList(link Link) ([]Qdisc, error) {
-	h, err := NewHandle()
-	if err != nil {
-		return nil, err
-	}
-	defer h.Delete()
-	return h.QdiscList(link)
+	return pkgHandle.QdiscList(link)
 }
 
 // QdiscList gets a list of qdiscs in the system.

--- a/route_linux.go
+++ b/route_linux.go
@@ -26,12 +26,7 @@ const (
 // RouteAdd will add a route to the system.
 // Equivalent to: `ip route add $route`
 func RouteAdd(route *Route) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.RouteAdd(route)
+	return pkgHandle.RouteAdd(route)
 }
 
 // RouteAdd will add a route to the system.
@@ -44,12 +39,7 @@ func (h *Handle) RouteAdd(route *Route) error {
 // RouteDel will delete a route from the system.
 // Equivalent to: `ip route del $route`
 func RouteDel(route *Route) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.RouteDel(route)
+	return pkgHandle.RouteDel(route)
 }
 
 // RouteDel will delete a route from the system.
@@ -162,12 +152,7 @@ func (h *Handle) routeHandle(route *Route, req *nl.NetlinkRequest, msg *nl.RtMsg
 // Equivalent to: `ip route show`.
 // The list can be filtered by link and ip family.
 func RouteList(link Link, family int) ([]Route, error) {
-	h, err := NewHandle()
-	if err != nil {
-		return nil, err
-	}
-	defer h.Delete()
-	return h.RouteList(link, family)
+	return pkgHandle.RouteList(link, family)
 }
 
 // RouteList gets a list of routes in the system.
@@ -186,12 +171,7 @@ func (h *Handle) RouteList(link Link, family int) ([]Route, error) {
 // RouteListFiltered gets a list of routes in the system filtered with specified rules.
 // All rules must be defined in RouteFilter struct
 func RouteListFiltered(family int, filter *Route, filterMask uint64) ([]Route, error) {
-	h, err := NewHandle()
-	if err != nil {
-		return nil, err
-	}
-	defer h.Delete()
-	return h.RouteListFiltered(family, filter, filterMask)
+	return pkgHandle.RouteListFiltered(family, filter, filterMask)
 }
 
 // RouteListFiltered gets a list of routes in the system filtered with specified rules.
@@ -303,12 +283,7 @@ func deserializeRoute(m []byte) (Route, error) {
 // RouteGet gets a route to a specific destination from the host system.
 // Equivalent to: 'ip route get'.
 func RouteGet(destination net.IP) ([]Route, error) {
-	h, err := NewHandle()
-	if err != nil {
-		return nil, err
-	}
-	defer h.Delete()
-	return h.RouteGet(destination)
+	return pkgHandle.RouteGet(destination)
 }
 
 // RouteGet gets a route to a specific destination from the host system.

--- a/rule_linux.go
+++ b/rule_linux.go
@@ -11,12 +11,7 @@ import (
 // RuleAdd adds a rule to the system.
 // Equivalent to: ip rule add
 func RuleAdd(rule *Rule) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.RuleAdd(rule)
+	return pkgHandle.RuleAdd(rule)
 }
 
 // RuleAdd adds a rule to the system.
@@ -29,12 +24,7 @@ func (h *Handle) RuleAdd(rule *Rule) error {
 // RuleDel deletes a rule from the system.
 // Equivalent to: ip rule del
 func RuleDel(rule *Rule) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.RuleDel(rule)
+	return pkgHandle.RuleDel(rule)
 }
 
 // RuleDel deletes a rule from the system.
@@ -150,12 +140,7 @@ func ruleHandle(rule *Rule, req *nl.NetlinkRequest) error {
 // RuleList lists rules in the system.
 // Equivalent to: ip rule list
 func RuleList(family int) ([]Rule, error) {
-	h, err := NewHandle()
-	if err != nil {
-		return nil, err
-	}
-	defer h.Delete()
-	return h.RuleList(family)
+	return pkgHandle.RuleList(family)
 }
 
 // RuleList lists rules in the system.

--- a/xfrm_policy_linux.go
+++ b/xfrm_policy_linux.go
@@ -24,11 +24,7 @@ func selFromPolicy(sel *nl.XfrmSelector, policy *XfrmPolicy) {
 // XfrmPolicyAdd will add an xfrm policy to the system.
 // Equivalent to: `ip xfrm policy add $policy`
 func XfrmPolicyAdd(policy *XfrmPolicy) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	return h.XfrmPolicyAdd(policy)
+	return pkgHandle.XfrmPolicyAdd(policy)
 }
 
 // XfrmPolicyAdd will add an xfrm policy to the system.
@@ -40,12 +36,7 @@ func (h *Handle) XfrmPolicyAdd(policy *XfrmPolicy) error {
 // XfrmPolicyUpdate will update an xfrm policy to the system.
 // Equivalent to: `ip xfrm policy update $policy`
 func XfrmPolicyUpdate(policy *XfrmPolicy) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.XfrmPolicyUpdate(policy)
+	return pkgHandle.XfrmPolicyUpdate(policy)
 }
 
 // XfrmPolicyUpdate will update an xfrm policy to the system.
@@ -98,12 +89,7 @@ func (h *Handle) xfrmPolicyAddOrUpdate(policy *XfrmPolicy, nlProto int) error {
 // the Tmpls are ignored when matching the policy to delete.
 // Equivalent to: `ip xfrm policy del $policy`
 func XfrmPolicyDel(policy *XfrmPolicy) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.XfrmPolicyDel(policy)
+	return pkgHandle.XfrmPolicyDel(policy)
 }
 
 // XfrmPolicyDel will delete an xfrm policy from the system. Note that
@@ -131,12 +117,7 @@ func (h *Handle) XfrmPolicyDel(policy *XfrmPolicy) error {
 // Equivalent to: `ip xfrm policy show`.
 // The list can be filtered by ip family.
 func XfrmPolicyList(family int) ([]XfrmPolicy, error) {
-	h, err := NewHandle()
-	if err != nil {
-		return nil, err
-	}
-	defer h.Delete()
-	return h.XfrmPolicyList(family)
+	return pkgHandle.XfrmPolicyList(family)
 }
 
 // XfrmPolicyList gets a list of xfrm policies in the system.

--- a/xfrm_state_linux.go
+++ b/xfrm_state_linux.go
@@ -48,12 +48,7 @@ func writeMark(m *XfrmMark) []byte {
 // XfrmStateAdd will add an xfrm state to the system.
 // Equivalent to: `ip xfrm state add $state`
 func XfrmStateAdd(state *XfrmState) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.XfrmStateAdd(state)
+	return pkgHandle.XfrmStateAdd(state)
 }
 
 // XfrmStateAdd will add an xfrm state to the system.
@@ -65,12 +60,7 @@ func (h *Handle) XfrmStateAdd(state *XfrmState) error {
 // XfrmStateUpdate will update an xfrm state to the system.
 // Equivalent to: `ip xfrm state update $state`
 func XfrmStateUpdate(state *XfrmState) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.XfrmStateUpdate(state)
+	return pkgHandle.XfrmStateUpdate(state)
 }
 
 // XfrmStateUpdate will update an xfrm state to the system.
@@ -132,12 +122,7 @@ func (h *Handle) xfrmStateAddOrUpdate(state *XfrmState, nlProto int) error {
 // the Algos are ignored when matching the state to delete.
 // Equivalent to: `ip xfrm state del $state`
 func XfrmStateDel(state *XfrmState) error {
-	h, err := NewHandle()
-	if err != nil {
-		return err
-	}
-	defer h.Delete()
-	return h.XfrmStateDel(state)
+	return pkgHandle.XfrmStateDel(state)
 }
 
 // XfrmStateDel will delete an xfrm state from the system. Note that
@@ -170,12 +155,7 @@ func (h *Handle) XfrmStateDel(state *XfrmState) error {
 // Equivalent to: `ip [-4|-6] xfrm state show`.
 // The list can be filtered by ip family.
 func XfrmStateList(family int) ([]XfrmState, error) {
-	h, err := NewHandle()
-	if err != nil {
-		return nil, err
-	}
-	defer h.Delete()
-	return h.XfrmStateList(family)
+	return pkgHandle.XfrmStateList(family)
 }
 
 // XfrmStateList gets a list of xfrm states in the system.


### PR DESCRIPTION
#104 introduced the Handle structure with all the netlink pkg methods over it. The existing package methods were reworked to call the counterpart Handle methods for code re-use.

For this, in each pkg method a new handle is created, but this causes a couple of sockets (ROUTE and XFRM) be created and then closed, when it is not really needed...

Original intention was for the above change to be much less pervasive, in fact nl.Execute() was already modified to expect an handle with no allocated socket, causing the socket to be allocated on demand, therefore working as if the handle is not there, as it was doing before #104 

Unfortunately I oversaw this. With this change I am fixing the damage (runtime wise pkg method would behave as before #104) and makes the code more readable IMO.

Signed-off-by: Alessandro Boch <aboch@docker.com>