### PR TITLE
Replace redundant copied u32 types with type aliases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: go
+go:
+  - 1.9
 before_script:
   # make sure we keep path in tact when we sudo
   - sudo sed -i -e 's/^Defaults\tsecure_path.*$//' /etc/sudoers

--- a/filter.go
+++ b/filter.go
@@ -192,31 +192,15 @@ const (
 	TC_U32_EAT       = nl.TC_U32_EAT
 )
 
-// Sel of the U32 filters that contains multiple TcU32Key. This is the copy
-// and the frontend representation of nl.TcU32Sel. It is serialized into canonical
-// nl.TcU32Sel with the appropriate endianness.
-type TcU32Sel struct {
-	Flags    uint8
-	Offshift uint8
-	Nkeys    uint8
-	Pad      uint8
-	Offmask  uint16
-	Off      uint16
-	Offoff   int16
-	Hoff     int16
-	Hmask    uint32
-	Keys     []TcU32Key
-}
+// Sel of the U32 filters that contains multiple TcU32Key. This is the type
+// alias and the frontend representation of nl.TcU32Sel. It is serialized into
+// canonical nl.TcU32Sel with the appropriate endianness.
+type TcU32Sel = nl.TcU32Sel
 
-// TcU32Key contained of Sel in the U32 filters. This is the copy and the frontend
-// representation of nl.TcU32Key. It is serialized into chanonical nl.TcU32Sel
-// with the appropriate endianness.
-type TcU32Key struct {
-	Mask    uint32
-	Val     uint32
-	Off     int32
-	OffMask int32
-}
+// TcU32Key contained of Sel in the U32 filters. This is the type alias and the
+// frontend representation of nl.TcU32Key. It is serialized into chanonical
+// nl.TcU32Sel with the appropriate endianness.
+type TcU32Key = nl.TcU32Key
 
 // U32 filters on many packet related properties
 type U32 struct {

--- a/filter_linux.go
+++ b/filter_linux.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"syscall"
-	"unsafe"
 
 	"github.com/vishvananda/netlink/nl"
 )
@@ -129,8 +128,7 @@ func (h *Handle) FilterAdd(filter Filter) error {
 
 	options := nl.NewRtAttr(nl.TCA_OPTIONS, nil)
 	if u32, ok := filter.(*U32); ok {
-		// Convert TcU32Sel into nl.TcU32Sel as it is without copy.
-		sel := (*nl.TcU32Sel)(unsafe.Pointer(u32.Sel))
+		sel := u32.Sel
 		if sel == nil {
 			// match all
 			sel = &nl.TcU32Sel{
@@ -448,7 +446,7 @@ func parseU32Data(filter Filter, data []syscall.NetlinkRouteAttr) (bool, error) 
 		case nl.TCA_U32_SEL:
 			detailed = true
 			sel := nl.DeserializeTcU32Sel(datum.Value)
-			u32.Sel = (*TcU32Sel)(unsafe.Pointer(sel))
+			u32.Sel = sel
 			if native != networkOrder {
 				// Handle the endianness of attributes
 				u32.Sel.Offmask = native.Uint16(htons(sel.Offmask))


### PR DESCRIPTION
This patch replaces TcU32Sel and TcU32Key that are copied from nl
package with type aliases for the original types. This eliminates the
usages of unsafe packages and redundant copied structs that are
identical to the original ones.

Type aliases are newly introduced in Go 1.9 and it is not backward
compatibile. Therefore this patch shall be merged only if the project is
entirely migrated to Go 1.9.

See #206.

Signed-off-by: Taku Fukushima <taku@soracom.jp>