### PR TITLE
Properly pass IP address flags

### DIFF
--- a/addr_linux.go
+++ b/addr_linux.go
@@ -69,10 +69,14 @@ func (h *Handle) addrHandle(link Link, addr *Addr, req *nl.NetlinkRequest) error
 	req.AddData(addressData)
 
 	if addr.Flags != 0 {
-		b := make([]byte, 4)
-		native.PutUint32(b, uint32(addr.Flags))
-		flagsData := nl.NewRtAttr(IFA_FLAGS, b)
-		req.AddData(flagsData)
+		if addr.Flags <= 0xff {
+			msg.IfAddrmsg.Flags = uint8(addr.Flags)
+		} else {
+			b := make([]byte, 4)
+			native.PutUint32(b, uint32(addr.Flags))
+			flagsData := nl.NewRtAttr(IFA_FLAGS, b)
+			req.AddData(flagsData)
+		}
 	}
 
 	if addr.Label != "" {


### PR DESCRIPTION
Older kernel expect the flags in the main netlink message, not as attribute.
Once flag number increased beyond 8 in newer kernels, they moved them into the attributes.

Tested on ubuntu 3.13

Fixes #105

Signed-off-by: Alessandro Boch <aboch@docker.com>