### PR TITLE
Run both Inline/Encap mode in TestSEG6RouteAddDel

### DIFF
--- a/netlink_test.go
+++ b/netlink_test.go
@@ -109,12 +109,6 @@ func setUpSEG6NetlinkTest(t *testing.T) tearDownNetlinkTest {
 		log.Printf(msg)
 		t.Skip(msg)
 	}
-	key = string("CONFIG_IPV6_SEG6_INLINE=y")
-	if _, err := grepKey(key, filename); err != nil {
-		msg := "Skipped test because it requires SEG6_INLINE support."
-		log.Printf(msg)
-		t.Skip(msg)
-	}
 	// Add CONFIG_IPV6_SEG6_HMAC to support seg6_hamc
 	// key := string("CONFIG_IPV6_SEG6_HMAC=y")
 


### PR DESCRIPTION
TestSEG6RouteAddDel was skipped due to checking unnecessary Kernel build option and hiding a bug in SEG6_INLINE mode testing.
Changes in this PR will fix both of it. (Details will follow)
