### PR TITLE
Provide access to the 64 bits link statistics

### DIFF
--- a/link.go
+++ b/link.go
@@ -32,6 +32,7 @@ type LinkAttrs struct {
 	Namespace    interface{} // nil | NsPid | NsFd
 	Alias        string
 	Statistics   *LinkStatistics
+	Statistics64 *LinkStatistics64
 	Promisc      int
 	Xdp          *LinkXdp
 	EncapType    string
@@ -108,6 +109,34 @@ type LinkStatistics struct {
 	TxCompressed      uint32
 }
 
+/*
+Ref: struct rtnl_link_stats64 {...}
+*/
+type LinkStatistics64 struct {
+	RxPackets         uint64
+	TxPackets         uint64
+	RxBytes           uint64
+	TxBytes           uint64
+	RxErrors          uint64
+	TxErrors          uint64
+	RxDropped         uint64
+	TxDropped         uint64
+	Multicast         uint64
+	Collisions        uint64
+	RxLengthErrors    uint64
+	RxOverErrors      uint64
+	RxCrcErrors       uint64
+	RxFrameErrors     uint64
+	RxFifoErrors      uint64
+	RxMissedErrors    uint64
+	TxAbortedErrors   uint64
+	TxCarrierErrors   uint64
+	TxFifoErrors      uint64
+	TxHeartbeatErrors uint64
+	TxWindowErrors    uint64
+	RxCompressed      uint64
+	TxCompressed      uint64
+}
 type LinkXdp struct {
 	Fd       int
 	Attached bool

--- a/link_test.go
+++ b/link_test.go
@@ -949,11 +949,19 @@ func TestLinkStats(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Check the 32 bits counter stats
 	v0Stats := veth0.Attrs().Statistics
 	v1Stats := veth1.Attrs().Statistics
 	if v0Stats.RxPackets != v1Stats.TxPackets || v0Stats.TxPackets != v1Stats.RxPackets ||
 		v0Stats.RxBytes != v1Stats.TxBytes || v0Stats.TxBytes != v1Stats.RxBytes {
 		t.Fatalf("veth ends counters differ:\n%v\n%v", v0Stats, v1Stats)
+	}
+	// Check the 64 bits counter stats
+	v0Stats64 := veth0.Attrs().Statistics64
+	v1Stats64 := veth1.Attrs().Statistics64
+	if v0Stats64.RxPackets != v1Stats64.TxPackets || v0Stats64.TxPackets != v1Stats64.RxPackets ||
+		v0Stats64.RxBytes != v1Stats64.TxBytes || v0Stats64.TxBytes != v1Stats64.RxBytes {
+		t.Fatalf("veth ends counters differ:\n%v\n%v", v0Stats64, v1Stats64)
 	}
 }
 


### PR DESCRIPTION

This is an example of statistics for my `lo` interface being flooded by ping:

```
Statistics32: &{61691558 61691558 887395372 887395372 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0}
Statistics64: &{61691558 61691558 5182362668 5182362668 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0}
```

Note the byte rx count on the 32 stats has reset: `5182362668 - 2^32 = 887395372`

Signed-off-by: Alessandro Boch <aboch@docker.com>