### PR TITLE
Add support for IFLA_XDP_PROG_ID

### DIFF
--- a/link.go
+++ b/link.go
@@ -171,6 +171,7 @@ type LinkXdp struct {
 	Fd       int
 	Attached bool
 	Flags    uint32
+	ProgId   uint32
 }
 
 // Device links cannot be created via netlink. These links

--- a/link_linux.go
+++ b/link_linux.go
@@ -1668,6 +1668,8 @@ func parseLinkXdp(data []byte) (*LinkXdp, error) {
 			xdp.Attached = attr.Value[0] != 0
 		case nl.IFLA_XDP_FLAGS:
 			xdp.Flags = native.Uint32(attr.Value[0:4])
+		case nl.IFLA_XDP_PROG_ID:
+			xdp.ProgId = native.Uint32(attr.Value[0:4])
 		}
 	}
 	return xdp, nil

--- a/nl/link_linux.go
+++ b/nl/link_linux.go
@@ -424,7 +424,8 @@ const (
 	IFLA_XDP_FD       /* fd of xdp program to attach, or -1 to remove */
 	IFLA_XDP_ATTACHED /* read-only bool indicating if prog is attached */
 	IFLA_XDP_FLAGS    /* xdp prog related flags */
-	IFLA_XDP_MAX      = IFLA_XDP_FLAGS
+	IFLA_XDP_PROG_ID  /* xdp prog id */
+	IFLA_XDP_MAX      = IFLA_XDP_PROG_ID
 )
 
 const (


### PR DESCRIPTION
Allow to get IFLA_XDP_PROG_ID which will be part of Linux kernel 4.13+.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>