### PR TITLE
Fix compilation errors for non linux platforms.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ $(call testdirs,$(DIRS)):
 	sudo -E go test -test.parallel 4 -timeout 60s -v github.com/vishvananda/netlink/$@
 
 $(call fmt,$(call testdirs,$(DIRS))):
-	! gofmt -l $(subst fmt-,,$@)/*.go | grep ''
+	! gofmt -l $(subst fmt-,,$@)/*.go | grep -q .
 
 .PHONY: fmt
 fmt: $(call fmt,$(call testdirs,$(DIRS)))

--- a/addr_test.go
+++ b/addr_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package netlink
 
 import (

--- a/class_test.go
+++ b/class_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package netlink
 
 import (

--- a/filter_test.go
+++ b/filter_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package netlink
 
 import (

--- a/handle_test.go
+++ b/handle_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package netlink
 
 import (

--- a/link_test.go
+++ b/link_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package netlink
 
 import (

--- a/neigh_test.go
+++ b/neigh_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package netlink
 
 import (

--- a/nl/nl_unspecified.go
+++ b/nl/nl_unspecified.go
@@ -1,0 +1,11 @@
+// +build !linux
+
+package nl
+
+import "encoding/binary"
+
+var SupportedNlFamilies = []int{}
+
+func NativeEndian() binary.ByteOrder {
+	return nil
+}

--- a/protinfo_test.go
+++ b/protinfo_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package netlink
 
 import "testing"

--- a/qdisc_test.go
+++ b/qdisc_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package netlink
 
 import (

--- a/route_test.go
+++ b/route_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package netlink
 
 import (

--- a/route_unspecified.go
+++ b/route_unspecified.go
@@ -5,3 +5,7 @@ package netlink
 func (r *Route) ListFlags() []string {
 	return []string{}
 }
+
+func (n *NexthopInfo) ListFlags() []string {
+	return []string{}
+}

--- a/rule_test.go
+++ b/rule_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package netlink
 
 import (

--- a/socket_test.go
+++ b/socket_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package netlink
 
 import (

--- a/xfrm_monitor_test.go
+++ b/xfrm_monitor_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package netlink
 
 import (

--- a/xfrm_policy_test.go
+++ b/xfrm_policy_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package netlink
 
 import (

--- a/xfrm_state_test.go
+++ b/xfrm_state_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package netlink
 
 import (


### PR DESCRIPTION
#### Summary
The `go get` command and `make` both fail when executed on
non-linux platforms. Modified it so that there are no
compilation errors when developing in such an
environment.

#### Testing Done
Ensured that tests pass on OS X and that builds are successful on Linux.