### PR TITLE
Fix LinkAdd for sit tunnel on 3.10 kernel

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -2035,7 +2035,11 @@ func addSittunAttrs(sittun *Sittun, linkInfo *nl.RtAttr) {
 		nl.NewRtAttrChild(data, nl.IFLA_IPTUN_REMOTE, []byte(ip))
 	}
 
-	nl.NewRtAttrChild(data, nl.IFLA_IPTUN_TTL, nl.Uint8Attr(sittun.Ttl))
+	if sittun.Ttl > 0 {
+		// Would otherwise fail on 3.10 kernel
+		nl.NewRtAttrChild(data, nl.IFLA_IPTUN_TTL, nl.Uint8Attr(sittun.Ttl))
+	}
+
 	nl.NewRtAttrChild(data, nl.IFLA_IPTUN_TOS, nl.Uint8Attr(sittun.Tos))
 	nl.NewRtAttrChild(data, nl.IFLA_IPTUN_PMTUDISC, nl.Uint8Attr(sittun.PMtuDisc))
 	nl.NewRtAttrChild(data, nl.IFLA_IPTUN_ENCAP_TYPE, nl.Uint16Attr(sittun.EncapType))

--- a/link_test.go
+++ b/link_test.go
@@ -444,6 +444,8 @@ func TestLinkAddDelVeth(t *testing.T) {
 }
 
 func TestLinkAddDelBond(t *testing.T) {
+	minKernelRequired(t, 3, 13)
+
 	tearDown := setUpNetlinkTest(t)
 	defer tearDown()
 

--- a/neigh_test.go
+++ b/neigh_test.go
@@ -53,6 +53,8 @@ func dumpContainsProxy(dump []Neigh, p proxyEntry) bool {
 }
 
 func TestNeighAddDelLLIPAddr(t *testing.T) {
+	setUpNetlinkTestWithKModule(t, "ipip")
+
 	tearDown := setUpNetlinkTest(t)
 	defer tearDown()
 


### PR DESCRIPTION
- TTL attribute must be added only if non-zero on older kernel

`TestLinkAddDelSittun` does in fact fail on 3.10 kernel with 
```
--- FAIL: TestLinkAddDelSittun (0.07s)
	link_test.go:31: operation not supported
```

- Also add kernel req to `TestLinkAddDelBond` and module check to `TestNeighAddDelLLIPAddr`