### PR TITLE
fix a bug for net statistics when the whole network flow bytes is beyond 4GB, i.e. uint32

### DIFF
--- a/nl/nl_linux.go
+++ b/nl/nl_linux.go
@@ -363,7 +363,7 @@ func (req *NetlinkRequest) Execute(sockType int, resType uint16) ([][]byte, erro
 	if req.Sockets != nil {
 		if sh, ok := req.Sockets[sockType]; ok {
 			s = sh.Socket
-			req.Seq = atomic.AddUint32(&sh.Seq, 1)
+			req.Seq = atomic.AddUint64(&sh.Seq, 1)
 		}
 	}
 	sharedSocket := s != nil
@@ -438,7 +438,7 @@ func NewNetlinkRequest(proto, flags int) *NetlinkRequest {
 			Len:   uint32(syscall.SizeofNlMsghdr),
 			Type:  uint16(proto),
 			Flags: syscall.NLM_F_REQUEST | uint16(flags),
-			Seq:   atomic.AddUint32(&nextSeqNr, 1),
+			Seq:   atomic.AddUint64(&nextSeqNr, 1),
 		},
 	}
 }
@@ -688,7 +688,7 @@ func netlinkRouteAttrAndValue(b []byte) (*syscall.RtAttr, []byte, int, error) {
 // SocketHandle contains the netlink socket and the associated
 // sequence counter for a specific netlink family
 type SocketHandle struct {
-	Seq    uint32
+	Seq    uint64
 	Socket *NetlinkSocket
 }
 

--- a/nl/xfrm_state_linux_test.go
+++ b/nl/xfrm_state_linux_test.go
@@ -76,7 +76,7 @@ func (msg *XfrmUsersaInfo) write(b []byte) {
 	msg.Lft.write(b[AddressEnd:CfgEnd])
 	msg.Curlft.write(b[CfgEnd:CurEnd])
 	msg.Stats.write(b[CurEnd:StatsEnd])
-	native.PutUint32(b[StatsEnd:StatsEnd+4], msg.Seq)
+	native.PutUint64(b[StatsEnd:StatsEnd+4], msg.Seq)
 	native.PutUint32(b[StatsEnd+4:StatsEnd+8], msg.Reqid)
 	native.PutUint16(b[StatsEnd+8:StatsEnd+10], msg.Family)
 	b[StatsEnd+10] = msg.Mode


### PR DESCRIPTION
when the network flow bytes is growing up beyond 4GB,  i.e. uint32, the network flow bytes will return to count from zero, this is not correct, and some golang program which depends on this package will have a wrong return, like "Docker", you know, the docker command `docker stats` will return a wrong result for network flow monitor.

I hope this can be fix, and reference to Docker community. thx~

Signed-off-by: Xin He <hexin@jiedaibao.com>