### PR TITLE
Allow Tuntap non-persist, allow empty tuntap name

### DIFF
--- a/fou.go
+++ b/fou.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package netlink
 
 import (

--- a/link.go
+++ b/link.go
@@ -302,10 +302,11 @@ type TuntapFlag uint16
 // Tuntap links created via /dev/tun/tap, but can be destroyed via netlink
 type Tuntap struct {
 	LinkAttrs
-	Mode   TuntapMode
-	Flags  TuntapFlag
-	Queues int
-	Fds    []*os.File
+	Mode       TuntapMode
+	Flags      TuntapFlag
+	NonPersist bool
+	Queues     int
+	Fds        []*os.File
 }
 
 func (tuntap *Tuntap) Attrs() *LinkAttrs {


### PR DESCRIPTION
- added conditional build in fou.go, did not build on macOS (cosmetic)
- made tuntap creation to allow non-persistent tuntaps.
- allowed passing an empty interface name for tuntap creation. In this case, the OS will choose an appropriate name and copies it back into the linkattr.Name.

This patch also ensures that the link name is always identical to what the kernel returns. Not only in case of an empty name, but also when using name templates. E.g. when the provided name is `"tap%d"`, the kernel replaces `%d` with the next available number.

Added `Persist` to the Tuntap struct. Now, since this is `false` by default, it *might* be better for backward compatibility to call it `NoPersist` and explicitly set it to `true` if the Tuntap should be created as non-persistent. Thoughts?