### PR TITLE
Corrected library function to have Vf prefix

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -415,7 +415,7 @@ func (h *Handle) LinkSetVfSpoofchk(link Link, vf int, check bool) error {
 
 // LinkSetVfTrust enables/disables trust state on a vf for the link.
 // Equivalent to: `ip link set $link vf $vf trust $state`
-func LinkSetTrust(link Link, vf int, state bool) error {
+func LinkSetVfTrust(link Link, vf int, state bool) error {
 	return pkgHandle.LinkSetVfTrust(link, vf, state)
 }
 


### PR DESCRIPTION
Corrected function signature to have correct name LinkSetVfTrust
instead of LinkSetTrust.
This aligns with code comment and rest of the other VF functions.

Signed-off-by: Parav Pandit <parav@mellanox.com>