### PR TITLE
Update link functions on non-Linux builds

### DIFF
--- a/netlink_unspecified.go
+++ b/netlink_unspecified.go
@@ -4,41 +4,114 @@ package netlink
 
 import (
 	"errors"
+	"net"
 )
 
 var (
 	ErrNotImplemented = errors.New("not implemented")
 )
 
-func LinkSetUp(link *Link) error {
+func LinkSetUp(link Link) error {
 	return ErrNotImplemented
 }
 
-func LinkSetDown(link *Link) error {
+func LinkSetDown(link Link) error {
 	return ErrNotImplemented
 }
 
-func LinkSetMTU(link *Link, mtu int) error {
+func LinkSetMTU(link Link, mtu int) error {
 	return ErrNotImplemented
 }
 
-func LinkSetMaster(link *Link, master *Link) error {
+func LinkSetMaster(link Link, master *Link) error {
 	return ErrNotImplemented
 }
 
-func LinkSetNsPid(link *Link, nspid int) error {
+func LinkSetNsPid(link Link, nspid int) error {
 	return ErrNotImplemented
 }
 
-func LinkSetNsFd(link *Link, fd int) error {
+func LinkSetNsFd(link Link, fd int) error {
 	return ErrNotImplemented
 }
 
-func LinkAdd(link *Link) error {
+func LinkSetName(link Link, name string) error {
 	return ErrNotImplemented
 }
 
-func LinkDel(link *Link) error {
+func LinkSetAlias(link Link, name string) error {
+	return ErrNotImplemented
+}
+
+func LinkSetHardwareAddr(link Link, hwaddr net.HardwareAddr) error {
+	return ErrNotImplemented
+}
+
+func LinkSetVfHardwareAddr(link Link, vf int, hwaddr net.HardwareAddr) error {
+	return ErrNotImplemented
+}
+
+func LinkSetVfVlan(link Link, vf, vlan int) error {
+	return ErrNotImplemented
+}
+
+func LinkSetVfTxRate(link Link, vf, rate int) error {
+	return ErrNotImplemented
+}
+
+func LinkSetNoMaster(link Link) error {
+	return ErrNotImplemented
+}
+
+func LinkSetMasterByIndex(link Link, masterIndex int) error {
+	return ErrNotImplemented
+}
+
+func LinkSetXdpFd(link Link, fd int) error {
+	return ErrNotImplemented
+}
+
+func LinkByName(name string) (Link, error) {
+	return nil, ErrNotImplemented
+}
+
+func LinkByAlias(alias string) (Link, error) {
+	return nil, ErrNotImplemented
+}
+
+func LinkByIndex(index int) (Link, error) {
+	return nil, ErrNotImplemented
+}
+
+func LinkSetHairpin(link Link, mode bool) error {
+	return ErrNotImplemented
+}
+
+func LinkSetGuard(link Link, mode bool) error {
+	return ErrNotImplemented
+}
+
+func LinkSetFastLeave(link Link, mode bool) error {
+	return ErrNotImplemented
+}
+
+func LinkSetLearning(link Link, mode bool) error {
+	return ErrNotImplemented
+}
+
+func LinkSetRootBlock(link Link, mode bool) error {
+	return ErrNotImplemented
+}
+
+func LinkSetFlood(link Link, mode bool) error {
+	return ErrNotImplemented
+}
+
+func LinkAdd(link Link) error {
+	return ErrNotImplemented
+}
+
+func LinkDel(link Link) error {
 	return ErrNotImplemented
 }
 


### PR DESCRIPTION
The non-Linux stub implementation found in netlink_unspecified.go was
missing quite a few Link related functions.  Also, some of the
functions that were there took a `*Link` instead of a `Link`.