### PR TITLE
Update netlink_unspecified with new Addr function prototypes

### DIFF
--- a/netlink_unspecified.go
+++ b/netlink_unspecified.go
@@ -143,11 +143,11 @@ func LinkList() ([]Link, error) {
 	return nil, ErrNotImplemented
 }
 
-func AddrAdd(link *Link, addr *Addr) error {
+func AddrAdd(link Link, addr *Addr) error {
 	return ErrNotImplemented
 }
 
-func AddrDel(link *Link, addr *Addr) error {
+func AddrDel(link Link, addr *Addr) error {
 	return ErrNotImplemented
 }
 


### PR DESCRIPTION
At some point the function prototypes for the `AddrAdd` and `AddrDel`
functions got out of sync with addr_linix.go.  This patch fixes it.