### PR TITLE
Add Coveralls to monitor test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,12 @@ before_script:
   - sudo modprobe nf_conntrack_netlink
   - sudo modprobe nf_conntrack_ipv4
   - sudo modprobe nf_conntrack_ipv6
+before_install:
+  - mkdir -p $GOPATH/src/github.com/vishvananda
+  # Symlink to allow builds of pull requests
+  - ln -s $TRAVIS_BUILD_DIR $HOME/gopath/src/github.com/vishvananda/ || true
 install:
   - go get github.com/vishvananda/netns
+  - go get github.com/mattn/goveralls
+script:
+  - sudo goveralls -v

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # netlink - netlink library for go #
 
-[![Build Status](https://travis-ci.org/vishvananda/netlink.png?branch=master)](https://travis-ci.org/vishvananda/netlink) [![GoDoc](https://godoc.org/github.com/vishvananda/netlink?status.svg)](https://godoc.org/github.com/vishvananda/netlink)
+[![Build Status](https://travis-ci.org/vishvananda/netlink.png?branch=master)](https://travis-ci.org/vishvananda/netlink)
+[![Coverage Status](https://coveralls.io/repos/vishvananda/netlink/badge.svg?branch=master&service=github)](https://coveralls.io/github/vishvananda/netlink?branch=master)
+[![GoDoc](https://godoc.org/github.com/vishvananda/netlink?status.svg)](https://godoc.org/github.com/vishvananda/netlink)
 
 The netlink package provides a simple netlink library for go. Netlink
 is the interface a user-space program in linux uses to communicate with


### PR DESCRIPTION
You have to enable your repository at [Coveralls](https://coveralls.io/).
Example of the result: https://coveralls.io/github/digineo/netlink