### PR TITLE
fix prefixlen for PtP addresses

### DIFF
--- a/addr_test.go
+++ b/addr_test.go
@@ -24,7 +24,7 @@ func DoTestAddr(t *testing.T, FunctionUndertest func(Link, *Addr) error) {
 		t.Skipf("Fails in travis with: addr_test.go:68: Address flags not set properly, got=0, expected=128")
 	}
 	// TODO: IFA_F_PERMANENT does not seem to be set by default on older kernels?
-	var address = &net.IPNet{IP: net.IPv4(127, 0, 0, 2), Mask: net.CIDRMask(24, 32)}
+	var address = &net.IPNet{IP: net.IPv4(127, 0, 0, 2), Mask: net.CIDRMask(32, 32)}
 	var peer = &net.IPNet{IP: net.IPv4(127, 0, 0, 3), Mask: net.CIDRMask(24, 32)}
 	var addrTests = []struct {
 		addr     *Addr


### PR DESCRIPTION
From libnl addr.c comment:
IPv6 sends the local address as IFA_ADDRESS with no
IFA_LOCAL, IPv4 sends both IFA_LOCAL and IFA_ADDRESS
with IFA_ADDRESS being the peer address if they differ

But obviously, IPv6 sends IFA_LOCAL in case of PtP.

From iproute2 manual:
If a peer address is specified, the local address
cannot have a prefix length. The network prefix is
associated with the peer rather than with the local
address.