### PR TITLE
allow listing all routes tables with a Table:RT_TABLE_UNSPEC filter

### DIFF
--- a/route_linux.go
+++ b/route_linux.go
@@ -401,7 +401,7 @@ func (h *Handle) RouteListFiltered(family int, filter *Route, filterMask uint64)
 		}
 		if filter != nil {
 			switch {
-			case filterMask&RT_FILTER_TABLE != 0 && route.Table != filter.Table:
+			case filterMask&RT_FILTER_TABLE != 0 && filter.Table != syscall.RT_TABLE_UNSPEC && route.Table != filter.Table:
 				continue
 			case filterMask&RT_FILTER_PROTOCOL != 0 && route.Protocol != filter.Protocol:
 				continue


### PR DESCRIPTION
Replicate the behavior of `ip route show table all`, which is the same as `ip route show table 0`

Signed-off-by: Fabio Kung <fabio.kung@gmail.com>