### PR TITLE
Enhance u32 filters

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -212,6 +212,7 @@ type TcU32Key struct {
 type U32 struct {
 	FilterAttrs
 	ClassId    uint32
+	Divisor    uint32 // Divisor MUST be power of 2.
 	RedirIndex int
 	Sel        *TcU32Sel
 	Actions    []Action

--- a/filter.go
+++ b/filter.go
@@ -213,6 +213,7 @@ type U32 struct {
 	FilterAttrs
 	ClassId    uint32
 	Divisor    uint32 // Divisor MUST be power of 2.
+	Hash       uint32
 	RedirIndex int
 	Sel        *TcU32Sel
 	Actions    []Action

--- a/filter_linux.go
+++ b/filter_linux.go
@@ -178,6 +178,9 @@ func (h *Handle) FilterAdd(filter Filter) error {
 			}
 			nl.NewRtAttrChild(options, nl.TCA_U32_DIVISOR, nl.Uint32Attr(filter.Divisor))
 		}
+		if filter.Hash != 0 {
+			nl.NewRtAttrChild(options, nl.TCA_U32_HASH, nl.Uint32Attr(filter.Hash))
+		}
 		actionsAttr := nl.NewRtAttrChild(options, nl.TCA_U32_ACT, nil)
 		// backwards compatibility
 		if filter.RedirIndex != 0 {
@@ -508,6 +511,8 @@ func parseU32Data(filter Filter, data []syscall.NetlinkRouteAttr) (bool, error) 
 			u32.ClassId = native.Uint32(datum.Value)
 		case nl.TCA_U32_DIVISOR:
 			u32.Divisor = native.Uint32(datum.Value)
+		case nl.TCA_U32_HASH:
+			u32.Hash = native.Uint32(datum.Value)
 		}
 	}
 	return detailed, nil

--- a/filter_linux.go
+++ b/filter_linux.go
@@ -172,6 +172,12 @@ func (h *Handle) FilterAdd(filter Filter) error {
 		if filter.ClassId != 0 {
 			nl.NewRtAttrChild(options, nl.TCA_U32_CLASSID, nl.Uint32Attr(filter.ClassId))
 		}
+		if filter.Divisor != 0 {
+			if (filter.Divisor-1)&filter.Divisor != 0 {
+				return fmt.Errorf("illegal divisor %d. Must be a power of 2.", filter.Divisor)
+			}
+			nl.NewRtAttrChild(options, nl.TCA_U32_DIVISOR, nl.Uint32Attr(filter.Divisor))
+		}
 		actionsAttr := nl.NewRtAttrChild(options, nl.TCA_U32_ACT, nil)
 		// backwards compatibility
 		if filter.RedirIndex != 0 {
@@ -500,6 +506,8 @@ func parseU32Data(filter Filter, data []syscall.NetlinkRouteAttr) (bool, error) 
 			}
 		case nl.TCA_U32_CLASSID:
 			u32.ClassId = native.Uint32(datum.Value)
+		case nl.TCA_U32_DIVISOR:
+			u32.Divisor = native.Uint32(datum.Value)
 		}
 	}
 	return detailed, nil

--- a/filter_test.go
+++ b/filter_test.go
@@ -167,6 +167,27 @@ func TestAdvancedFilterAddDel(t *testing.T) {
 		t.Fatal("Class is the wrong type")
 	}
 
+	htid := MakeHandle(0x0010, 0000)
+	divisor := uint32(1)
+	hashTable := &U32{
+		FilterAttrs: FilterAttrs{
+			LinkIndex: index,
+			Handle:    htid,
+			Parent:    qdiscHandle,
+			Priority:  1,
+			Protocol:  unix.ETH_P_ALL,
+		},
+		Divisor: divisor,
+	}
+	cHashTable := *hashTable
+	if err := FilterAdd(hashTable); err != nil {
+		t.Fatal(err)
+	}
+	// Check if the hash table is identical before and after FilterAdd.
+	if !reflect.DeepEqual(cHashTable, *hashTable) {
+		t.Fatalf("Hash table %v and %v are not equal", cHashTable, *hashTable)
+	}
+
 	u32SelKeys := []TcU32Key{
 		{
 			Mask:    0xff,

--- a/filter_test.go
+++ b/filter_test.go
@@ -202,9 +202,12 @@ func TestAdvancedFilterAddDel(t *testing.T) {
 			OffMask: 0,
 		},
 	}
+
+	handle := MakeHandle(0x0000, 0001)
 	filter := &U32{
 		FilterAttrs: FilterAttrs{
 			LinkIndex: index,
+			Handle:    handle,
 			Parent:    qdiscHandle,
 			Priority:  1,
 			Protocol:  unix.ETH_P_ALL,
@@ -214,6 +217,7 @@ func TestAdvancedFilterAddDel(t *testing.T) {
 			Flags: TC_U32_TERMINAL,
 		},
 		ClassId: classId,
+		Hash:    htid,
 		Actions: []Action{},
 	}
 	// Copy filter.
@@ -253,8 +257,15 @@ func TestAdvancedFilterAddDel(t *testing.T) {
 			t.Fatal("The endianness of TcU32Key.Val is wrong")
 		}
 	}
+	if u32.Handle != (handle | htid) {
+		t.Fatalf("The handle is wrong. expected %v but actually %v",
+			(handle | htid), u32.Handle)
+	}
+	if u32.Hash != htid {
+		t.Fatal("The hash table ID is wrong")
+	}
 
-	if err := FilterDel(filter); err != nil {
+	if err := FilterDel(u32); err != nil {
 		t.Fatal(err)
 	}
 	filters, err = FilterList(link, qdiscHandle)


### PR DESCRIPTION
This series of patches introduces `Divisor` and `Hash` attributes to `U32` struct.

* With `Divisor` specified, a u32 hash table can be created
* A filter can be created and associated with the filter that has the hash table ID specified with `Hash` attribute

Although these changes enable users to construct the more flexible filter configurations, I'd like to note a hash table cannot be listed or deleted with the current interfaces, `FilterList` and `FilterDel`. We can create a hash table but we *cannot* list and delete one either.

I just added a capability to create a hash table with this PR. If we want to make sure a hash table can be treated as the legitimate entity like it currently is in `tc`, the overhaul for the filter interfaces will be required in the following patches.

See the following links to know the details of the u32 hash table.
- https://git.kernel.org/pub/scm/network/iproute2/iproute2.git/tree/README.iproute2+tc#n92
- https://www.systutorials.com/docs/linux/man/8-tc-u32/