### PR TITLE
Fix a bug in selFromPolicy()

### DIFF
--- a/xfrm_policy_linux.go
+++ b/xfrm_policy_linux.go
@@ -7,13 +7,18 @@ import (
 )
 
 func selFromPolicy(sel *nl.XfrmSelector, policy *XfrmPolicy) {
-	sel.Family = uint16(nl.GetIPFamily(policy.Dst.IP))
-	sel.Daddr.FromIP(policy.Dst.IP)
-	sel.Saddr.FromIP(policy.Src.IP)
-	prefixlenD, _ := policy.Dst.Mask.Size()
-	sel.PrefixlenD = uint8(prefixlenD)
-	prefixlenS, _ := policy.Src.Mask.Size()
-	sel.PrefixlenS = uint8(prefixlenS)
+	sel.Family = uint16(nl.FAMILY_V4)
+	if policy.Dst != nil {
+		sel.Family = uint16(nl.GetIPFamily(policy.Dst.IP))
+		sel.Daddr.FromIP(policy.Dst.IP)
+		prefixlenD, _ := policy.Dst.Mask.Size()
+		sel.PrefixlenD = uint8(prefixlenD)
+	}
+	if policy.Src != nil {
+		sel.Saddr.FromIP(policy.Src.IP)
+		prefixlenS, _ := policy.Src.Mask.Size()
+		sel.PrefixlenS = uint8(prefixlenS)
+	}
 	sel.Proto = uint8(policy.Proto)
 	sel.Dport = nl.Swap16(uint16(policy.DstPort))
 	sel.Sport = nl.Swap16(uint16(policy.SrcPort))


### PR DESCRIPTION
- This causes nil pointer exceptions because it assumes Src and Dst *ipNet are always specified in the policy. While they are not mandatory fields.

Signed-off-by: Alessandro Boch <aboch@docker.com>