### PR TITLE
Multipath route is not installed due to gwData is duplicated in block.

### DIFF
--- a/route_linux.go
+++ b/route_linux.go
@@ -153,7 +153,7 @@ func (h *Handle) routeHandle(route *Route, req *nl.NetlinkRequest, msg *nl.RtMsg
 				} else {
 					gw = nl.NewRtAttr(syscall.RTA_GATEWAY, []byte(nh.Gw.To16()))
 				}
-				gwData := gw.Serialize()
+				gwData = gw.Serialize()
 				rtnh.Len += uint16(len(gwData))
 			}
 			buf = append(buf, rtnh.Serialize()...)


### PR DESCRIPTION
Multipath route with Gw is not properly installed due to gwData is newly allocated in block.
With this fix, multipath route with gateway address is properly installed into the kernel.