### PR TITLE
Send IFA_CACHEINFO when setting up addresses

### DIFF
--- a/addr_linux.go
+++ b/addr_linux.go
@@ -118,6 +118,17 @@ func (h *Handle) addrHandle(link Link, addr *Addr, req *nl.NetlinkRequest) error
 		}
 	}
 
+	// 0 is the default value for these attributes. However, 0 means "expired", while the least-surprising default
+	// value should be "forever". To compensate for that, only add the attributes if at least one of the values is
+	// non-zero, which means the caller has explicitly set them
+	if addr.ValidLft > 0 || addr.PreferedLft > 0 {
+		cachedata := nl.IfaCacheInfo{
+			IfaValid:    uint32(addr.ValidLft),
+			IfaPrefered: uint32(addr.PreferedLft),
+		}
+		req.AddData(nl.NewRtAttr(unix.IFA_CACHEINFO, cachedata.Serialize()))
+	}
+
 	_, err := req.Execute(unix.NETLINK_ROUTE, 0)
 	return err
 }

--- a/addr_linux.go
+++ b/addr_linux.go
@@ -102,18 +102,20 @@ func (h *Handle) addrHandle(link Link, addr *Addr, req *nl.NetlinkRequest) error
 		}
 	}
 
-	if addr.Broadcast == nil {
-		calcBroadcast := make(net.IP, masklen/8)
-		for i := range localAddrData {
-			calcBroadcast[i] = localAddrData[i] | ^addr.Mask[i]
+	if family == FAMILY_V4 {
+		if addr.Broadcast == nil {
+			calcBroadcast := make(net.IP, masklen/8)
+			for i := range localAddrData {
+				calcBroadcast[i] = localAddrData[i] | ^addr.Mask[i]
+			}
+			addr.Broadcast = calcBroadcast
 		}
-		addr.Broadcast = calcBroadcast
-	}
-	req.AddData(nl.NewRtAttr(unix.IFA_BROADCAST, addr.Broadcast))
+		req.AddData(nl.NewRtAttr(unix.IFA_BROADCAST, addr.Broadcast))
 
-	if addr.Label != "" {
-		labelData := nl.NewRtAttr(unix.IFA_LABEL, nl.ZeroTerminated(addr.Label))
-		req.AddData(labelData)
+		if addr.Label != "" {
+			labelData := nl.NewRtAttr(unix.IFA_LABEL, nl.ZeroTerminated(addr.Label))
+			req.AddData(labelData)
+		}
 	}
 
 	_, err := req.Execute(unix.NETLINK_ROUTE, 0)


### PR DESCRIPTION
This patch implements setting the cacheinfo attributes in addrHandle, to enable setting the valid_lft and preferred_lft values on addresses inserted. Currently, these values are ignored.

There is an interface issue because the default values for these fields in go are valid values for the netlink fields, but they are not very good default values. I have implemented what I think is a reasonable interface there, but I don't believe it is especially great. Any feedback on a better way to handle these parameters would be welcome.

This also removes the IFA_BROADCAST and IFA_LABEL fields from messages for non-ipv4 addresses, since these attributes are ignored for other kinds of addresses.