### PR TITLE
Allow index specification at link creation time

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -851,6 +851,10 @@ func (h *Handle) linkModify(link Link, flags int) error {
 		msg.Change |= syscall.IFF_MULTICAST
 		msg.Flags |= syscall.IFF_MULTICAST
 	}
+	if base.Index != 0 {
+		msg.Index = int32(base.Index)
+	}
+
 	req.AddData(msg)
 
 	if base.ParentIndex != 0 {

--- a/link_test.go
+++ b/link_test.go
@@ -38,6 +38,12 @@ func testLinkAddDel(t *testing.T, link Link) {
 
 	rBase := result.Attrs()
 
+	if base.Index != 0 {
+		if base.Index != rBase.Index {
+			t.Fatalf("index is %d, should be %d", rBase.Index, base.Index)
+		}
+	}
+
 	if vlan, ok := link.(*Vlan); ok {
 		other, ok := result.(*Vlan)
 		if !ok {
@@ -258,6 +264,13 @@ func compareVxlan(t *testing.T, expected, actual *Vxlan) {
 			t.Fatal("Vxlan.PortHigh doesn't match")
 		}
 	}
+}
+
+func TestLinkAddDelWithIndex(t *testing.T) {
+	tearDown := setUpNetlinkTest(t)
+	defer tearDown()
+
+	testLinkAddDel(t, &Dummy{LinkAttrs{Index: 1000, Name: "foo"}})
 }
 
 func TestLinkAddDelDummy(t *testing.T) {


### PR DESCRIPTION
Allow the caller to specify the desired link index at link creation.

This is equivalent to
ip link add link eth0 name testmacvtap index 1000 type macvtap
ip link add dummy1 index 1001 type dummy

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>