### PR TITLE
fix macvtap interface mode setup

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -675,6 +675,11 @@ func (h *Handle) LinkAdd(link Link) error {
 			data := nl.NewRtAttrChild(linkInfo, nl.IFLA_INFO_DATA, nil)
 			nl.NewRtAttrChild(data, nl.IFLA_MACVLAN_MODE, nl.Uint32Attr(macvlanModes[macv.Mode]))
 		}
+	} else if macv, ok := link.(*Macvtap); ok {
+		if macv.Mode != MACVLAN_MODE_DEFAULT {
+			data := nl.NewRtAttrChild(linkInfo, nl.IFLA_INFO_DATA, nil)
+			nl.NewRtAttrChild(data, nl.IFLA_MACVLAN_MODE, nl.Uint32Attr(macvlanModes[macv.Mode]))
+		}
 	} else if gretap, ok := link.(*Gretap); ok {
 		addGretapAttrs(gretap, linkInfo)
 	}

--- a/link_test.go
+++ b/link_test.go
@@ -110,6 +110,16 @@ func testLinkAddDel(t *testing.T, link Link) {
 		}
 	}
 
+	if macv, ok := link.(*Macvtap); ok {
+		other, ok := result.(*Macvtap)
+		if !ok {
+			t.Fatal("Result of create is not a macvtap")
+		}
+		if macv.Mode != other.Mode {
+			t.Fatalf("Got unexpected mode: %d, expected: %d", other.Mode, macv.Mode)
+		}
+	}
+
 	if err = LinkDel(link); err != nil {
 		t.Fatal(err)
 	}
@@ -247,6 +257,16 @@ func TestLinkAddDelMacvlan(t *testing.T) {
 		Mode:      MACVLAN_MODE_PRIVATE,
 	})
 
+	testLinkAddDel(t, &Macvlan{
+		LinkAttrs: LinkAttrs{Name: "bar", ParentIndex: parent.Attrs().Index},
+		Mode:      MACVLAN_MODE_BRIDGE,
+	})
+
+	testLinkAddDel(t, &Macvlan{
+		LinkAttrs: LinkAttrs{Name: "bar", ParentIndex: parent.Attrs().Index},
+		Mode:      MACVLAN_MODE_VEPA,
+	})
+
 	if err := LinkDel(parent); err != nil {
 		t.Fatal(err)
 	}
@@ -265,6 +285,20 @@ func TestLinkAddDelMacvtap(t *testing.T) {
 		Macvlan: Macvlan{
 			LinkAttrs: LinkAttrs{Name: "bar", ParentIndex: parent.Attrs().Index},
 			Mode:      MACVLAN_MODE_PRIVATE,
+		},
+	})
+
+	testLinkAddDel(t, &Macvtap{
+		Macvlan: Macvlan{
+			LinkAttrs: LinkAttrs{Name: "bar", ParentIndex: parent.Attrs().Index},
+			Mode:      MACVLAN_MODE_BRIDGE,
+		},
+	})
+
+	testLinkAddDel(t, &Macvtap{
+		Macvlan: Macvlan{
+			LinkAttrs: LinkAttrs{Name: "bar", ParentIndex: parent.Attrs().Index},
+			Mode:      MACVLAN_MODE_VEPA,
 		},
 	})
 


### PR DESCRIPTION
The mode on macvtap interfaces was not being set correctly.
Due to this the mode on macvtap is always set to default.

Set the mode correctly and add unit tests to check the same

This fixes issue https://github.com/vishvananda/netlink/issues/136

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>