### PR TITLE
Fix bug in xfrmStateGetOrDelete

### DIFF
--- a/xfrm_state_linux.go
+++ b/xfrm_state_linux.go
@@ -213,7 +213,7 @@ func (h *Handle) xfrmStateGetOrDelete(state *XfrmState, nlProto int) (*XfrmState
 		req.AddData(out)
 	}
 	if state.Src != nil {
-		out := nl.NewRtAttr(nl.XFRMA_SRCADDR, state.Src)
+		out := nl.NewRtAttr(nl.XFRMA_SRCADDR, state.Src.To16())
 		req.AddData(out)
 	}
 

--- a/xfrm_state_test.go
+++ b/xfrm_state_test.go
@@ -160,8 +160,9 @@ func TestXfrmStateUpdateLimits(t *testing.T) {
 
 func getBaseState() *XfrmState {
 	return &XfrmState{
-		Src:   net.ParseIP("127.0.0.1"),
-		Dst:   net.ParseIP("127.0.0.2"),
+		// Force 4 byte notation for the IPv4 addresses
+		Src:   net.ParseIP("127.0.0.1").To4(),
+		Dst:   net.ParseIP("127.0.0.2").To4(),
 		Proto: XFRM_PROTO_ESP,
 		Mode:  XFRM_MODE_TUNNEL,
 		Spi:   1,
@@ -184,6 +185,7 @@ func getAeadState() *XfrmState {
 	// 128 key bits + 32 salt bits
 	k, _ := hex.DecodeString("d0562776bf0e75830ba3f7f8eb6c09b555aa1177")
 	return &XfrmState{
+		// Leave IPv4 addresses in Ipv4 in IPv6 notation
 		Src:   net.ParseIP("192.168.1.1"),
 		Dst:   net.ParseIP("192.168.2.2"),
 		Proto: XFRM_PROTO_ESP,


### PR DESCRIPTION
- It fails if source address attribute is passed in 4 byte notation 

It fails with `numerical result out of range`

Signed-off-by: Alessandro Boch <aboch@docker.com>