### PR TITLE
Parse the IFLA_OPERSTATE flag and record in the link attributes.

### DIFF
--- a/link.go
+++ b/link.go
@@ -36,6 +36,40 @@ type LinkAttrs struct {
 	Xdp          *LinkXdp
 	EncapType    string
 	Protinfo     *Protinfo
+	OperState    LinkOperState
+}
+
+// LinkOperState represents the values of the IFLA_OPERSTATE link
+// attribute, which contains the RFC2863 state of the interface.
+type LinkOperState uint8
+
+const (
+	OperUnknown        = iota // Status can't be determined.
+	OperNotPresent            // Some component is missing.
+	OperDown                  // Down.
+	OperLowerLayerDown        // Down due to state of lower layer.
+	OperTesting               // In some test mode.
+	OperDormant               // Not up but pending an external event.
+	OperUp                    // Up, ready to send packets.
+)
+
+func (s LinkOperState) String() string {
+	switch s {
+	case OperNotPresent:
+		return "not-present"
+	case OperDown:
+		return "down"
+	case OperLowerLayerDown:
+		return "lower-layer-down"
+	case OperTesting:
+		return "testing"
+	case OperDormant:
+		return "dormant"
+	case OperUp:
+		return "up"
+	default:
+		return "unknown"
+	}
 }
 
 // NewLinkAttrs returns LinkAttrs structure filled with default values

--- a/link_linux.go
+++ b/link_linux.go
@@ -1083,6 +1083,8 @@ func LinkDeserialize(hdr *syscall.NlMsghdr, m []byte) (Link, error) {
 				}
 				base.Protinfo = parseProtinfo(attrs)
 			}
+		case syscall.IFLA_OPERSTATE:
+			base.OperState = LinkOperState(uint8(attr.Value[0]))
 		}
 	}
 	// Links that don't have IFLA_INFO_KIND are hardware devices


### PR DESCRIPTION
The operstate gives the best picture of whether the interface is really up.