### PR TITLE
Expose link's raw flags

### DIFF
--- a/link.go
+++ b/link.go
@@ -26,6 +26,7 @@ type LinkAttrs struct {
 	Name         string
 	HardwareAddr net.HardwareAddr
 	Flags        net.Flags
+	RawFlags     uint32
 	ParentIndex  int         // index of the parent link device
 	MasterIndex  int         // must be the index of a bridge
 	Namespace    interface{} // nil | NsPid | NsFd

--- a/link_linux.go
+++ b/link_linux.go
@@ -936,7 +936,7 @@ func linkDeserialize(m []byte) (Link, error) {
 		return nil, err
 	}
 
-	base := LinkAttrs{Index: int(msg.Index), Flags: linkFlags(msg.Flags)}
+	base := LinkAttrs{Index: int(msg.Index), RawFlags: msg.Flags, Flags: linkFlags(msg.Flags)}
 	if msg.Flags&syscall.IFF_PROMISC != 0 {
 		base.Promisc = 1
 	}


### PR DESCRIPTION
Currently LinkAttrs structure only exposes link flags which can be represented as net.Flags.
Unfortunately only very few flags fall in this category or they only represent administrative states (configurations).

To allow caller to check link's operational states, for example if the link is effectively up (syscall.IFF_RUNNING), this change adds to the attribute structures the raw flags returned by kernel as part of the `syscall.IfInfomsg` message.

This allows greater flexibility on the caller side without need for this library to create a field for each state.

Fixes #158 

Signed-off-by: Alessandro Boch <aboch@docker.com>