### PR TITLE
Add IFF_RUNNING flag to be RFC2863 compliant

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -1838,6 +1838,9 @@ func linkFlags(rawFlags uint32) net.Flags {
 	if rawFlags&unix.IFF_MULTICAST != 0 {
 		f |= net.FlagMulticast
 	}
+	if rawFlags&syscall.IFF_RUNNING != 0 {
+		f |= syscall.IFF_RUNNING
+	}
 	return f
 }
 


### PR DESCRIPTION
Regarding to:
[https://www.kernel.org/doc/Documentation/networking/operstates.txt](https://www.kernel.org/doc/Documentation/networking/operstates.txt) :

if_flags & IFF_RUNNING:
 Interface is in RFC2863 operational state UP or UNKNOWN. This is for
 backward compatibility, routing daemons, dhcp clients can use this
 flag to determine whether they should use the interface.

In my opinion we should be able to determine operational state using netlink.Link attributes