### PR TITLE
Parse link statistics

### DIFF
--- a/link.go
+++ b/link.go
@@ -31,6 +31,7 @@ type LinkAttrs struct {
 	MasterIndex  int         // must be the index of a bridge
 	Namespace    interface{} // nil | NsPid | NsFd
 	Alias        string
+	Statistics   *LinkStatistics
 }
 
 // NewLinkAttrs returns LinkAttrs structure filled with default values
@@ -38,6 +39,35 @@ func NewLinkAttrs() LinkAttrs {
 	return LinkAttrs{
 		TxQLen: -1,
 	}
+}
+
+/*
+Ref: struct rtnl_link_stats {...}
+*/
+type LinkStatistics struct {
+	RxPackets         uint32
+	TxPackets         uint32
+	RxBytes           uint32
+	TxBytes           uint32
+	RxErrors          uint32
+	TxErrors          uint32
+	RxDropped         uint32
+	TxDropped         uint32
+	Multicast         uint32
+	Collisions        uint32
+	RxLengthErrors    uint32
+	RxOverErrors      uint32
+	RxCrcErrors       uint32
+	RxFrameErrors     uint32
+	RxFifoErrors      uint32
+	RxMissedErrors    uint32
+	TxAbortedErrors   uint32
+	TxCarrierErrors   uint32
+	TxFifoErrors      uint32
+	TxHeartbeatErrors uint32
+	TxWindowErrors    uint32
+	RxCompressed      uint32
+	TxCompressed      uint32
 }
 
 // Device links cannot be created via netlink. These links

--- a/link_linux.go
+++ b/link_linux.go
@@ -12,6 +12,8 @@ import (
 	"github.com/vishvananda/netlink/nl"
 )
 
+const SizeofLinkStats = 0x5c
+
 var native = nl.NativeEndian()
 var lookupByDump = false
 
@@ -943,6 +945,8 @@ func linkDeserialize(m []byte) (Link, error) {
 			base.TxQLen = int(native.Uint32(attr.Value[0:4]))
 		case syscall.IFLA_IFALIAS:
 			base.Alias = string(attr.Value[:len(attr.Value)-1])
+		case syscall.IFLA_STATS:
+			base.Statistics = parseLinkStats(attr.Value[:])
 		}
 	}
 	// Links that don't have IFLA_INFO_KIND are hardware devices
@@ -1359,4 +1363,8 @@ func parseGretapData(link Link, data []syscall.NetlinkRouteAttr) {
 			gre.EncapFlags = native.Uint16(datum.Value[0:2])
 		}
 	}
+}
+
+func parseLinkStats(data []byte) *LinkStatistics {
+	return (*LinkStatistics)(unsafe.Pointer(&data[0:SizeofLinkStats][0]))
 }


### PR DESCRIPTION
So that `ip -s link show <dev>` info is accessible

Tested on ubuntu 3.13, 3.19, and 4.4

Signed-off-by: Alessandro Boch <aboch@docker.com>