### PR TITLE
Inconsistent AddrList() interface

### DIFF
--- a/netlink_unspecified.go
+++ b/netlink_unspecified.go
@@ -78,7 +78,7 @@ func AddrDel(link *Link, addr *Addr) error {
 	return ErrNotImplemented
 }
 
-func AddrList(link *Link, family int) ([]Addr, error) {
+func AddrList(link Link, family int) ([]Addr, error) {
 	return nil, ErrNotImplemented
 }
 


### PR DESCRIPTION
The issue was noticed when building coreos/flannel on Mac. By default
the build would fail with:

    pkg/ip/iface.go:32: cannot use link (type *netlink.Device) as type
    *netlink.Link in argument to netlink.AddrList:
        *netlink.Link is pointer to interface, not interface

Resolved by making interfaces of AddList() implementations the same,
although the reason for having `netlink_unspecified.go` is not fully
clear to me and given that there's only one implementation available.
Perhaps a better idea would be to remove the "interface" altoghether.