### PR TITLE
Properly tear down netns at the end of test

### DIFF
--- a/rule_test.go
+++ b/rule_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestRuleAddDel(t *testing.T) {
 	skipUnlessRoot(t)
-	setUpNetlinkTest(t)()
+	defer setUpNetlinkTest(t)()
 
 	srcNet := &net.IPNet{IP: net.IPv4(172, 16, 0, 1), Mask: net.CIDRMask(16, 32)}
 	dstNet := &net.IPNet{IP: net.IPv4(172, 16, 1, 1), Mask: net.CIDRMask(24, 32)}

--- a/xfrm_monitor_test.go
+++ b/xfrm_monitor_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestXfrmMonitorExpire(t *testing.T) {
-	setUpNetlinkTest(t)()
+	defer setUpNetlinkTest(t)()
 
 	ch := make(chan XfrmMsg)
 	done := make(chan struct{})

--- a/xfrm_policy_test.go
+++ b/xfrm_policy_test.go
@@ -92,7 +92,7 @@ func TestXfrmPolicyAddUpdateDel(t *testing.T) {
 }
 
 func TestXfrmPolicyFlush(t *testing.T) {
-	setUpNetlinkTest(t)()
+	defer setUpNetlinkTest(t)()
 
 	p1 := getPolicy()
 	if err := XfrmPolicyAdd(p1); err != nil {

--- a/xfrm_state_test.go
+++ b/xfrm_state_test.go
@@ -63,7 +63,7 @@ func testXfrmStateAddGetDel(t *testing.T, state *XfrmState) {
 }
 
 func TestXfrmStateAllocSpi(t *testing.T) {
-	setUpNetlinkTest(t)()
+	defer setUpNetlinkTest(t)()
 
 	state := getBaseState()
 	state.Spi = 0
@@ -83,7 +83,7 @@ func TestXfrmStateAllocSpi(t *testing.T) {
 }
 
 func TestXfrmStateFlush(t *testing.T) {
-	setUpNetlinkTest(t)()
+	defer setUpNetlinkTest(t)()
 
 	state1 := getBaseState()
 	state2 := getBaseState()
@@ -134,7 +134,7 @@ func TestXfrmStateFlush(t *testing.T) {
 }
 
 func TestXfrmStateUpdateLimits(t *testing.T) {
-	setUpNetlinkTest(t)()
+	defer setUpNetlinkTest(t)()
 
 	// Program state with limits
 	state := getBaseState()
@@ -182,7 +182,7 @@ func TestXfrmStateUpdateLimits(t *testing.T) {
 }
 
 func TestXfrmStateStats(t *testing.T) {
-	setUpNetlinkTest(t)()
+	defer setUpNetlinkTest(t)()
 
 	// Program state and record time
 	state := getBaseState()


### PR DESCRIPTION
- In few tests the tear down function was not called in defer, therefore those tests were not being run in a dedicated netns.