### PR TITLE
Move consts to Linux-specific file

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -2,8 +2,6 @@ package netlink
 
 import (
 	"fmt"
-
-	"github.com/vishvananda/netlink/nl"
 )
 
 type Filter interface {
@@ -183,14 +181,6 @@ func NewMirredAction(redirIndex int) *MirredAction {
 		Ifindex:      redirIndex,
 	}
 }
-
-// Constants used in TcU32Sel.Flags.
-const (
-	TC_U32_TERMINAL  = nl.TC_U32_TERMINAL
-	TC_U32_OFFSET    = nl.TC_U32_OFFSET
-	TC_U32_VAROFFSET = nl.TC_U32_VAROFFSET
-	TC_U32_EAT       = nl.TC_U32_EAT
-)
 
 // Sel of the U32 filters that contains multiple TcU32Key. This is the copy
 // and the frontend representation of nl.TcU32Sel. It is serialized into canonical

--- a/filter_linux.go
+++ b/filter_linux.go
@@ -11,6 +11,14 @@ import (
 	"github.com/vishvananda/netlink/nl"
 )
 
+// Constants used in TcU32Sel.Flags.
+const (
+	TC_U32_TERMINAL  = nl.TC_U32_TERMINAL
+	TC_U32_OFFSET    = nl.TC_U32_OFFSET
+	TC_U32_VAROFFSET = nl.TC_U32_VAROFFSET
+	TC_U32_EAT       = nl.TC_U32_EAT
+)
+
 // Fw filter filters on firewall marks
 // NOTE: this is in filter_linux because it refers to nl.TcPolice which
 //       is defined in nl/tc_linux.go


### PR DESCRIPTION
 Fixes #243 

## What
Simple movement of some constant declarations into a `_linux.go` file in the same package to enable building on macOS.

## Why
I need a project that uses this lib as a dependency to be able to *build* on macOS even though that OS family obviously isn't going to have the same API.