### PR TITLE
addr: don't log errors happening when receiving notifications

### DIFF
--- a/addr_linux.go
+++ b/addr_linux.go
@@ -2,7 +2,6 @@ package netlink
 
 import (
 	"fmt"
-	"log"
 	"net"
 	"strings"
 	"syscall"
@@ -262,19 +261,16 @@ func addrSubscribe(newNs, curNs netns.NsHandle, ch chan<- AddrUpdate, done <-cha
 		for {
 			msgs, err := s.Receive()
 			if err != nil {
-				log.Printf("netlink.AddrSubscribe: Receive() error: %v", err)
 				return
 			}
 			for _, m := range msgs {
 				msgType := m.Header.Type
 				if msgType != syscall.RTM_NEWADDR && msgType != syscall.RTM_DELADDR {
-					log.Printf("netlink.AddrSubscribe: bad message type: %d", msgType)
 					continue
 				}
 
 				addr, _, ifindex, err := parseAddr(m.Data)
 				if err != nil {
-					log.Printf("netlink.AddrSubscribe: could not parse address: %v", err)
 					continue
 				}
 


### PR DESCRIPTION
A user may have its own log handling. Another solution would be to
make this configurable by allowing a user to provide a logger. A
better solution would be to transmit the errors to some handler to let
the package user knows about them (notably the nature of the receive
error).

This is not done here since this is the only use of `log.Printf`. For
example, when listening for routes, errors are not displayed.