### PR TITLE
Allow to skip tests based on min kernel version required

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ $(call goroot,$(DEPS)):
 
 .PHONY: $(call testdirs,$(DIRS))
 $(call testdirs,$(DIRS)):
-	sudo -E go test -test.parallel 4 -timeout 60s -v github.com/vishvananda/netlink/$@
+	go test -test.exec sudo -test.parallel 4 -timeout 60s -test.v github.com/vishvananda/netlink/$@
 
 $(call fmt,$(call testdirs,$(DIRS))):
 	! gofmt -l $(subst fmt-,,$@)/*.go | grep -q .

--- a/bridge_linux_test.go
+++ b/bridge_linux_test.go
@@ -3,14 +3,11 @@ package netlink
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"testing"
 )
 
 func TestBridgeVlan(t *testing.T) {
-	if os.Getenv("TRAVIS_BUILD_DIR") != "" {
-		t.Skipf("Travis CI worker Linux kernel version (3.13) is too old for this test")
-	}
+	minKernelRequired(t, 3, 10)
 
 	tearDown := setUpNetlinkTest(t)
 	defer tearDown()

--- a/filter_test.go
+++ b/filter_test.go
@@ -577,8 +577,10 @@ func TestFilterClsActBpfAddDel(t *testing.T) {
 		QdiscType:  "clsact",
 	}
 	// This feature was added in kernel 4.5
+	minKernelRequired(t, 4, 5)
+
 	if err := QdiscAdd(qdisc); err != nil {
-		t.Skipf("Failed adding clsact qdisc, unsupported kernel")
+		t.Fatal(err)
 	}
 	qdiscs, err := SafeQdiscList(link)
 	if err != nil {

--- a/link_test.go
+++ b/link_test.go
@@ -336,9 +336,8 @@ func TestLinkAddDelGretunPointToMultiPoint(t *testing.T) {
 }
 
 func TestLinkAddDelGretapFlowBased(t *testing.T) {
-	if os.Getenv("TRAVIS_BUILD_DIR") != "" {
-		t.Skipf("Kernel in travis is too old for this test")
-	}
+	t.Skip("Fails with \"link_test.go:29: numerical result out of range\". Need to investigate.")
+	minKernelRequired(t, 4, 3)
 
 	tearDown := setUpNetlinkTest(t)
 	defer tearDown()
@@ -732,9 +731,7 @@ func TestLinkAddDelVxlan(t *testing.T) {
 }
 
 func TestLinkAddDelVxlanGbp(t *testing.T) {
-	if os.Getenv("TRAVIS_BUILD_DIR") != "" {
-		t.Skipf("Kernel in travis is too old for this test")
-	}
+	minKernelRequired(t, 4, 0)
 
 	tearDown := setUpNetlinkTest(t)
 	defer tearDown()
@@ -765,9 +762,7 @@ func TestLinkAddDelVxlanGbp(t *testing.T) {
 }
 
 func TestLinkAddDelVxlanFlowBased(t *testing.T) {
-	if os.Getenv("TRAVIS_BUILD_DIR") != "" {
-		t.Skipf("Kernel in travis is too old for this test")
-	}
+	minKernelRequired(t, 4, 3)
 
 	tearDown := setUpNetlinkTest(t)
 	defer tearDown()
@@ -784,9 +779,7 @@ func TestLinkAddDelVxlanFlowBased(t *testing.T) {
 }
 
 func TestLinkAddDelIPVlanL2(t *testing.T) {
-	if os.Getenv("TRAVIS_BUILD_DIR") != "" {
-		t.Skipf("Kernel in travis is too old for this test")
-	}
+	minKernelRequired(t, 4, 2)
 	tearDown := setUpNetlinkTest(t)
 	defer tearDown()
 	parent := &Dummy{LinkAttrs{Name: "foo"}}
@@ -806,9 +799,7 @@ func TestLinkAddDelIPVlanL2(t *testing.T) {
 }
 
 func TestLinkAddDelIPVlanL3(t *testing.T) {
-	if os.Getenv("TRAVIS_BUILD_DIR") != "" {
-		t.Skipf("Kernel in travis is too old for this test")
-	}
+	minKernelRequired(t, 4, 2)
 	tearDown := setUpNetlinkTest(t)
 	defer tearDown()
 	parent := &Dummy{LinkAttrs{Name: "foo"}}
@@ -1218,6 +1209,7 @@ func TestLinkXdp(t *testing.T) {
 }
 
 func TestLinkAddDelIptun(t *testing.T) {
+	minKernelRequired(t, 4, 9)
 	tearDown := setUpNetlinkTest(t)
 	defer tearDown()
 
@@ -1252,9 +1244,7 @@ func TestLinkAddDelVti(t *testing.T) {
 }
 
 func TestBridgeCreationWithMulticastSnooping(t *testing.T) {
-	if os.Getenv("TRAVIS_BUILD_DIR") != "" {
-		t.Skipf("Travis CI worker Linux kernel version (3.13) is too old for this test")
-	}
+	minKernelRequired(t, 4, 4)
 
 	tearDown := setUpNetlinkTest(t)
 	defer tearDown()
@@ -1293,9 +1283,7 @@ func TestBridgeCreationWithMulticastSnooping(t *testing.T) {
 }
 
 func TestBridgeSetMcastSnoop(t *testing.T) {
-	if os.Getenv("TRAVIS_BUILD_DIR") != "" {
-		t.Skipf("Travis CI worker Linux kernel version (3.13) is too old for this test")
-	}
+	minKernelRequired(t, 4, 4)
 
 	tearDown := setUpNetlinkTest(t)
 	defer tearDown()
@@ -1334,9 +1322,7 @@ func expectMcastSnooping(t *testing.T, linkName string, expected bool) {
 }
 
 func TestBridgeCreationWithHelloTime(t *testing.T) {
-	if os.Getenv("TRAVIS_BUILD_DIR") != "" {
-		t.Skipf("Travis CI worker Linux kernel version (3.13) is too old for this test")
-	}
+	minKernelRequired(t, 3, 18)
 
 	tearDown := setUpNetlinkTest(t)
 	defer tearDown()

--- a/netlink_test.go
+++ b/netlink_test.go
@@ -3,7 +3,6 @@ package netlink
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"runtime"
 	"strings"
@@ -17,9 +16,7 @@ type tearDownNetlinkTest func()
 
 func skipUnlessRoot(t *testing.T) {
 	if os.Getuid() != 0 {
-		msg := "Skipped test because it requires root privileges."
-		log.Printf(msg)
-		t.Skip(msg)
+		t.Skip("Test requires root privileges.")
 	}
 }
 
@@ -43,9 +40,7 @@ func setUpNetlinkTest(t *testing.T) tearDownNetlinkTest {
 
 func setUpMPLSNetlinkTest(t *testing.T) tearDownNetlinkTest {
 	if _, err := os.Stat("/proc/sys/net/mpls/platform_labels"); err != nil {
-		msg := "Skipped test because it requires MPLS support."
-		log.Printf(msg)
-		t.Skip(msg)
+		t.Skip("Test requires MPLS support.")
 	}
 	f := setUpNetlinkTest(t)
 	setUpF := func(path, value string) {
@@ -76,9 +71,7 @@ func setUpNetlinkTestWithKModule(t *testing.T, name string) tearDownNetlinkTest 
 
 	}
 	if !found {
-		msg := fmt.Sprintf("Skipped test because it requres kmodule %s.", name)
-		log.Println(msg)
-		t.Skip(msg)
+		t.Skipf("Test requires kmodule %q.", name)
 	}
 	return setUpNetlinkTest(t)
 }

--- a/protinfo_test.go
+++ b/protinfo_test.go
@@ -3,7 +3,6 @@
 package netlink
 
 import (
-	"os"
 	"testing"
 )
 
@@ -121,9 +120,8 @@ func TestProtinfo(t *testing.T) {
 		t.Fatalf("Set protinfo attrs for link without master is not supported, but err: %s", err)
 	}
 
-	if os.Getenv("TRAVIS_BUILD_DIR") != "" {
-		t.Skipf("Skipped some tests because travis kernel is to old to support BR_PROXYARP.")
-	}
+	// Setting kernel requirement for next tests which require BR_PROXYARP
+	minKernelRequired(t, 3, 19)
 
 	if err := LinkSetBrProxyArp(iface4, true); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
- Adds utility to selectively skip tests based on minimum kernel version required.

Example:
```
minRequiredKernel(t, 3, 16)
```
This should be better than what we have now:
```
	if os.Getenv("TRAVIS_BUILD_DIR") != "" {
		t.Skipf("Skipped some tests because travis kernel is to old to support BR_PROXYARP.")
	}
```

- Also, properly use the test `Skip()` method, do not log separately the skip message.  Run the tests with the verbose `-test.v` option which will cause the skip message to be properly printed.

Signed-off-by: Alessandro Boch <aboch@tetrationanalytics.com>