### PR TITLE
Ensure bond settings are populated correctly

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -1370,7 +1370,7 @@ func parseVxlanData(link Link, data []syscall.NetlinkRouteAttr) {
 }
 
 func parseBondData(link Link, data []syscall.NetlinkRouteAttr) {
-	bond := NewLinkBond(NewLinkAttrs())
+	bond := link.(*Bond)
 	for i := range data {
 		switch data[i].Attr.Type {
 		case nl.IFLA_BOND_MODE:

--- a/link_test.go
+++ b/link_test.go
@@ -128,6 +128,16 @@ func testLinkAddDel(t *testing.T, link Link) {
 		}
 	}
 
+	if bond, ok := link.(*Bond); ok {
+		other, ok := result.(*Bond)
+		if !ok {
+			t.Fatal("Result of create is not a bond")
+		}
+		if bond.Mode != other.Mode {
+			t.Fatalf("Got unexpected mode: %d, expected: %d", other.Mode, bond.Mode)
+		}
+	}
+
 	if _, ok := link.(*Iptun); ok {
 		_, ok := result.(*Iptun)
 		if !ok {
@@ -335,7 +345,9 @@ func TestLinkAddDelBond(t *testing.T) {
 	tearDown := setUpNetlinkTest(t)
 	defer tearDown()
 
-	testLinkAddDel(t, NewLinkBond(LinkAttrs{Name: "foo"}))
+	bond := NewLinkBond(LinkAttrs{Name: "foo"})
+	bond.Mode = StringToBondModeMap["802.3ad"]
+	testLinkAddDel(t, bond)
 }
 
 func TestLinkAddVethWithDefaultTxQLen(t *testing.T) {


### PR DESCRIPTION
Currently a LinkByName("bondX") doesn't return the bond specific attributes.

parseBondData needs to update the link that is passed in in order for
the bond's Mode, Miimon etc to be populated correctly.