### PR TITLE
filter: fix recursive string call

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -60,7 +60,7 @@ func (a TcAct) String() string {
 	case TC_ACT_JUMP:
 		return "jump"
 	}
-	return fmt.Sprintf("0x%x", a)
+	return fmt.Sprintf("0x%x", int32(a))
 }
 
 type TcPolAct int32
@@ -86,7 +86,7 @@ func (a TcPolAct) String() string {
 	case TC_POLICE_PIPE:
 		return "pipe"
 	}
-	return fmt.Sprintf("0x%x", a)
+	return fmt.Sprintf("0x%x", int32(a))
 }
 
 type ActionAttrs struct {


### PR DESCRIPTION
I've tested and that call indeed can lead to infinite recursion.
Found with `go vet`.