### PR TITLE
[link] add Link Encapsulation Type in LinkAttr

### DIFF
--- a/link.go
+++ b/link.go
@@ -34,6 +34,7 @@ type LinkAttrs struct {
 	Statistics   *LinkStatistics
 	Promisc      int
 	Xdp          *LinkXdp
+	EncapType    string
 }
 
 // NewLinkAttrs returns LinkAttrs structure filled with default values

--- a/link_linux.go
+++ b/link_linux.go
@@ -936,7 +936,7 @@ func linkDeserialize(m []byte) (Link, error) {
 		return nil, err
 	}
 
-	base := LinkAttrs{Index: int(msg.Index), RawFlags: msg.Flags, Flags: linkFlags(msg.Flags)}
+	base := LinkAttrs{Index: int(msg.Index), RawFlags: msg.Flags, Flags: linkFlags(msg.Flags), EncapType: msg.EncapType()}
 	if msg.Flags&syscall.IFF_PROMISC != 0 {
 		base.Promisc = 1
 	}

--- a/nl/nl_linux.go
+++ b/nl/nl_linux.go
@@ -100,6 +100,147 @@ func (msg *IfInfomsg) Len() int {
 	return syscall.SizeofIfInfomsg
 }
 
+func (msg *IfInfomsg) EncapType() string {
+	switch msg.Type {
+	case 0:
+		return "generic"
+	case syscall.ARPHRD_ETHER:
+		return "ether"
+	case syscall.ARPHRD_EETHER:
+		return "eether"
+	case syscall.ARPHRD_AX25:
+		return "ax25"
+	case syscall.ARPHRD_PRONET:
+		return "pronet"
+	case syscall.ARPHRD_CHAOS:
+		return "chaos"
+	case syscall.ARPHRD_IEEE802:
+		return "ieee802"
+	case syscall.ARPHRD_ARCNET:
+		return "arcnet"
+	case syscall.ARPHRD_APPLETLK:
+		return "atalk"
+	case syscall.ARPHRD_DLCI:
+		return "dlci"
+	case syscall.ARPHRD_ATM:
+		return "atm"
+	case syscall.ARPHRD_METRICOM:
+		return "metricom"
+	case syscall.ARPHRD_IEEE1394:
+		return "ieee1394"
+	case syscall.ARPHRD_INFINIBAND:
+		return "infiniband"
+	case syscall.ARPHRD_SLIP:
+		return "slip"
+	case syscall.ARPHRD_CSLIP:
+		return "cslip"
+	case syscall.ARPHRD_SLIP6:
+		return "slip6"
+	case syscall.ARPHRD_CSLIP6:
+		return "cslip6"
+	case syscall.ARPHRD_RSRVD:
+		return "rsrvd"
+	case syscall.ARPHRD_ADAPT:
+		return "adapt"
+	case syscall.ARPHRD_ROSE:
+		return "rose"
+	case syscall.ARPHRD_X25:
+		return "x25"
+	case syscall.ARPHRD_HWX25:
+		return "hwx25"
+	case syscall.ARPHRD_PPP:
+		return "ppp"
+	case syscall.ARPHRD_HDLC:
+		return "hdlc"
+	case syscall.ARPHRD_LAPB:
+		return "lapb"
+	case syscall.ARPHRD_DDCMP:
+		return "ddcmp"
+	case syscall.ARPHRD_RAWHDLC:
+		return "rawhdlc"
+	case syscall.ARPHRD_TUNNEL:
+		return "ipip"
+	case syscall.ARPHRD_TUNNEL6:
+		return "tunnel6"
+	case syscall.ARPHRD_FRAD:
+		return "frad"
+	case syscall.ARPHRD_SKIP:
+		return "skip"
+	case syscall.ARPHRD_LOOPBACK:
+		return "loopback"
+	case syscall.ARPHRD_LOCALTLK:
+		return "ltalk"
+	case syscall.ARPHRD_FDDI:
+		return "fddi"
+	case syscall.ARPHRD_BIF:
+		return "bif"
+	case syscall.ARPHRD_SIT:
+		return "sit"
+	case syscall.ARPHRD_IPDDP:
+		return "ip/ddp"
+	case syscall.ARPHRD_IPGRE:
+		return "gre"
+	case syscall.ARPHRD_PIMREG:
+		return "pimreg"
+	case syscall.ARPHRD_HIPPI:
+		return "hippi"
+	case syscall.ARPHRD_ASH:
+		return "ash"
+	case syscall.ARPHRD_ECONET:
+		return "econet"
+	case syscall.ARPHRD_IRDA:
+		return "irda"
+	case syscall.ARPHRD_FCPP:
+		return "fcpp"
+	case syscall.ARPHRD_FCAL:
+		return "fcal"
+	case syscall.ARPHRD_FCPL:
+		return "fcpl"
+	case syscall.ARPHRD_FCFABRIC:
+		return "fcfb0"
+	case syscall.ARPHRD_FCFABRIC + 1:
+		return "fcfb1"
+	case syscall.ARPHRD_FCFABRIC + 2:
+		return "fcfb2"
+	case syscall.ARPHRD_FCFABRIC + 3:
+		return "fcfb3"
+	case syscall.ARPHRD_FCFABRIC + 4:
+		return "fcfb4"
+	case syscall.ARPHRD_FCFABRIC + 5:
+		return "fcfb5"
+	case syscall.ARPHRD_FCFABRIC + 6:
+		return "fcfb6"
+	case syscall.ARPHRD_FCFABRIC + 7:
+		return "fcfb7"
+	case syscall.ARPHRD_FCFABRIC + 8:
+		return "fcfb8"
+	case syscall.ARPHRD_FCFABRIC + 9:
+		return "fcfb9"
+	case syscall.ARPHRD_FCFABRIC + 10:
+		return "fcfb10"
+	case syscall.ARPHRD_FCFABRIC + 11:
+		return "fcfb11"
+	case syscall.ARPHRD_FCFABRIC + 12:
+		return "fcfb12"
+	case syscall.ARPHRD_IEEE802_TR:
+		return "tr"
+	case syscall.ARPHRD_IEEE80211:
+		return "ieee802.11"
+	case syscall.ARPHRD_IEEE80211_PRISM:
+		return "ieee802.11/prism"
+	case syscall.ARPHRD_IEEE80211_RADIOTAP:
+		return "ieee802.11/radiotap"
+	case syscall.ARPHRD_IEEE802154:
+		return "ieee802.15.4"
+
+	case 65534:
+		return "none"
+	case 65535:
+		return "void"
+	}
+	return fmt.Sprintf("unknown%d", msg.Type)
+}
+
 func rtaAlignOf(attrlen int) int {
 	return (attrlen + syscall.RTA_ALIGNTO - 1) & ^(syscall.RTA_ALIGNTO - 1)
 }


### PR DESCRIPTION
Retreive the link type from Netlink GetLink information.
Aim to return the same value as nl-link-list for example :

gre0 gre <noarp,up,running,lowerup> slave-of NONE group 0 ipgre : gre0
gretap0 ether <broadcast,multicast> slave-of NONE group 0 ipgre : gretap0
dummy0 ether 36:d5:87:cf:eb:35 <broadcast,noarp> group 0
tun0 none <pointopoint,multicast,noarp> group 0
tap0 ether 4e:ce:43:4a:82:c2 <broadcast,multicast> group 0

Signed-off-by: Nicolas PLANEL nplanel@redhat.com
