### PR TITLE
Fix: Proper parsing of mark

### DIFF
--- a/conntrack_linux.go
+++ b/conntrack_linux.go
@@ -242,59 +242,60 @@ func parseByteAndPacketCounters(r *bytes.Reader) (bytes, packets uint64) {
 }
 
 func parseRawData(data []byte) *ConntrackFlow {
-	s := &ConntrackFlow{}
-	var proto uint8
-	// First there is the Nfgenmsg header
-	// consume only the family field
-	reader := bytes.NewReader(data)
-	binary.Read(reader, nl.NativeEndian(), &s.FamilyType)
+    s := &ConntrackFlow{}
+    var proto uint8
+    // First there is the Nfgenmsg header
+    // consume only the family field
+    reader := bytes.NewReader(data)
+    binary.Read(reader, nl.NativeEndian(), &s.FamilyType)
 
-	// skip rest of the Netfilter header
-	reader.Seek(3, seekCurrent)
-	// The message structure is the following:
-	// <len, NLA_F_NESTED|CTA_TUPLE_ORIG> 4 bytes
-	// <len, NLA_F_NESTED|CTA_TUPLE_IP> 4 bytes
-	// flow information of the forward flow
-	// <len, NLA_F_NESTED|CTA_TUPLE_REPLY> 4 bytes
-	// <len, NLA_F_NESTED|CTA_TUPLE_IP> 4 bytes
-	// flow information of the reverse flow
-	for reader.Len() > 0 {
-		if nested, t, l := parseNfAttrTL(reader); nested {
-			switch t {
-			case nl.CTA_TUPLE_ORIG:
-				if nested, t, _ = parseNfAttrTL(reader); nested && t == nl.CTA_TUPLE_IP {
-					proto = parseIpTuple(reader, &s.Forward)
-				}
-			case nl.CTA_TUPLE_REPLY:
-				if nested, t, _ = parseNfAttrTL(reader); nested && t == nl.CTA_TUPLE_IP {
-					parseIpTuple(reader, &s.Reverse)
-				} else {
-					// Header not recognized skip it
-					reader.Seek(int64(l), seekCurrent)
-				}
-			case nl.CTA_COUNTERS_ORIG:
-				s.Forward.Bytes, s.Forward.Packets = parseByteAndPacketCounters(reader)
-			case nl.CTA_COUNTERS_REPLY:
-				s.Reverse.Bytes, s.Reverse.Packets = parseByteAndPacketCounters(reader)
-			}
-		}
-	}
-	if proto == TCP_PROTO {
-		reader.Seek(64, seekCurrent)
-		_, t, _, v := parseNfAttrTLV(reader)
-		if t == nl.CTA_MARK {
-			s.Mark = uint32(v[3])
-		}
-	} else if proto == UDP_PROTO {
-		reader.Seek(16, seekCurrent)
-		_, t, _, v := parseNfAttrTLV(reader)
-		if t == nl.CTA_MARK {
-			s.Mark = uint32(v[3])
-		}
-	}
-	return s
+    // skip rest of the Netfilter header
+    reader.Seek(3, seekCurrent)
+    // The message structure is the following:
+    // <len, NLA_F_NESTED|CTA_TUPLE_ORIG> 4 bytes
+    // <len, NLA_F_NESTED|CTA_TUPLE_IP> 4 bytes
+    // flow information of the forward flow
+    // <len, NLA_F_NESTED|CTA_TUPLE_REPLY> 4 bytes
+    // <len, NLA_F_NESTED|CTA_TUPLE_IP> 4 bytes
+    // flow information of the reverse flow
+    for reader.Len() > 0 {
+        nested, t, l := parseNfAttrTL(reader)
+        if nested && t == nl.CTA_TUPLE_ORIG {
+            if nested, t, _ = parseNfAttrTL(reader); nested && t == nl.CTA_TUPLE_IP {
+                proto = parseIpTuple(reader, &s.Forward)
+            }
+        } else if nested && t == nl.CTA_TUPLE_REPLY {
+            if nested, t, _ = parseNfAttrTL(reader); nested && t == nl.CTA_TUPLE_IP {
+                parseIpTuple(reader, &s.Reverse)
+
+                // Got all the useful information stop parsing
+                break
+            } else {
+                // Header not recognized skip it
+                reader.Seek(int64(l), seekCurrent)
+            }
+        } else if nested && t == nl.CTA_COUNTERS_ORIG {
+            s.Forward.Bytes, s.Forward.Packets = parseByteAndPacketCounters(reader)
+        } else if nested && t == nl.CTA_COUNTERS_REPLY {
+            s.Reverse.Bytes, s.Reverse.Packets = parseByteAndPacketCounters(reader)
+        }
+    }
+
+    if proto == TCP_PROTO {
+        reader.Seek(64, seekCurrent)
+        _, t, _, v := parseNfAttrTLV(reader)
+        if t == nl.CTA_MARK {
+            s.Mark = uint32(v[3])
+        }
+    } else if proto == UDP_PROTO {
+        reader.Seek(16, seekCurrent)
+        _, t, _, v := parseNfAttrTLV(reader)
+        if t == nl.CTA_MARK {
+            s.Mark = uint32(v[3])
+        }
+    }
+    return s
 }
-
 // Conntrack parameters and options:
 //   -n, --src-nat ip                      source NAT ip
 //   -g, --dst-nat ip                      destination NAT ip

--- a/conntrack_linux.go
+++ b/conntrack_linux.go
@@ -279,20 +279,20 @@ func parseRawData(data []byte) *ConntrackFlow {
 				}
 			}
 	}
-		if proto == TCP_PROTO {
-			reader.Seek(64, seekCurrent)
-			_, t, _, v := parseNfAttrTLV(reader)
-			if t == nl.CTA_MARK {
-				s.Mark = uint32(v[3])
-			}
-		} else if proto == UDP_PROTO {
-			reader.Seek(16, seekCurrent)
-			_, t, _, v := parseNfAttrTLV(reader)
-			if t == nl.CTA_MARK {
-				s.Mark = uint32(v[3])
-			}
+	if proto == TCP_PROTO {
+		reader.Seek(64, seekCurrent)
+		_, t, _, v := parseNfAttrTLV(reader)
+		if t == nl.CTA_MARK {
+			s.Mark = uint32(v[3])
 		}
-		return s
+	} else if proto == UDP_PROTO {
+		reader.Seek(16, seekCurrent)
+		_, t, _, v := parseNfAttrTLV(reader)
+		if t == nl.CTA_MARK {
+			s.Mark = uint32(v[3])
+		}
+	}
+	return s
 }
 
 // Conntrack parameters and options:

--- a/conntrack_linux.go
+++ b/conntrack_linux.go
@@ -242,60 +242,59 @@ func parseByteAndPacketCounters(r *bytes.Reader) (bytes, packets uint64) {
 }
 
 func parseRawData(data []byte) *ConntrackFlow {
-    s := &ConntrackFlow{}
-    var proto uint8
-    // First there is the Nfgenmsg header
-    // consume only the family field
-    reader := bytes.NewReader(data)
-    binary.Read(reader, nl.NativeEndian(), &s.FamilyType)
+		s := &ConntrackFlow{}
+		var proto uint8
+		// First there is the Nfgenmsg header
+		// consume only the family field
+		reader := bytes.NewReader(data)
+		binary.Read(reader, nl.NativeEndian(), &s.FamilyType)
 
-    // skip rest of the Netfilter header
-    reader.Seek(3, seekCurrent)
-    // The message structure is the following:
-    // <len, NLA_F_NESTED|CTA_TUPLE_ORIG> 4 bytes
-    // <len, NLA_F_NESTED|CTA_TUPLE_IP> 4 bytes
-    // flow information of the forward flow
-    // <len, NLA_F_NESTED|CTA_TUPLE_REPLY> 4 bytes
-    // <len, NLA_F_NESTED|CTA_TUPLE_IP> 4 bytes
-    // flow information of the reverse flow
-    for reader.Len() > 0 {
-        nested, t, l := parseNfAttrTL(reader)
-        if nested && t == nl.CTA_TUPLE_ORIG {
-            if nested, t, _ = parseNfAttrTL(reader); nested && t == nl.CTA_TUPLE_IP {
-                proto = parseIpTuple(reader, &s.Forward)
-            }
-        } else if nested && t == nl.CTA_TUPLE_REPLY {
-            if nested, t, _ = parseNfAttrTL(reader); nested && t == nl.CTA_TUPLE_IP {
-                parseIpTuple(reader, &s.Reverse)
-
-                // Got all the useful information stop parsing
-                break
-            } else {
-                // Header not recognized skip it
-                reader.Seek(int64(l), seekCurrent)
-            }
-        } else if nested && t == nl.CTA_COUNTERS_ORIG {
-            s.Forward.Bytes, s.Forward.Packets = parseByteAndPacketCounters(reader)
-        } else if nested && t == nl.CTA_COUNTERS_REPLY {
-            s.Reverse.Bytes, s.Reverse.Packets = parseByteAndPacketCounters(reader)
-        }
-    }
-
-    if proto == TCP_PROTO {
-        reader.Seek(64, seekCurrent)
-        _, t, _, v := parseNfAttrTLV(reader)
-        if t == nl.CTA_MARK {
-            s.Mark = uint32(v[3])
-        }
-    } else if proto == UDP_PROTO {
-        reader.Seek(16, seekCurrent)
-        _, t, _, v := parseNfAttrTLV(reader)
-        if t == nl.CTA_MARK {
-            s.Mark = uint32(v[3])
-        }
-    }
-    return s
+		// skip rest of the Netfilter header
+		reader.Seek(3, seekCurrent)
+		// The message structure is the following:
+		// <len, NLA_F_NESTED|CTA_TUPLE_ORIG> 4 bytes
+		// <len, NLA_F_NESTED|CTA_TUPLE_IP> 4 bytes
+		// flow information of the forward flow
+		// <len, NLA_F_NESTED|CTA_TUPLE_REPLY> 4 bytes
+		// <len, NLA_F_NESTED|CTA_TUPLE_IP> 4 bytes
+		// flow information of the reverse flow
+		for reader.Len() > 0 {
+			if nested, t, l := parseNfAttrTL(reader); nested {
+				switch t {
+				case nl.CTA_TUPLE_ORIG:
+					if nested, t, _ = parseNfAttrTL(reader); nested && t == nl.CTA_TUPLE_IP {
+						proto = parseIpTuple(reader, &s.Forward)
+					}
+				case nl.CTA_TUPLE_REPLY:
+					if nested, t, _ = parseNfAttrTL(reader); nested && t == nl.CTA_TUPLE_IP {
+						parseIpTuple(reader, &s.Reverse)
+					} else {
+						// Header not recognized skip it
+						reader.Seek(int64(l), seekCurrent)
+					}
+				case nl.CTA_COUNTERS_ORIG:
+					s.Forward.Bytes, s.Forward.Packets = parseByteAndPacketCounters(reader)
+				case nl.CTA_COUNTERS_REPLY:
+					s.Reverse.Bytes, s.Reverse.Packets = parseByteAndPacketCounters(reader)
+				}
+			}
+	}
+		if proto == TCP_PROTO {
+			reader.Seek(64, seekCurrent)
+			_, t, _, v := parseNfAttrTLV(reader)
+			if t == nl.CTA_MARK {
+				s.Mark = uint32(v[3])
+			}
+		} else if proto == UDP_PROTO {
+			reader.Seek(16, seekCurrent)
+			_, t, _, v := parseNfAttrTLV(reader)
+			if t == nl.CTA_MARK {
+				s.Mark = uint32(v[3])
+			}
+		}
+		return s
 }
+
 // Conntrack parameters and options:
 //   -n, --src-nat ip                      source NAT ip
 //   -g, --dst-nat ip                      destination NAT ip

--- a/conntrack_linux.go
+++ b/conntrack_linux.go
@@ -281,20 +281,20 @@ func parseRawData(data []byte) *ConntrackFlow {
       }
   }
 
-  if proto == TCP_PROTO {
-      reader.Seek(64, seekCurrent)
-      _, t, _, v := parseNfAttrTLV(reader)
-      if t == nl.CTA_MARK {
-          s.Mark = uint32(v[3])
-      }
-  } else if proto == UDP_PROTO {
-      reader.Seek(16, seekCurrent)
-      _, t, _, v := parseNfAttrTLV(reader)
-      if t == nl.CTA_MARK {
-          s.Mark = uint32(v[3])
-      }
-  }
-  return s
+		if proto == TCP_PROTO {
+		    reader.Seek(64, seekCurrent)
+		    _, t, _, v := parseNfAttrTLV(reader)
+		    if t == nl.CTA_MARK {
+		        s.Mark = uint32(v[3])
+		    }
+		} else if proto == UDP_PROTO {
+		    reader.Seek(16, seekCurrent)
+		    _, t, _, v := parseNfAttrTLV(reader)
+		    if t == nl.CTA_MARK {
+		        s.Mark = uint32(v[3])
+		    }
+		}
+		return s
 }
 // Conntrack parameters and options:
 //   -n, --src-nat ip                      source NAT ip

--- a/conntrack_linux.go
+++ b/conntrack_linux.go
@@ -242,42 +242,42 @@ func parseByteAndPacketCounters(r *bytes.Reader) (bytes, packets uint64) {
 }
 
 func parseRawData(data []byte) *ConntrackFlow {
-		s := &ConntrackFlow{}
-		var proto uint8
-		// First there is the Nfgenmsg header
-		// consume only the family field
-		reader := bytes.NewReader(data)
-		binary.Read(reader, nl.NativeEndian(), &s.FamilyType)
+	s := &ConntrackFlow{}
+	var proto uint8
+	// First there is the Nfgenmsg header
+	// consume only the family field
+	reader := bytes.NewReader(data)
+	binary.Read(reader, nl.NativeEndian(), &s.FamilyType)
 
-		// skip rest of the Netfilter header
-		reader.Seek(3, seekCurrent)
-		// The message structure is the following:
-		// <len, NLA_F_NESTED|CTA_TUPLE_ORIG> 4 bytes
-		// <len, NLA_F_NESTED|CTA_TUPLE_IP> 4 bytes
-		// flow information of the forward flow
-		// <len, NLA_F_NESTED|CTA_TUPLE_REPLY> 4 bytes
-		// <len, NLA_F_NESTED|CTA_TUPLE_IP> 4 bytes
-		// flow information of the reverse flow
-		for reader.Len() > 0 {
-			if nested, t, l := parseNfAttrTL(reader); nested {
-				switch t {
-				case nl.CTA_TUPLE_ORIG:
-					if nested, t, _ = parseNfAttrTL(reader); nested && t == nl.CTA_TUPLE_IP {
-						proto = parseIpTuple(reader, &s.Forward)
-					}
-				case nl.CTA_TUPLE_REPLY:
-					if nested, t, _ = parseNfAttrTL(reader); nested && t == nl.CTA_TUPLE_IP {
-						parseIpTuple(reader, &s.Reverse)
-					} else {
-						// Header not recognized skip it
-						reader.Seek(int64(l), seekCurrent)
-					}
-				case nl.CTA_COUNTERS_ORIG:
-					s.Forward.Bytes, s.Forward.Packets = parseByteAndPacketCounters(reader)
-				case nl.CTA_COUNTERS_REPLY:
-					s.Reverse.Bytes, s.Reverse.Packets = parseByteAndPacketCounters(reader)
+	// skip rest of the Netfilter header
+	reader.Seek(3, seekCurrent)
+	// The message structure is the following:
+	// <len, NLA_F_NESTED|CTA_TUPLE_ORIG> 4 bytes
+	// <len, NLA_F_NESTED|CTA_TUPLE_IP> 4 bytes
+	// flow information of the forward flow
+	// <len, NLA_F_NESTED|CTA_TUPLE_REPLY> 4 bytes
+	// <len, NLA_F_NESTED|CTA_TUPLE_IP> 4 bytes
+	// flow information of the reverse flow
+	for reader.Len() > 0 {
+		if nested, t, l := parseNfAttrTL(reader); nested {
+			switch t {
+			case nl.CTA_TUPLE_ORIG:
+				if nested, t, _ = parseNfAttrTL(reader); nested && t == nl.CTA_TUPLE_IP {
+					proto = parseIpTuple(reader, &s.Forward)
 				}
+			case nl.CTA_TUPLE_REPLY:
+				if nested, t, _ = parseNfAttrTL(reader); nested && t == nl.CTA_TUPLE_IP {
+					parseIpTuple(reader, &s.Reverse)
+				} else {
+					// Header not recognized skip it
+					reader.Seek(int64(l), seekCurrent)
+				}
+			case nl.CTA_COUNTERS_ORIG:
+				s.Forward.Bytes, s.Forward.Packets = parseByteAndPacketCounters(reader)
+			case nl.CTA_COUNTERS_REPLY:
+				s.Reverse.Bytes, s.Reverse.Packets = parseByteAndPacketCounters(reader)
 			}
+		}
 	}
 	if proto == TCP_PROTO {
 		reader.Seek(64, seekCurrent)


### PR DESCRIPTION
--> This PR fixes the bug that breaks the parsing

`udp	17 src=127.0.0.1 dst=127.0.0.10 sport=2003 dport=3000 packets=0 bytes=0	src=127.0.0.10 dst=127.0.0.1 sport=3000 dport=2003 packets=0 bytes=0 mark=0`