### PR TITLE
Allow SPI to be passed in policy template

### DIFF
--- a/xfrm_policy.go
+++ b/xfrm_policy.go
@@ -43,12 +43,13 @@ type XfrmPolicyTmpl struct {
 	Src   net.IP
 	Proto Proto
 	Mode  Mode
+	Spi   int
 	Reqid int
 }
 
 func (t XfrmPolicyTmpl) String() string {
-	return fmt.Sprintf("{Dst: %v, Src: %v, Proto: %s, Mode: %s, Reqid: 0x%x}",
-		t.Dst, t.Src, t.Proto, t.Mode, t.Reqid)
+	return fmt.Sprintf("{Dst: %v, Src: %v, Proto: %s, Mode: %s, Spi: 0x%x, Reqid: 0x%x}",
+		t.Dst, t.Src, t.Proto, t.Mode, t.Spi, t.Reqid)
 }
 
 // XfrmPolicy represents an ipsec policy. It represents the overlay network

--- a/xfrm_policy_linux.go
+++ b/xfrm_policy_linux.go
@@ -71,6 +71,7 @@ func (h *Handle) xfrmPolicyAddOrUpdate(policy *XfrmPolicy, nlProto int) error {
 		userTmpl.XfrmId.Daddr.FromIP(tmpl.Dst)
 		userTmpl.Saddr.FromIP(tmpl.Src)
 		userTmpl.XfrmId.Proto = uint8(tmpl.Proto)
+		userTmpl.XfrmId.Spi = nl.Swap32(uint32(tmpl.Spi))
 		userTmpl.Mode = uint8(tmpl.Mode)
 		userTmpl.Reqid = uint32(tmpl.Reqid)
 		userTmpl.Aalgos = ^uint32(0)
@@ -236,6 +237,7 @@ func parseXfrmPolicy(m []byte, family int) (*XfrmPolicy, error) {
 				resTmpl.Src = tmpl.Saddr.ToIP()
 				resTmpl.Proto = Proto(tmpl.XfrmId.Proto)
 				resTmpl.Mode = Mode(tmpl.Mode)
+				resTmpl.Spi = int(nl.Swap32(tmpl.XfrmId.Spi))
 				resTmpl.Reqid = int(tmpl.Reqid)
 				policy.Tmpls = append(policy.Tmpls, resTmpl)
 			}

--- a/xfrm_policy_test.go
+++ b/xfrm_policy_test.go
@@ -147,7 +147,7 @@ func compareTemplates(a, b []XfrmPolicyTmpl) bool {
 	}
 	for i, ta := range a {
 		tb := b[i]
-		if !ta.Dst.Equal(tb.Dst) || !ta.Src.Equal(tb.Src) ||
+		if !ta.Dst.Equal(tb.Dst) || !ta.Src.Equal(tb.Src) || ta.Spi != tb.Spi ||
 			ta.Mode != tb.Mode || ta.Reqid != tb.Reqid || ta.Proto != tb.Proto {
 			return false
 		}
@@ -190,6 +190,7 @@ func getPolicy() *XfrmPolicy {
 		Dst:   net.ParseIP("127.0.0.2"),
 		Proto: XFRM_PROTO_ESP,
 		Mode:  XFRM_MODE_TUNNEL,
+		Spi:   0xabcdef99,
 	}
 	policy.Tmpls = append(policy.Tmpls, tmpl)
 	return policy


### PR DESCRIPTION
- It is part of the ID and it is needed when you
  program policies for different SAs which share
  same src and dst

Signed-off-by: Alessandro Boch <aboch@docker.com>