### PR TITLE
Add class ID parsing to parseU32Data

### DIFF
--- a/filter_linux.go
+++ b/filter_linux.go
@@ -443,6 +443,8 @@ func parseU32Data(filter Filter, data []syscall.NetlinkRouteAttr) (bool, error) 
 					u32.RedirIndex = int(action.Ifindex)
 				}
 			}
+		case nl.TCA_U32_CLASSID:
+			u32.ClassId = native.Uint32(datum.Value)
 		}
 	}
 	return detailed, nil


### PR DESCRIPTION
This patch adds a new switch case that handles the class ID attribute of
the U32 filter data listed by FilterList. Without this case block the
class ID of the U32 filter is always set to zero. The new test
conditions are added to TestFilterAddDel and TestFilterU32BpfAddDel in
filter_test.go as well.

Signed-off-by: Taku Fukushima <taku@soracom.jp>