### PR TITLE
add a named error when links are not found

### DIFF
--- a/link.go
+++ b/link.go
@@ -755,3 +755,11 @@ func (gtp *GTP) Type() string {
 // bridge | bond | ipoib | ip6tnl | ipip | sit | vxlan |
 // gre | gretap | ip6gre | ip6gretap | vti | nlmon |
 // bond_slave | ipvlan
+
+// LinkNotFoundError wraps the various not found errors when
+// getting/reading links. This is intended for better error
+// handling by dependent code so that "not found error" can
+// be distinguished from other errors
+type LinkNotFoundError struct {
+	error
+}

--- a/link_linux.go
+++ b/link_linux.go
@@ -903,7 +903,7 @@ func (h *Handle) linkByNameDump(name string) (Link, error) {
 			return link, nil
 		}
 	}
-	return nil, fmt.Errorf("Link %s not found", name)
+	return nil, LinkNotFoundError{fmt.Errorf("Link %s not found", name)}
 }
 
 func (h *Handle) linkByAliasDump(alias string) (Link, error) {
@@ -917,7 +917,7 @@ func (h *Handle) linkByAliasDump(alias string) (Link, error) {
 			return link, nil
 		}
 	}
-	return nil, fmt.Errorf("Link alias %s not found", alias)
+	return nil, LinkNotFoundError{fmt.Errorf("Link alias %s not found", alias)}
 }
 
 // LinkByName finds a link by name and returns a pointer to the object.
@@ -1003,7 +1003,7 @@ func execGetLink(req *nl.NetlinkRequest) (Link, error) {
 	if err != nil {
 		if errno, ok := err.(syscall.Errno); ok {
 			if errno == syscall.ENODEV {
-				return nil, fmt.Errorf("Link not found")
+				return nil, LinkNotFoundError{fmt.Errorf("Link not found")}
 			}
 		}
 		return nil, err
@@ -1011,7 +1011,7 @@ func execGetLink(req *nl.NetlinkRequest) (Link, error) {
 
 	switch {
 	case len(msgs) == 0:
-		return nil, fmt.Errorf("Link not found")
+		return nil, LinkNotFoundError{fmt.Errorf("Link not found")}
 
 	case len(msgs) == 1:
 		return LinkDeserialize(nil, msgs[0])

--- a/link_test.go
+++ b/link_test.go
@@ -1280,3 +1280,27 @@ func TestLinkAddDelGTP(t *testing.T) {
 	gtp := testGTPLink(t)
 	testLinkAddDel(t, gtp)
 }
+
+func TestLinkByNameWhenLinkIsNotFound(t *testing.T) {
+	_, err := LinkByName("iammissing")
+	if err == nil {
+		t.Fatal("Link not expected to found")
+	}
+
+	_, ok := err.(LinkNotFoundError)
+	if !ok {
+		t.Errorf("Error returned expected to of LinkNotFoundError type: %v", err)
+	}
+}
+
+func TestLinkByAliasWhenLinkIsNotFound(t *testing.T) {
+	_, err := LinkByAlias("iammissing")
+	if err == nil {
+		t.Fatal("Link not expected to found")
+	}
+
+	_, ok := err.(LinkNotFoundError)
+	if !ok {
+		t.Errorf("Error returned expected to of LinkNotFoundError type: %v", err)
+	}
+}


### PR DESCRIPTION
A new error type LinkNotFoundError is returned instead
of the default error type to facilitate better error
handling by downstream consumers of this package.

I have added additional tests to cover these changes as well