### PR TITLE
Allow to specify netlink families for Handle

### DIFF
--- a/handle_test.go
+++ b/handle_test.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/vishvananda/netlink/nl"
 	"github.com/vishvananda/netns"
 )
 
@@ -18,12 +19,18 @@ func TestHandleCreateDelete(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if h.routeSocket == nil || h.xfrmSocket == nil {
-		t.Fatalf("Handle socket(s) were not created")
+	for _, f := range nl.SupportedNlFamilies {
+		sh, ok := h.sockets[f]
+		if !ok {
+			t.Fatalf("Handle socket(s) for family %d was not created", f)
+		}
+		if sh.Socket == nil {
+			t.Fatalf("Socket for family %d was not created", f)
+		}
 	}
 
 	h.Delete()
-	if h.routeSocket != nil || h.xfrmSocket != nil {
+	if h.sockets != nil {
 		t.Fatalf("Handle socket(s) were not destroyed")
 	}
 }

--- a/nl/nl_linux.go
+++ b/nl/nl_linux.go
@@ -22,6 +22,9 @@ const (
 	FAMILY_V6  = syscall.AF_INET6
 )
 
+// SupportedNlFamilies contains the list of netlink families this netlink package supports
+var SupportedNlFamilies = []int{syscall.NETLINK_ROUTE, syscall.NETLINK_XFRM}
+
 var nextSeqNr uint32
 
 // GetIPFamily returns the family type of a net.IP.
@@ -175,9 +178,8 @@ func (a *RtAttr) Serialize() []byte {
 
 type NetlinkRequest struct {
 	syscall.NlMsghdr
-	Data        []NetlinkRequestData
-	RouteSocket *NetlinkSocket
-	XfmrSocket  *NetlinkSocket
+	Data    []NetlinkRequestData
+	Sockets map[int]*SocketHandle
 }
 
 // Serialize the Netlink Request into a byte array
@@ -217,15 +219,12 @@ func (req *NetlinkRequest) Execute(sockType int, resType uint16) ([][]byte, erro
 		err error
 	)
 
-	switch sockType {
-	case syscall.NETLINK_XFRM:
-		s = req.XfmrSocket
-	case syscall.NETLINK_ROUTE:
-		s = req.RouteSocket
-	default:
-		return nil, fmt.Errorf("Socket type %d is not handled", sockType)
+	if req.Sockets != nil {
+		if sh, ok := req.Sockets[sockType]; ok {
+			s = sh.Socket
+			req.Seq = atomic.AddUint32(&sh.Seq, 1)
+		}
 	}
-
 	sharedSocket := s != nil
 
 	if s == nil {
@@ -485,4 +484,18 @@ func netlinkRouteAttrAndValue(b []byte) (*syscall.RtAttr, []byte, int, error) {
 		return nil, nil, 0, syscall.EINVAL
 	}
 	return a, b[syscall.SizeofRtAttr:], rtaAlignOf(int(a.Len)), nil
+}
+
+// SocketHandle contains the netlink socket and the associated
+// sequence counter for a specific netlink family
+type SocketHandle struct {
+	Seq    uint32
+	Socket *NetlinkSocket
+}
+
+// Close closes the netlink socket
+func (sh *SocketHandle) Close() {
+	if sh.Socket != nil {
+		sh.Socket.Close()
+	}
 }


### PR DESCRIPTION
- Allow to specify the netlink families at Handle creation
- Add a method to Handle to verify if a family is supported
- Backward compatible change, if no families are specified, it works as today
- Move the Seq counter per socket type

If this change is accepted, it would supersede #139 . Caller would now be able to not specify a family if the required modules are missing, thus it will still be able to create the Handle. And code which later uses the Handle would be able to first check if a family is supported.

Signed-off-by: Alessandro Boch <aboch@docker.com>