### PR TITLE
Fix go vet issues in tests

### DIFF
--- a/bridge_linux_test.go
+++ b/bridge_linux_test.go
@@ -38,7 +38,7 @@ func TestBridgeVlan(t *testing.T) {
 				t.Fatal()
 			} else {
 				if !vInfo[0].EngressUntag() || !vInfo[0].PortVID() || vInfo[0].Vid != 1 {
-					t.Fatal("bridge vlan show get wrong return %s", vInfo[0].String())
+					t.Fatalf("bridge vlan show get wrong return %s", vInfo[0].String())
 				}
 			}
 		}

--- a/filter_test.go
+++ b/filter_test.go
@@ -201,7 +201,7 @@ func TestAdvancedFilterAddDel(t *testing.T) {
 	}
 	// Check if the filter is identical before and after FilterAdd.
 	if !reflect.DeepEqual(cFilter, *filter) {
-		t.Fatal("U32 %v and %v are not equal", cFilter, *filter)
+		t.Fatalf("U32 %v and %v are not equal", cFilter, *filter)
 	}
 
 	filters, err := FilterList(link, qdiscHandle)


### PR DESCRIPTION
Fix the following two issues reported by go vet:

  bridge_linux_test.go:41: possible formatting directive in Fatal call
  filter_test.go:204: possible formatting directive in Fatal call

by using Fatalf instead of Fatal when using formatting directives.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>