### PR TITLE
handle: get/set receive buffer size

### DIFF
--- a/handle_linux.go
+++ b/handle_linux.go
@@ -61,10 +61,14 @@ func (h *Handle) SetSocketTimeout(to time.Duration) error {
 // SetSocketReceiveBufferSize sets the receive buffer size for each
 // socket in the netlink handle. The maximum value is capped by
 // /proc/sys/net/core/rmem_max.
-func (h *Handle) SetSocketReceiveBufferSize(size int) error {
+func (h *Handle) SetSocketReceiveBufferSize(size int, force bool) error {
+	opt := syscall.SO_RCVBUF
+	if force {
+		opt = syscall.SO_RCVBUFFORCE
+	}
 	for _, sh := range h.sockets {
 		fd := sh.Socket.GetFd()
-		err := syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_RCVBUF, size)
+		err := syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, opt, size)
 		if err != nil {
 			return err
 		}

--- a/handle_test.go
+++ b/handle_test.go
@@ -138,7 +138,7 @@ func TestHandleReceiveBuffer(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer h.Delete()
-	if err := h.SetSocketReceiveBufferSize(65536); err != nil {
+	if err := h.SetSocketReceiveBufferSize(65536, false); err != nil {
 		t.Fatal(err)
 	}
 	sizes, err := h.GetSocketReceiveBufferSize()

--- a/handle_test.go
+++ b/handle_test.go
@@ -132,6 +132,31 @@ func TestHandleTimeout(t *testing.T) {
 	}
 }
 
+func TestHandleReceiveBuffer(t *testing.T) {
+	h, err := NewHandle()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer h.Delete()
+	if err := h.SetSocketReceiveBufferSize(65536); err != nil {
+		t.Fatal(err)
+	}
+	sizes, err := h.GetSocketReceiveBufferSize()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sizes) != len(h.sockets) {
+		t.Fatalf("Unexpected number of socket buffer sizes: %d (expected %d)",
+			len(sizes), len(h.sockets))
+	}
+	for _, s := range sizes {
+		if s < 65536 || s > 2*65536 {
+			t.Fatalf("Unexpected socket receive buffer size: %d (expected around %d)",
+				s, 65536)
+		}
+	}
+}
+
 func verifySockTimeVal(t *testing.T, fd int, tv syscall.Timeval) {
 	var (
 		tr syscall.Timeval


### PR DESCRIPTION
When receiving a lot of route changes (10,000 routes are enough), the
default receive buffer size (value of
`/proc/sys/net/core/rmem_default`) is too small and we get a `ENOBUF`
error. A user may want to increase the buffer size up to the value of
`/proc/sys/net/core/rmem_max` (by default, this is the same value). A
`SetSocketReceiveBufferSize()` function is provided to this
destination.

Possible improvements:

 1. automatically increase receive buffer size in higher level
    functions until we hit a maximum (get an error and/or the current
    value is smaller than expected)

 2. accept a "force" argument to use `SO_RCVBUFFORCE` to increase the
    value over `rmem_max` value