### PR TITLE
Fix go build issue for fou code

### DIFF
--- a/fou.go
+++ b/fou.go
@@ -1,7 +1,6 @@
 package netlink
 
 import (
-	"encoding/binary"
 	"errors"
 )
 
@@ -19,46 +18,4 @@ type Fou struct {
 	Port      int
 	Protocol  int
 	EncapType int
-}
-
-func deserializeFouMsg(msg []byte) (Fou, error) {
-	// we'll skip to byte 4 to first attribute
-	msg = msg[3:]
-	var shift int
-	fou := Fou{}
-
-	for {
-		// attribute header is at least 16 bits
-		if len(msg) < 4 {
-			return fou, ErrAttrHeaderTruncated
-		}
-
-		lgt := int(binary.BigEndian.Uint16(msg[0:2]))
-		if len(msg) < lgt+4 {
-			return fou, ErrAttrBodyTruncated
-		}
-		attr := binary.BigEndian.Uint16(msg[2:4])
-
-		shift = lgt + 3
-		switch attr {
-		case FOU_ATTR_AF:
-			fou.Family = int(msg[5])
-		case FOU_ATTR_PORT:
-			fou.Port = int(binary.BigEndian.Uint16(msg[5:7]))
-			// port is 2 bytes
-			shift = lgt + 2
-		case FOU_ATTR_IPPROTO:
-			fou.Protocol = int(msg[5])
-		case FOU_ATTR_TYPE:
-			fou.EncapType = int(msg[5])
-		}
-
-		msg = msg[shift:]
-
-		if len(msg) < 4 {
-			break
-		}
-	}
-
-	return fou, nil
 }

--- a/fou_linux.go
+++ b/fou_linux.go
@@ -171,3 +171,45 @@ func (h *Handle) FouList(fam int) ([]Fou, error) {
 
 	return fous, nil
 }
+
+func deserializeFouMsg(msg []byte) (Fou, error) {
+	// we'll skip to byte 4 to first attribute
+	msg = msg[3:]
+	var shift int
+	fou := Fou{}
+
+	for {
+		// attribute header is at least 16 bits
+		if len(msg) < 4 {
+			return fou, ErrAttrHeaderTruncated
+		}
+
+		lgt := int(binary.BigEndian.Uint16(msg[0:2]))
+		if len(msg) < lgt+4 {
+			return fou, ErrAttrBodyTruncated
+		}
+		attr := binary.BigEndian.Uint16(msg[2:4])
+
+		shift = lgt + 3
+		switch attr {
+		case FOU_ATTR_AF:
+			fou.Family = int(msg[5])
+		case FOU_ATTR_PORT:
+			fou.Port = int(binary.BigEndian.Uint16(msg[5:7]))
+			// port is 2 bytes
+			shift = lgt + 2
+		case FOU_ATTR_IPPROTO:
+			fou.Protocol = int(msg[5])
+		case FOU_ATTR_TYPE:
+			fou.EncapType = int(msg[5])
+		}
+
+		msg = msg[shift:]
+
+		if len(msg) < 4 {
+			break
+		}
+	}
+
+	return fou, nil
+}

--- a/fou_test.go
+++ b/fou_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package netlink
 
 import (


### PR DESCRIPTION
Fixes #297 

- Moved linux dependent code into fou_linux.go
- Restrict fou test execution to linux machine