### PR TITLE
Add Family to struct Rule so that user can specify address family.

### DIFF
--- a/rule.go
+++ b/rule.go
@@ -8,6 +8,7 @@ import (
 // Rule represents a netlink rule.
 type Rule struct {
 	Priority          int
+	Family            int
 	Table             int
 	Mark              int
 	Mask              int

--- a/rule_linux.go
+++ b/rule_linux.go
@@ -37,6 +37,9 @@ func (h *Handle) RuleDel(rule *Rule) error {
 func ruleHandle(rule *Rule, req *nl.NetlinkRequest) error {
 	msg := nl.NewRtMsg()
 	msg.Family = syscall.AF_INET
+	if rule.Family != 0 {
+		msg.Family = uint8(rule.Family)
+	}
 	var dstFamily uint8
 
 	var rtAttrs []*nl.RtAttr


### PR DESCRIPTION
With this change, user can specify address family which the rule to be installed.