### PR TITLE
Mended LinkSetMaster signature mismatch

### DIFF
--- a/netlink_unspecified.go
+++ b/netlink_unspecified.go
@@ -16,7 +16,7 @@ func LinkSetMTU(link Link, mtu int) error {
 	return ErrNotImplemented
 }
 
-func LinkSetMaster(link Link, master *Link) error {
+func LinkSetMaster(link Link, master *Bridge) error {
 	return ErrNotImplemented
 }
 


### PR DESCRIPTION
Signature mismatches when you try and compile on non-Linux machines. Instead of ErrNotImplemented, you get a message about wrongly using *Bridge.