### PR TITLE
XFRM Get/Delete state/policy should share same code

### DIFF
--- a/xfrm_policy_test.go
+++ b/xfrm_policy_test.go
@@ -104,6 +104,10 @@ func TestXfrmPolicyAddUpdateDel(t *testing.T) {
 	if err = XfrmPolicyDel(policy); err != nil {
 		t.Fatal(err)
 	}
+
+	if _, err := XfrmPolicyGet(policy); err == nil {
+		t.Fatalf("Unexpected success")
+	}
 }
 
 func comparePolicies(a, b *XfrmPolicy) bool {

--- a/xfrm_state_test.go
+++ b/xfrm_state_test.go
@@ -29,6 +29,7 @@ func TestXfrmStateAddDel(t *testing.T) {
 			Mask:  0xffff0000,
 		},
 	}
+
 	if err := XfrmStateAdd(state); err != nil {
 		t.Fatal(err)
 	}
@@ -65,6 +66,10 @@ func TestXfrmStateAddDel(t *testing.T) {
 	}
 	if len(states) != 0 {
 		t.Fatal("State not removed properly")
+	}
+
+	if _, err := XfrmStateGet(state); err == nil {
+		t.Fatalf("Unexpected success")
 	}
 }
 


### PR DESCRIPTION
- Currently they are not and GET methods are passing
  the wrong structure. Also they are setting the incorrect
  XFRM_F_DUMP flag. Because of this, current get methods
  do not return expected error when query target is not found.

Signed-off-by: Alessandro Boch <aboch@docker.com>