### PR TITLE
Fix the RouteList() prototype on non-linux platforms

### DIFF
--- a/netlink_unspecified.go
+++ b/netlink_unspecified.go
@@ -163,7 +163,7 @@ func RouteDel(route *Route) error {
 	return ErrNotImplemented
 }
 
-func RouteList(link *Link, family int) ([]Route, error) {
+func RouteList(link Link, family int) ([]Route, error) {
 	return nil, ErrNotImplemented
 }
 


### PR DESCRIPTION
The RouteList() function prototype had become out of sync with its
Linux counterpart.  This patch updates it.