### PR TITLE
Remove unnecessary condition of parsing U32 data

### DIFF
--- a/filter_linux.go
+++ b/filter_linux.go
@@ -458,10 +458,6 @@ func parseU32Data(filter Filter, data []syscall.NetlinkRouteAttr) (bool, error) 
 					key.Val = native.Uint32(htonl(key.Val))
 				}
 			}
-			// only parse if we have a very basic redirect
-			if sel.Flags&nl.TC_U32_TERMINAL == 0 || sel.Nkeys != 1 {
-				return detailed, nil
-			}
 		case nl.TCA_U32_ACT:
 			tables, err := nl.ParseRouteAttr(datum.Value)
 			if err != nil {


### PR DESCRIPTION
This patch removes the unnecessary condition of parsing U32 data that
checks if sel.Flags has nl.TC_U32_TERMINAL or sel.Nkeys is not 1.
Because of the modification to U32 that enalbed to specify multiple sel
keys, this condition is not valid anymore. This condition stops the
parsing of U32 fliter data with multiple attributes and this prevents
the users from getting all the necessary attributes, e.g., the class Id
of the filter.

Signed-off-by: Taku Fukushima <taku@soracom.jp>