### PR TITLE
Implement "vti6" device support

### DIFF
--- a/addr_test.go
+++ b/addr_test.go
@@ -24,7 +24,7 @@ func DoTestAddr(t *testing.T, FunctionUndertest func(Link, *Addr) error) {
 		t.Skipf("Fails in travis with: addr_test.go:68: Address flags not set properly, got=0, expected=128")
 	}
 	// TODO: IFA_F_PERMANENT does not seem to be set by default on older kernels?
-	var address = &net.IPNet{IP: net.IPv4(127, 0, 0, 2), Mask: net.CIDRMask(24, 32)}
+	var address = &net.IPNet{IP: net.IPv4(127, 0, 0, 2), Mask: net.CIDRMask(32, 32)}
 	var peer = &net.IPNet{IP: net.IPv4(127, 0, 0, 3), Mask: net.CIDRMask(24, 32)}
 	var addrTests = []struct {
 		addr     *Addr

--- a/link.go
+++ b/link.go
@@ -784,9 +784,8 @@ func (vti *Vti) Attrs() *LinkAttrs {
 func (vti *Vti) Type() string {
 	if vti.Local.To4() == nil {
 		return "vti6"
-	} else {
-		return "vti"
 	}
+	return "vti"
 }
 
 type Gretun struct {

--- a/link.go
+++ b/link.go
@@ -781,8 +781,12 @@ func (vti *Vti) Attrs() *LinkAttrs {
 	return &vti.LinkAttrs
 }
 
-func (iptun *Vti) Type() string {
-	return "vti"
+func (vti *Vti) Type() string {
+	if vti.Local.To4() == nil {
+		return "vti6"
+	} else {
+		return "vti"
+	}
 }
 
 type Gretun struct {
@@ -846,7 +850,7 @@ func (gtp *GTP) Type() string {
 // iproute2 supported devices;
 // vlan | veth | vcan | dummy | ifb | macvlan | macvtap |
 // bridge | bond | ipoib | ip6tnl | ipip | sit | vxlan |
-// gre | gretap | ip6gre | ip6gretap | vti | nlmon |
+// gre | gretap | ip6gre | ip6gretap | vti | vti6 | nlmon |
 // bond_slave | ipvlan
 
 // LinkNotFoundError wraps the various not found errors when

--- a/link_test.go
+++ b/link_test.go
@@ -1482,6 +1482,13 @@ func TestLinkAddDelVti(t *testing.T) {
 		OKey:      0x101,
 		Local:     net.IPv4(127, 0, 0, 1),
 		Remote:    net.IPv4(127, 0, 0, 1)})
+
+	testLinkAddDel(t, &Vti{
+		LinkAttrs: LinkAttrs{Name: "vtibar"},
+		IKey:      0x101,
+		OKey:      0x101,
+		Local:     net.IPv6loopback,
+		Remote:    net.IPv6loopback})
 }
 
 func TestBridgeCreationWithMulticastSnooping(t *testing.T) {


### PR DESCRIPTION
Updates VTI code to support "vti6"devices in addition to "vti".
Also fixes a bug in point-to-point address assignment/parsing. VTI devices functionality depends on the fix.