### PR TITLE
route: add `Equal()` method to compare routes

### DIFF
--- a/route.go
+++ b/route.go
@@ -114,3 +114,16 @@ func (n *NexthopInfo) String() string {
 	elems = append(elems, fmt.Sprintf("Flags: %s", n.ListFlags()))
 	return fmt.Sprintf("{%s}", strings.Join(elems, " "))
 }
+
+// ipNetEqual returns true iff both IPNet are equal
+func ipNetEqual(ipn1 *net.IPNet, ipn2 *net.IPNet) bool {
+	if ipn1 == ipn2 {
+		return true
+	}
+	if ipn1 == nil || ipn2 == nil {
+		return false
+	}
+	m1, _ := ipn1.Mask.Size()
+	m2, _ := ipn2.Mask.Size()
+	return m1 == m2 && ipn1.IP.Equal(ipn2.IP)
+}

--- a/route.go
+++ b/route.go
@@ -16,6 +16,7 @@ type Destination interface {
 	Decode([]byte) error
 	Encode() ([]byte, error)
 	String() string
+	Equal(Destination) bool
 }
 
 type Encap interface {
@@ -23,6 +24,7 @@ type Encap interface {
 	Decode([]byte) error
 	Encode() ([]byte, error)
 	String() string
+	Equal(Encap) bool
 }
 
 // Route represents a netlink route.
@@ -72,6 +74,25 @@ func (r Route) String() string {
 	return fmt.Sprintf("{%s}", strings.Join(elems, " "))
 }
 
+func (r Route) Equal(x Route) bool {
+	return r.LinkIndex == x.LinkIndex &&
+		r.ILinkIndex == x.ILinkIndex &&
+		r.Scope == x.Scope &&
+		ipNetEqual(r.Dst, x.Dst) &&
+		r.Src.Equal(x.Src) &&
+		r.Gw.Equal(x.Gw) &&
+		nexthopInfoSlice(r.MultiPath).Equal(x.MultiPath) &&
+		r.Protocol == x.Protocol &&
+		r.Priority == x.Priority &&
+		r.Table == x.Table &&
+		r.Type == x.Type &&
+		r.Tos == x.Tos &&
+		r.Flags == x.Flags &&
+		(r.MPLSDst == x.MPLSDst || (r.MPLSDst != nil && x.MPLSDst != nil && *r.MPLSDst == *x.MPLSDst)) &&
+		(r.NewDst == x.NewDst || (r.NewDst != nil && r.NewDst.Equal(x.NewDst))) &&
+		(r.Encap == x.Encap || (r.Encap != nil && r.Encap.Equal(x.Encap)))
+}
+
 func (r *Route) SetFlag(flag NextHopFlag) {
 	r.Flags |= int(flag)
 }
@@ -113,6 +134,32 @@ func (n *NexthopInfo) String() string {
 	elems = append(elems, fmt.Sprintf("Gw: %d", n.Gw))
 	elems = append(elems, fmt.Sprintf("Flags: %s", n.ListFlags()))
 	return fmt.Sprintf("{%s}", strings.Join(elems, " "))
+}
+
+func (n NexthopInfo) Equal(x NexthopInfo) bool {
+	return n.LinkIndex == x.LinkIndex &&
+		n.Hops == x.Hops &&
+		n.Gw.Equal(x.Gw) &&
+		n.Flags == x.Flags &&
+		(n.NewDst == x.NewDst || (n.NewDst != nil && n.NewDst.Equal(x.NewDst))) &&
+		(n.Encap == x.Encap || (n.Encap != nil && n.Encap.Equal(x.Encap)))
+}
+
+type nexthopInfoSlice []*NexthopInfo
+
+func (n nexthopInfoSlice) Equal(x []*NexthopInfo) bool {
+	if len(n) != len(x) {
+		return false
+	}
+	for i := range n {
+		if n[i] == nil || x[i] == nil {
+			return false
+		}
+		if !n[i].Equal(*x[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 // ipNetEqual returns true iff both IPNet are equal

--- a/route_linux.go
+++ b/route_linux.go
@@ -421,19 +421,8 @@ func (h *Handle) RouteListFiltered(family int, filter *Route, filterMask uint64)
 				continue
 			case filterMask&RT_FILTER_DST != 0:
 				if filter.MPLSDst == nil || route.MPLSDst == nil || (*filter.MPLSDst) != (*route.MPLSDst) {
-					if filter.Dst == nil {
-						if route.Dst != nil {
-							continue
-						}
-					} else {
-						if route.Dst == nil {
-							continue
-						}
-						aMaskLen, aMaskBits := route.Dst.Mask.Size()
-						bMaskLen, bMaskBits := filter.Dst.Mask.Size()
-						if !(route.Dst.IP.Equal(filter.Dst.IP) && aMaskLen == bMaskLen && aMaskBits == bMaskBits) {
-							continue
-						}
+					if !ipNetEqual(route.Dst, filter.Dst) {
+						continue
 					}
 				}
 			}

--- a/route_linux.go
+++ b/route_linux.go
@@ -86,6 +86,34 @@ func (d *MPLSDestination) String() string {
 	return strings.Join(s, "/")
 }
 
+func (d *MPLSDestination) Equal(x Destination) bool {
+	o, ok := x.(*MPLSDestination)
+	if !ok {
+		return false
+	}
+	if d == nil && o == nil {
+		return true
+	}
+	if d == nil || o == nil {
+		return false
+	}
+	if d.Labels == nil && o.Labels == nil {
+		return true
+	}
+	if d.Labels == nil || o.Labels == nil {
+		return false
+	}
+	if len(d.Labels) != len(o.Labels) {
+		return false
+	}
+	for i := range d.Labels {
+		if d.Labels[i] != o.Labels[i] {
+			return false
+		}
+	}
+	return true
+}
+
 type MPLSEncap struct {
 	Labels []int
 }
@@ -127,6 +155,34 @@ func (e *MPLSEncap) String() string {
 		s = append(s, fmt.Sprintf("%d", l))
 	}
 	return strings.Join(s, "/")
+}
+
+func (e *MPLSEncap) Equal(x Encap) bool {
+	o, ok := x.(*MPLSEncap)
+	if !ok {
+		return false
+	}
+	if e == nil && o == nil {
+		return true
+	}
+	if e == nil || o == nil {
+		return false
+	}
+	if e.Labels == nil && o.Labels == nil {
+		return true
+	}
+	if e.Labels == nil || o.Labels == nil {
+		return false
+	}
+	if len(e.Labels) != len(o.Labels) {
+		return false
+	}
+	for i := range e.Labels {
+		if e.Labels[i] != o.Labels[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // RouteAdd will add a route to the system.

--- a/route_test.go
+++ b/route_test.go
@@ -4,6 +4,7 @@ package netlink
 
 import (
 	"net"
+	"strconv"
 	"syscall"
 	"testing"
 	"time"
@@ -577,4 +578,47 @@ func TestMPLSRouteAddDel(t *testing.T) {
 		t.Fatal("Route not removed properly")
 	}
 
+}
+
+func TestIPNetEqual(t *testing.T) {
+	cases := []string{
+		"1.1.1.1/24", "1.1.1.0/24", "1.1.1.1/32",
+		"0.0.0.0/0", "0.0.0.0/14",
+		"2001:db8::/32", "2001:db8::/128",
+		"2001:db8::caff/32", "2001:db8::caff/128",
+		"",
+	}
+	for _, c1 := range cases {
+		var n1 *net.IPNet
+		if c1 != "" {
+			var i1 net.IP
+			var err1 error
+			i1, n1, err1 = net.ParseCIDR(c1)
+			if err1 != nil {
+				panic(err1)
+			}
+			n1.IP = i1
+		}
+		for _, c2 := range cases {
+			var n2 *net.IPNet
+			if c2 != "" {
+				var i2 net.IP
+				var err2 error
+				i2, n2, err2 = net.ParseCIDR(c2)
+				if err2 != nil {
+					panic(err2)
+				}
+				n2.IP = i2
+			}
+
+			got := ipNetEqual(n1, n2)
+			expected := c1 == c2
+			if got != expected {
+				t.Errorf("IPNetEqual(%q,%q) == %s but expected %s",
+					c1, c2,
+					strconv.FormatBool(got),
+					strconv.FormatBool(expected))
+			}
+		}
+	}
 }

--- a/route_test.go
+++ b/route_test.go
@@ -580,6 +580,149 @@ func TestMPLSRouteAddDel(t *testing.T) {
 
 }
 
+func TestRouteEqual(t *testing.T) {
+	mplsDst := 100
+	cases := []Route{
+		Route{
+			Dst: nil,
+			Gw:  net.IPv4(1, 1, 1, 1),
+		},
+		Route{
+			LinkIndex: 20,
+			Dst:       nil,
+			Gw:        net.IPv4(1, 1, 1, 1),
+		},
+		Route{
+			ILinkIndex: 21,
+			LinkIndex:  20,
+			Dst:        nil,
+			Gw:         net.IPv4(1, 1, 1, 1),
+		},
+		Route{
+			LinkIndex: 20,
+			Dst:       nil,
+			Protocol:  20,
+			Gw:        net.IPv4(1, 1, 1, 1),
+		},
+		Route{
+			LinkIndex: 20,
+			Dst:       nil,
+			Priority:  20,
+			Gw:        net.IPv4(1, 1, 1, 1),
+		},
+		Route{
+			LinkIndex: 20,
+			Dst:       nil,
+			Type:      20,
+			Gw:        net.IPv4(1, 1, 1, 1),
+		},
+		Route{
+			LinkIndex: 20,
+			Dst:       nil,
+			Table:     200,
+			Gw:        net.IPv4(1, 1, 1, 1),
+		},
+		Route{
+			LinkIndex: 20,
+			Dst:       nil,
+			Tos:       1,
+			Gw:        net.IPv4(1, 1, 1, 1),
+		},
+		Route{
+			LinkIndex: 20,
+			Dst:       nil,
+			Flags:     int(FLAG_ONLINK),
+			Gw:        net.IPv4(1, 1, 1, 1),
+		},
+		Route{
+			LinkIndex: 10,
+			Dst: &net.IPNet{
+				IP:   net.IPv4(192, 168, 0, 0),
+				Mask: net.CIDRMask(24, 32),
+			},
+			Src: net.IPv4(127, 1, 1, 1),
+		},
+		Route{
+			LinkIndex: 10,
+			Scope:     syscall.RT_SCOPE_LINK,
+			Dst: &net.IPNet{
+				IP:   net.IPv4(192, 168, 0, 0),
+				Mask: net.CIDRMask(24, 32),
+			},
+			Src: net.IPv4(127, 1, 1, 1),
+		},
+		Route{
+			LinkIndex: 3,
+			Dst: &net.IPNet{
+				IP:   net.IPv4(1, 1, 1, 1),
+				Mask: net.CIDRMask(32, 32),
+			},
+			Src:      net.IPv4(127, 3, 3, 3),
+			Scope:    syscall.RT_SCOPE_LINK,
+			Priority: 13,
+			Table:    syscall.RT_TABLE_MAIN,
+			Type:     syscall.RTN_UNICAST,
+			Tos:      14,
+		},
+		Route{
+			LinkIndex: 10,
+			MPLSDst:   &mplsDst,
+			NewDst: &MPLSDestination{
+				Labels: []int{200, 300},
+			},
+		},
+		Route{
+			Dst: nil,
+			Gw:  net.IPv4(1, 1, 1, 1),
+			Encap: &MPLSEncap{
+				Labels: []int{100},
+			},
+		},
+		Route{
+			Dst:       nil,
+			MultiPath: []*NexthopInfo{&NexthopInfo{LinkIndex: 10}, &NexthopInfo{LinkIndex: 20}},
+		},
+		Route{
+			Dst: nil,
+			MultiPath: []*NexthopInfo{&NexthopInfo{
+				LinkIndex: 10,
+				Gw:        net.IPv4(1, 1, 1, 1),
+			}, &NexthopInfo{LinkIndex: 20}},
+		},
+		Route{
+			Dst: nil,
+			MultiPath: []*NexthopInfo{&NexthopInfo{
+				LinkIndex: 10,
+				Gw:        net.IPv4(1, 1, 1, 1),
+				Encap: &MPLSEncap{
+					Labels: []int{100},
+				},
+			}, &NexthopInfo{LinkIndex: 20}},
+		},
+		Route{
+			Dst: nil,
+			MultiPath: []*NexthopInfo{&NexthopInfo{
+				LinkIndex: 10,
+				NewDst: &MPLSDestination{
+					Labels: []int{200, 300},
+				},
+			}, &NexthopInfo{LinkIndex: 20}},
+		},
+	}
+	for i1 := range cases {
+		for i2 := range cases {
+			got := cases[i1].Equal(cases[i2])
+			expected := i1 == i2
+			if got != expected {
+				t.Errorf("Equal(%q,%q) == %s but expected %s",
+					cases[i1], cases[i2],
+					strconv.FormatBool(got),
+					strconv.FormatBool(expected))
+			}
+		}
+	}
+}
+
 func TestIPNetEqual(t *testing.T) {
 	cases := []string{
 		"1.1.1.1/24", "1.1.1.0/24", "1.1.1.1/32",


### PR DESCRIPTION
The equality is quite strict: absolutely everything must match.