### PR TITLE
Properly skip tests which require root.

### DIFF
--- a/handle_test.go
+++ b/handle_test.go
@@ -39,6 +39,8 @@ func TestHandleCreateDelete(t *testing.T) {
 }
 
 func TestHandleCreateNetns(t *testing.T) {
+	skipUnlessRoot(t)
+
 	id := make([]byte, 4)
 	if _, err := io.ReadFull(rand.Reader, id); err != nil {
 		t.Fatal(err)
@@ -236,6 +238,7 @@ func parallelDone() {
 
 // Do few route and xfrm operation on the two handles in parallel
 func runParallelTests(t *testing.T, thread int) {
+	skipUnlessRoot(t)
 	defer parallelDone()
 
 	t.Parallel()

--- a/link_test.go
+++ b/link_test.go
@@ -862,6 +862,8 @@ func TestLinkSubscribe(t *testing.T) {
 }
 
 func TestLinkSubscribeAt(t *testing.T) {
+	skipUnlessRoot(t)
+
 	// Create an handle on a custom netns
 	newNs, err := netns.New()
 	if err != nil {

--- a/netlink_test.go
+++ b/netlink_test.go
@@ -11,12 +11,16 @@ import (
 
 type tearDownNetlinkTest func()
 
-func setUpNetlinkTest(t *testing.T) tearDownNetlinkTest {
+func skipUnlessRoot(t *testing.T) {
 	if os.Getuid() != 0 {
 		msg := "Skipped test because it requires root privileges."
 		log.Printf(msg)
 		t.Skip(msg)
 	}
+}
+
+func setUpNetlinkTest(t *testing.T) tearDownNetlinkTest {
+	skipUnlessRoot(t)
 
 	// new temporary namespace so we don't pollute the host
 	// lock thread since the namespace is thread local

--- a/route_test.go
+++ b/route_test.go
@@ -146,6 +146,8 @@ func TestRouteSubscribe(t *testing.T) {
 }
 
 func TestRouteSubscribeAt(t *testing.T) {
+	skipUnlessRoot(t)
+
 	// Create an handle on a custom netns
 	newNs, err := netns.New()
 	if err != nil {

--- a/rule_test.go
+++ b/rule_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestRuleAddDel(t *testing.T) {
+	skipUnlessRoot(t)
+
 	srcNet := &net.IPNet{IP: net.IPv4(172, 16, 0, 1), Mask: net.CIDRMask(16, 32)}
 	dstNet := &net.IPNet{IP: net.IPv4(172, 16, 1, 1), Mask: net.CIDRMask(24, 32)}
 


### PR DESCRIPTION
All these tests currently fail with 'Operation not permitted' when run as
non-root.
With these changes, running tests as non-root passes.
