### PR TITLE
Set SOCK_CLOEXEC when creating netlink socket

### DIFF
--- a/nl/nl_linux.go
+++ b/nl/nl_linux.go
@@ -451,7 +451,7 @@ type NetlinkSocket struct {
 }
 
 func getNetlinkSocket(protocol int) (*NetlinkSocket, error) {
-	fd, err := syscall.Socket(syscall.AF_NETLINK, syscall.SOCK_RAW, protocol)
+	fd, err := syscall.Socket(syscall.AF_NETLINK, syscall.SOCK_RAW|syscall.SOCK_CLOEXEC, protocol)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Related to docker/docker/issues/32090

- So that the socket is not shared across execs

Signed-off-by: Alessandro Boch <aboch@docker.com>