### PR TITLE
Adding test to verify that close netlink unblock receive

### DIFF
--- a/handle_linux.go
+++ b/handle_linux.go
@@ -45,13 +45,10 @@ func (h *Handle) SetSocketTimeout(to time.Duration) error {
 	}
 	tv := syscall.NsecToTimeval(to.Nanoseconds())
 	for _, sh := range h.sockets {
-		fd := sh.Socket.GetFd()
-		err := syscall.SetsockoptTimeval(fd, syscall.SOL_SOCKET, syscall.SO_RCVTIMEO, &tv)
-		if err != nil {
+		if err := sh.Socket.SetSendTimeout(&tv); err != nil {
 			return err
 		}
-		err = syscall.SetsockoptTimeval(fd, syscall.SOL_SOCKET, syscall.SO_SNDTIMEO, &tv)
-		if err != nil {
+		if err := sh.Socket.SetReceiveTimeout(&tv); err != nil {
 			return err
 		}
 	}

--- a/nl/nl_linux.go
+++ b/nl/nl_linux.go
@@ -621,6 +621,20 @@ func (s *NetlinkSocket) Receive() ([]syscall.NetlinkMessage, error) {
 	return syscall.ParseNetlinkMessage(rb)
 }
 
+// SetSendTimeout allows to set a send timeout on the socket
+func (s *NetlinkSocket) SetSendTimeout(timeout *syscall.Timeval) error {
+	// Set a send timeout of SOCKET_SEND_TIMEOUT, this will allow the Send to periodically unblock and avoid that a routine
+	// remains stuck on a send on a closed fd
+	return syscall.SetsockoptTimeval(int(s.fd), syscall.SOL_SOCKET, syscall.SO_SNDTIMEO, timeout)
+}
+
+// SetReceiveTimeout allows to set a receive timeout on the socket
+func (s *NetlinkSocket) SetReceiveTimeout(timeout *syscall.Timeval) error {
+	// Set a read timeout of SOCKET_READ_TIMEOUT, this will allow the Read to periodically unblock and avoid that a routine
+	// remains stuck on a recvmsg on a closed fd
+	return syscall.SetsockoptTimeval(int(s.fd), syscall.SOL_SOCKET, syscall.SO_RCVTIMEO, timeout)
+}
+
 func (s *NetlinkSocket) GetPid() (uint32, error) {
 	fd := int(atomic.LoadInt32(&s.fd))
 	lsa, err := syscall.Getsockname(fd)


### PR DESCRIPTION
Looks like netlink sockets once closed are not waking up the go routines that are waiting on the recv.
This can create easily go routine leaks if there is a go routine that is listening for events and another thread just closes the socket.
At the moment I intentionally added the timeout only on the netlink socket created by the Subscribe method but maybe we can extend the same behavior also to the other netlink socket creation.

Signed-off-by: Flavio Crisciani <flavio.crisciani@docker.com>