### PR TITLE
Add ipvlan l3s mode

### DIFF
--- a/link.go
+++ b/link.go
@@ -261,6 +261,7 @@ type IPVlanMode uint16
 const (
 	IPVLAN_MODE_L2 IPVlanMode = iota
 	IPVLAN_MODE_L3
+	IPVLAN_MODE_L3S
 	IPVLAN_MODE_MAX
 )
 


### PR DESCRIPTION
Commit [4fbae7d83c98c30efcf0a2a2ac55fbb75ef5a1a5](https://github.com/torvalds/linux/commit/4fbae7d83c98c30efcf0a2a2ac55fbb75ef5a1a5) added l3s mode support to the kernel, add the value here.
