### PR TITLE
route: fix display of nexthop gateway for multipath routes

### DIFF
--- a/route.go
+++ b/route.go
@@ -110,7 +110,7 @@ func (n *NexthopInfo) String() string {
 		elems = append(elems, fmt.Sprintf("Encap: %s", n.Encap))
 	}
 	elems = append(elems, fmt.Sprintf("Weight: %d", n.Hops+1))
-	elems = append(elems, fmt.Sprintf("Gw: %d", n.Gw))
+	elems = append(elems, fmt.Sprintf("Gw: %s", n.Gw))
 	elems = append(elems, fmt.Sprintf("Flags: %s", n.ListFlags()))
 	return fmt.Sprintf("{%s}", strings.Join(elems, " "))
 }


### PR DESCRIPTION
This is a `net.IP` and therefore, we should use `%s`. Using `%d` gives
something like this:

    Gw: [0 0 0 0 0 0 0 0 0 0 255 255 192 168 24 2]

After this fix, we get:

    Gw: 192.168.24.2