### PR TITLE
Parse GRE IP addresses right

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -1974,9 +1974,9 @@ func parseGretapData(link Link, data []syscall.NetlinkRouteAttr) {
 		case nl.IFLA_GRE_IKEY:
 			gre.OKey = ntohl(datum.Value[0:4])
 		case nl.IFLA_GRE_LOCAL:
-			gre.Local = net.IP(datum.Value[0:16])
+			gre.Local = net.IP(datum.Value)
 		case nl.IFLA_GRE_REMOTE:
-			gre.Remote = net.IP(datum.Value[0:16])
+			gre.Remote = net.IP(datum.Value)
 		case nl.IFLA_GRE_ENCAP_SPORT:
 			gre.EncapSport = ntohs(datum.Value[0:2])
 		case nl.IFLA_GRE_ENCAP_DPORT:
@@ -1985,7 +1985,6 @@ func parseGretapData(link Link, data []syscall.NetlinkRouteAttr) {
 			gre.IFlags = ntohs(datum.Value[0:2])
 		case nl.IFLA_GRE_OFLAGS:
 			gre.OFlags = ntohs(datum.Value[0:2])
-
 		case nl.IFLA_GRE_TTL:
 			gre.Ttl = uint8(datum.Value[0])
 		case nl.IFLA_GRE_TOS:
@@ -2051,19 +2050,18 @@ func parseGretunData(link Link, data []syscall.NetlinkRouteAttr) {
 	gre := link.(*Gretun)
 	for _, datum := range data {
 		switch datum.Attr.Type {
-		case nl.IFLA_GRE_OKEY:
-			gre.IKey = ntohl(datum.Value[0:4])
 		case nl.IFLA_GRE_IKEY:
+			gre.IKey = ntohl(datum.Value[0:4])
+		case nl.IFLA_GRE_OKEY:
 			gre.OKey = ntohl(datum.Value[0:4])
 		case nl.IFLA_GRE_LOCAL:
-			gre.Local = net.IP(datum.Value[0:16])
+			gre.Local = net.IP(datum.Value)
 		case nl.IFLA_GRE_REMOTE:
-			gre.Remote = net.IP(datum.Value[0:16])
+			gre.Remote = net.IP(datum.Value)
 		case nl.IFLA_GRE_IFLAGS:
 			gre.IFlags = ntohs(datum.Value[0:2])
 		case nl.IFLA_GRE_OFLAGS:
 			gre.OFlags = ntohs(datum.Value[0:2])
-
 		case nl.IFLA_GRE_TTL:
 			gre.Ttl = uint8(datum.Value[0])
 		case nl.IFLA_GRE_TOS:

--- a/link_test.go
+++ b/link_test.go
@@ -185,17 +185,20 @@ func testLinkAddDel(t *testing.T, link Link) {
 		}
 	}
 
-	if _, ok := link.(*Gretap); ok {
-		_, ok := result.(*Gretap)
+	if gretap, ok := link.(*Gretap); ok {
+		other, ok := result.(*Gretap)
 		if !ok {
 			t.Fatal("Result of create is not a Gretap")
 		}
+		compareGretap(t, gretap, other)
 	}
-	if _, ok := link.(*Gretun); ok {
-		_, ok := result.(*Gretun)
+
+	if gretun, ok := link.(*Gretun); ok {
+		other, ok := result.(*Gretun)
 		if !ok {
 			t.Fatal("Result of create is not a Gretun")
 		}
+		compareGretun(t, gretun, other)
 	}
 
 	if err = LinkDel(link); err != nil {
@@ -211,6 +214,131 @@ func testLinkAddDel(t *testing.T, link Link) {
 		if l.Attrs().Name == link.Attrs().Name {
 			t.Fatal("Link not removed properly")
 		}
+	}
+}
+
+func compareGretap(t *testing.T, expected, actual *Gretap) {
+	if actual.IKey != expected.IKey {
+		t.Fatal("Gretap.IKey doesn't match")
+	}
+
+	if actual.OKey != expected.OKey {
+		t.Fatal("Gretap.OKey doesn't match")
+	}
+
+	if actual.EncapSport != expected.EncapSport {
+		t.Fatal("Gretap.EncapSport doesn't match")
+	}
+
+	if actual.EncapDport != expected.EncapDport {
+		t.Fatal("Gretap.EncapDport doesn't match")
+	}
+
+	if expected.Local != nil && !actual.Local.Equal(expected.Local) {
+		t.Fatal("Gretap.Local doesn't match")
+	}
+
+	if expected.Remote != nil && !actual.Remote.Equal(expected.Remote) {
+		t.Fatal("Gretap.Remote doesn't match")
+	}
+
+	if actual.IFlags != expected.IFlags {
+		t.Fatal("Gretap.IFlags doesn't match")
+	}
+
+	if actual.OFlags != expected.OFlags {
+		t.Fatal("Gretap.OFlags doesn't match")
+	}
+
+	if actual.PMtuDisc != expected.PMtuDisc {
+		t.Fatal("Gretap.PMtuDisc doesn't match")
+	}
+
+	if actual.Ttl != expected.Ttl {
+		t.Fatal("Gretap.Ttl doesn't match")
+	}
+
+	if actual.Tos != expected.Tos {
+		t.Fatal("Gretap.Tos doesn't match")
+	}
+
+	if actual.EncapType != expected.EncapType {
+		t.Fatal("Gretap.EncapType doesn't match")
+	}
+
+	if actual.EncapFlags != expected.EncapFlags {
+		t.Fatal("Gretap.EncapFlags doesn't match")
+	}
+
+	if actual.Link != expected.Link {
+		t.Fatal("Gretap.Link doesn't match")
+	}
+
+	/*
+		 * NOTE: setting the FlowBased flag doesn't seem to work, but by lack of
+		 * a proper way to debug this, this test is disabled for now
+
+		 if actual.FlowBased != expected.FlowBased {
+			t.Fatal("Gretap.FlowBased doesn't match")
+		 }
+	*/
+}
+
+func compareGretun(t *testing.T, expected, actual *Gretun) {
+	if actual.Link != expected.Link {
+		t.Fatal("Gretun.Link doesn't match")
+	}
+
+	if actual.IFlags != expected.IFlags {
+		t.Fatal("Gretun.IFlags doesn't match")
+	}
+
+	if actual.OFlags != expected.OFlags {
+		t.Fatal("Gretun.OFlags doesn't match")
+	}
+
+	if actual.IKey != expected.IKey {
+		t.Fatal("Gretun.IKey doesn't match")
+	}
+
+	if actual.OKey != expected.OKey {
+		t.Fatal("Gretun.OKey doesn't match")
+	}
+
+	if expected.Local != nil && !actual.Local.Equal(expected.Local) {
+		t.Fatal("Gretun.Local doesn't match")
+	}
+
+	if expected.Remote != nil && !actual.Remote.Equal(expected.Remote) {
+		t.Fatal("Gretun.Remote doesn't match")
+	}
+
+	if actual.Ttl != expected.Ttl {
+		t.Fatal("Gretun.Ttl doesn't match")
+	}
+
+	if actual.Tos != expected.Tos {
+		t.Fatal("Gretun.Tos doesn't match")
+	}
+
+	if actual.PMtuDisc != expected.PMtuDisc {
+		t.Fatal("Gretun.PMtuDisc doesn't match")
+	}
+
+	if actual.EncapType != expected.EncapType {
+		t.Fatal("Gretun.EncapType doesn't match")
+	}
+
+	if actual.EncapFlags != expected.EncapFlags {
+		t.Fatal("Gretun.EncapFlags doesn't match")
+	}
+
+	if actual.EncapSport != expected.EncapSport {
+		t.Fatal("Gretun.EncapSport doesn't match")
+	}
+
+	if actual.EncapDport != expected.EncapDport {
+		t.Fatal("Gretun.EncapDport doesn't match")
 	}
 }
 
@@ -325,7 +453,6 @@ func TestLinkAddDelGretap(t *testing.T) {
 		LinkAttrs: LinkAttrs{Name: "foo6"},
 		IKey:      0x101,
 		OKey:      0x101,
-		PMtuDisc:  1,
 		Local:     net.ParseIP("2001:db8:abcd::1"),
 		Remote:    net.ParseIP("2001:db8:ef33::2")})
 }


### PR DESCRIPTION
I had some issue with some gretun devices after upgrading the netlink library in my project. I traced it down to 5a988e882da75e9451a5a6b02eecd36df51606ed where IPv6 support for these interfaces was introduced. My problem is that the IP addresses are always considered IPv6 addresses, even when it is supposed to be IPv4.

I added additional testing to `Gretun` and `Gretap` interfaces and it turned out that it probably isn't working properly for anyone. I also added a proposed fix for it. The only thing left to discuss is the fact that `PMtuDisc` isn't properly parsed for IPv6 `Gretap`s, but I'm wondering if this is even relevant; isn't MTU discovery dealt with differently for IPv6 in the first place?