### PR TITLE
Add support for IFLA_XDP_FLAGS

### DIFF
--- a/link.go
+++ b/link.go
@@ -76,6 +76,7 @@ type LinkStatistics struct {
 type LinkXdp struct {
 	Fd       int
 	Attached bool
+	Flags    uint32
 }
 
 // Device links cannot be created via netlink. These links

--- a/link_linux.go
+++ b/link_linux.go
@@ -1511,6 +1511,8 @@ func addXdpAttrs(xdp *LinkXdp, req *nl.NetlinkRequest) {
 	b := make([]byte, 4)
 	native.PutUint32(b, uint32(xdp.Fd))
 	nl.NewRtAttrChild(attrs, nl.IFLA_XDP_FD, b)
+	native.PutUint32(b, xdp.Flags)
+	nl.NewRtAttrChild(attrs, nl.IFLA_XDP_FLAGS, b)
 	req.AddData(attrs)
 }
 
@@ -1526,6 +1528,8 @@ func parseLinkXdp(data []byte) (*LinkXdp, error) {
 			xdp.Fd = int(native.Uint32(attr.Value[0:4]))
 		case nl.IFLA_XDP_ATTACHED:
 			xdp.Attached = attr.Value[0] != 0
+		case nl.IFLA_XDP_FLAGS:
+			xdp.Flags = native.Uint32(attr.Value[0:4])
 		}
 	}
 	return xdp, nil

--- a/nl/link_linux.go
+++ b/nl/link_linux.go
@@ -416,7 +416,8 @@ const (
 	IFLA_XDP_UNSPEC   = iota
 	IFLA_XDP_FD       /* fd of xdp program to attach, or -1 to remove */
 	IFLA_XDP_ATTACHED /* read-only bool indicating if prog is attached */
-	IFLA_XDP_MAX      = IFLA_XDP_ATTACHED
+	IFLA_XDP_FLAGS    /* xdp prog related flags */
+	IFLA_XDP_MAX      = IFLA_XDP_FLAGS
 )
 
 const (


### PR DESCRIPTION
Allow to get/set IFLA_XDP_FLAGS which is part of Linux kernel >= 4.10.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>