### PR TITLE
Use IFF_MULTI_QUEUE from x/sys/unix to define TUNTAP_MULTI_QUEUE

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -28,7 +28,7 @@ const (
 	TUNTAP_TUN_EXCL             TuntapFlag = unix.IFF_TUN_EXCL
 	TUNTAP_NO_PI                TuntapFlag = unix.IFF_NO_PI
 	TUNTAP_ONE_QUEUE            TuntapFlag = unix.IFF_ONE_QUEUE
-	TUNTAP_MULTI_QUEUE          TuntapFlag = 0x0100
+	TUNTAP_MULTI_QUEUE          TuntapFlag = unix.IFF_MULTI_QUEUE
 	TUNTAP_MULTI_QUEUE_DEFAULTS TuntapFlag = TUNTAP_MULTI_QUEUE | TUNTAP_NO_PI
 )
 


### PR DESCRIPTION
Use the constant defined in the golang.org/x/sys/unix package instead of
locally open-coding it.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>