### PR TITLE
Add support for VRF.

### DIFF
--- a/link.go
+++ b/link.go
@@ -659,6 +659,19 @@ func (iptun *Vti) Type() string {
 	return "vti"
 }
 
+type Vrf struct {
+	LinkAttrs
+	Table uint32
+}
+
+func (vrf *Vrf) Attrs() *LinkAttrs {
+	return &vrf.LinkAttrs
+}
+
+func (vrf *Vrf) Type() string {
+	return "vrf"
+}
+
 // iproute2 supported devices;
 // vlan | veth | vcan | dummy | ifb | macvlan | macvtap |
 // bridge | bond | ipoib | ip6tnl | ipip | sit | vxlan |

--- a/nl/link_linux.go
+++ b/nl/link_linux.go
@@ -447,3 +447,8 @@ const (
 	IFLA_VTI_REMOTE
 	IFLA_VTI_MAX = IFLA_VTI_REMOTE
 )
+
+const (
+	IFLA_VRF_UNSPEC = iota
+	IFLA_VRF_TABLE
+)


### PR DESCRIPTION
After Linux 4.3, VRF feature is added to kernel.  With this change we can create VRF interface as same as:

$ sudo ip link add vrf1 type vrf table 1