### PR TITLE
Add class stats

### DIFF
--- a/class.go
+++ b/class.go
@@ -9,14 +9,63 @@ type Class interface {
 	Type() string
 }
 
+// Generic networking statistics for netlink users.
+// This file contains "gnet_" prefixed structs and relevant functions.
+// See Documentation/networking/getn_stats.txt in Linux source code for more details.
+
+// Ref: struct gnet_stats_basic { ... }
+type GnetStatsBasic struct {
+	Bytes   uint64 // number of seen bytes
+	Packets uint32 // number of seen packets
+}
+
+// Ref: struct gnet_stats_rate_est { ... }
+type GnetStatsRateEst struct {
+	Bps uint32 // current byte rate
+	Pps uint32 // current packet rate
+}
+
+// Ref: struct gnet_stats_rate_est64 { ... }
+type GnetStatsRateEst64 struct {
+	Bps uint64 // current byte rate
+	Pps uint64 // current packet rate
+}
+
+// Ref: struct gnet_stats_queue { ... }
+type GnetStatsQueue struct {
+	Qlen       uint32 // queue length
+	Backlog    uint32 // backlog size of queue
+	Drops      uint32 // number of dropped packets
+	Requeues   uint32 // number of requues
+	Overlimits uint32 // number of enqueues over the limit
+}
+
+// Statistics representaion based on generic networking statisticsfor netlink.
+// See Documentation/networking/gen_stats.txt in Linux source code for more details.
+type ClassStatistics struct {
+	Basic   *GnetStatsBasic
+	Queue   *GnetStatsQueue
+	RateEst *GnetStatsRateEst
+}
+
+// Construct a ClassStatistics struct which fields are all initialized by 0.
+func NewClassStatistics() *ClassStatistics {
+	return &ClassStatistics{
+		Basic:   &GnetStatsBasic{},
+		Queue:   &GnetStatsQueue{},
+		RateEst: &GnetStatsRateEst{},
+	}
+}
+
 // ClassAttrs represents a netlink class. A filter is associated with a link,
 // has a handle and a parent. The root filter of a device should have a
 // parent == HANDLE_ROOT.
 type ClassAttrs struct {
-	LinkIndex int
-	Handle    uint32
-	Parent    uint32
-	Leaf      uint32
+	LinkIndex  int
+	Handle     uint32
+	Parent     uint32
+	Leaf       uint32
+	Statistics *ClassStatistics
 }
 
 func (q ClassAttrs) String() string {

--- a/class_linux.go
+++ b/class_linux.go
@@ -1,12 +1,32 @@
 package netlink
 
 import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
 	"errors"
+	"fmt"
 	"syscall"
 
 	"github.com/vishvananda/netlink/nl"
 	"golang.org/x/sys/unix"
 )
+
+// Internal tc_stats representation in Go struct.
+// This is for internal uses only to deserialize the payload of rtattr.
+// After the deserialization, this should be converted into the canonical stats
+// struct, ClassStatistics, in case of statistics of a class.
+// Ref: struct tc_stats { ... }
+type tcStats struct {
+	Bytes      uint64 // Number of enqueued bytes
+	Packets    uint32 // Number of enqueued packets
+	Drops      uint32 // Packets dropped because of lack of resources
+	Overlimits uint32 // Number of throttle events when this flow goes out of allocated bandwidth
+	Bps        uint32 // Current flow byte rate
+	Pps        uint32 // Current flow packet rate
+	Qlen       uint32
+	Backlog    uint32
+}
 
 // NOTE: function is in here because it uses other linux functions
 func NewHtbClass(attrs ClassAttrs, cattrs HtbClassAttrs) *HtbClass {
@@ -197,9 +217,10 @@ func (h *Handle) ClassList(link Link, parent uint32) ([]Class, error) {
 		}
 
 		base := ClassAttrs{
-			LinkIndex: int(msg.Ifindex),
-			Handle:    msg.Handle,
-			Parent:    msg.Parent,
+			LinkIndex:  int(msg.Ifindex),
+			Handle:     msg.Handle,
+			Parent:     msg.Parent,
+			Statistics: nil,
 		}
 
 		var class Class
@@ -225,6 +246,17 @@ func (h *Handle) ClassList(link Link, parent uint32) ([]Class, error) {
 					if err != nil {
 						return nil, err
 					}
+				}
+			// For backward compatibility.
+			case nl.TCA_STATS:
+				base.Statistics, err = parseTcStats(attr.Value)
+				if err != nil {
+					return nil, err
+				}
+			case nl.TCA_STATS2:
+				base.Statistics, err = parseTcStats2(attr.Value)
+				if err != nil {
+					return nil, err
 				}
 			}
 		}
@@ -252,4 +284,62 @@ func parseHtbClassData(class Class, data []syscall.NetlinkRouteAttr) (bool, erro
 		}
 	}
 	return detailed, nil
+}
+
+func parseTcStats(data []byte) (*ClassStatistics, error) {
+	buf := &bytes.Buffer{}
+	buf.Write(data)
+	native := nl.NativeEndian()
+	tcStats := &tcStats{}
+	if err := binary.Read(buf, native, tcStats); err != nil {
+		return nil, err
+	}
+
+	stats := NewClassStatistics()
+	stats.Basic.Bytes = tcStats.Bytes
+	stats.Basic.Packets = tcStats.Packets
+	stats.Queue.Qlen = tcStats.Qlen
+	stats.Queue.Backlog = tcStats.Backlog
+	stats.Queue.Drops = tcStats.Drops
+	stats.Queue.Overlimits = tcStats.Overlimits
+	stats.RateEst.Bps = tcStats.Bps
+	stats.RateEst.Pps = tcStats.Pps
+
+	return stats, nil
+}
+
+func parseGnetStats(data []byte, gnetStats interface{}) error {
+	buf := &bytes.Buffer{}
+	buf.Write(data)
+	native := nl.NativeEndian()
+	return binary.Read(buf, native, gnetStats)
+}
+
+func parseTcStats2(data []byte) (*ClassStatistics, error) {
+	rtAttrs, err := nl.ParseRouteAttr(data)
+	if err != nil {
+		return nil, err
+	}
+	stats := NewClassStatistics()
+	for _, datum := range rtAttrs {
+		switch datum.Attr.Type {
+		case nl.TCA_STATS_BASIC:
+			if err := parseGnetStats(datum.Value, stats.Basic); err != nil {
+				return nil, fmt.Errorf("Failed to parse ClassStatistics.Basic with: %v\n%s",
+					err, hex.Dump(datum.Value))
+			}
+		case nl.TCA_STATS_QUEUE:
+			if err := parseGnetStats(datum.Value, stats.Queue); err != nil {
+				return nil, fmt.Errorf("Failed to parse ClassStatistics.Queue with: %v\n%s",
+					err, hex.Dump(datum.Value))
+			}
+		case nl.TCA_STATS_RATE_EST:
+			if err := parseGnetStats(datum.Value, stats.RateEst); err != nil {
+				return nil, fmt.Errorf("Failed to parse ClassStatistics.RateEst with: %v\n%s",
+					err, hex.Dump(datum.Value))
+			}
+		}
+	}
+
+	return stats, nil
 }

--- a/class_test.go
+++ b/class_test.go
@@ -3,6 +3,7 @@
 package netlink
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -21,6 +22,13 @@ func SafeQdiscList(link Link) ([]Qdisc, error) {
 		}
 	}
 	return result, nil
+}
+
+func testClassStats(this, that *ClassStatistics, t *testing.T) {
+	ok := reflect.DeepEqual(this, that)
+	if !ok {
+		t.Fatalf("%#v is expected but it actually was %#v", that, this)
+	}
 }
 
 func TestClassAddDel(t *testing.T) {
@@ -98,6 +106,8 @@ func TestClassAddDel(t *testing.T) {
 	if htb.Cbuffer != class.Cbuffer {
 		t.Fatal("Cbuffer doesn't match")
 	}
+
+	testClassStats(htb.ClassAttrs.Statistics, NewClassStatistics(), t)
 
 	qattrs := QdiscAttrs{
 		LinkIndex: link.Attrs().Index,
@@ -249,6 +259,8 @@ func TestHtbClassAddHtbClassChangeDel(t *testing.T) {
 	if !ok {
 		t.Fatal("Class is the wrong type")
 	}
+
+	testClassStats(htb.ClassAttrs.Statistics, NewClassStatistics(), t)
 
 	qattrs := QdiscAttrs{
 		LinkIndex: link.Attrs().Index,

--- a/nl/tc_linux.go
+++ b/nl/tc_linux.go
@@ -65,6 +65,15 @@ const (
 )
 
 const (
+	TCA_STATS_UNSPEC = iota
+	TCA_STATS_BASIC
+	TCA_STATS_RATE_EST
+	TCA_STATS_QUEUE
+	TCA_STATS_APP
+	TCA_STATS_MAX = TCA_STATS_APP
+)
+
+const (
 	SizeofTcMsg          = 0x14
 	SizeofTcActionMsg    = 0x04
 	SizeofTcPrioMap      = 0x14


### PR DESCRIPTION
This series of patches adds statistics fields that were not parsed previously to classes .

The first patch adds the parsing process of the rtattrs for the stats, `TCA_STATS` and `TCA_STATS2`, adding new structs for the statistics, `ClassStatistics`. `TCA_STATS` and `TCA_STATS2` have different structures internally but they are converted into `ClassStatistics` in the end. Brief sanity checks for the stats fields are added in `class_test.go` as well.

In the second patch, new legitimate tests that actually validate the stats for the real packets are added. It requires github.com/google/gopacket for generating and sending arbitrary packets in the tests.