### PR TITLE
key len is arch dependant (ppc64 big endian build problem)

### DIFF
--- a/nl/xfrm_state_linux_test.go
+++ b/nl/xfrm_state_linux_test.go
@@ -127,14 +127,18 @@ func deserializeXfrmAlgoSafe(b []byte) *XfrmAlgo {
 }
 
 func TestXfrmAlgoDeserializeSerialize(t *testing.T) {
+	native := NativeEndian()
 	// use a 32 byte key len
 	var orig = make([]byte, SizeofXfrmAlgo+32)
 	rand.Read(orig)
 	// set the key len to 256 bits
-	orig[64] = 0
-	orig[65] = 1
-	orig[66] = 0
-	orig[67] = 0
+	var KeyLen uint32 = 0x00000100 
+	// Little Endian    Big Endian
+	// orig[64] = 0     orig[64] = 0
+	// orig[65] = 1     orig[65] = 0
+	// orig[66] = 0     orig[66] = 1
+	// orig[67] = 0     orig[67] = 0
+	native.PutUint32(orig[64:68], KeyLen)
 	safemsg := deserializeXfrmAlgoSafe(orig)
 	msg := DeserializeXfrmAlgo(orig)
 	testDeserializeSerialize(t, orig, safemsg, msg)
@@ -164,14 +168,18 @@ func deserializeXfrmAlgoAuthSafe(b []byte) *XfrmAlgoAuth {
 }
 
 func TestXfrmAlgoAuthDeserializeSerialize(t *testing.T) {
+	native := NativeEndian()
 	// use a 32 byte key len
 	var orig = make([]byte, SizeofXfrmAlgoAuth+32)
 	rand.Read(orig)
 	// set the key len to 256 bits
-	orig[64] = 0
-	orig[65] = 1
-	orig[66] = 0
-	orig[67] = 0
+	var KeyLen uint32 = 0x00000100 
+	// Little Endian    Big Endian
+	// orig[64] = 0     orig[64] = 0
+	// orig[65] = 1     orig[65] = 0
+	// orig[66] = 0     orig[66] = 1
+	// orig[67] = 0     orig[67] = 0
+	native.PutUint32(orig[64:68], KeyLen)
 	safemsg := deserializeXfrmAlgoAuthSafe(orig)
 	msg := DeserializeXfrmAlgoAuth(orig)
 	testDeserializeSerialize(t, orig, safemsg, msg)


### PR DESCRIPTION
Key length used in DeserializeSerialise XfrmAlgo tests is
endianess dependant. Correction needed to have
TestXfrmAlgoDeserializeSerialize and
TestXfrmAlgoAuthDeserializeSerialize
pass ok on ppc64 arch (big endian).