### PR TITLE
Increase size of receive buffer

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -1553,6 +1553,8 @@ func (h *Handle) LinkList() ([]Link, error) {
 
 	msg := nl.NewIfInfomsg(unix.AF_UNSPEC)
 	req.AddData(msg)
+	attr := nl.NewRtAttr(unix.IFLA_EXT_MASK, nl.Uint32Attr(nl.RTEXT_FILTER_VF))
+	req.AddData(attr)
 
 	msgs, err := req.Execute(unix.NETLINK_ROUTE, unix.RTM_NEWLINK)
 	if err != nil {

--- a/nl/nl_linux.go
+++ b/nl/nl_linux.go
@@ -22,6 +22,10 @@ const (
 	FAMILY_V4   = unix.AF_INET
 	FAMILY_V6   = unix.AF_INET6
 	FAMILY_MPLS = AF_MPLS
+	// Arbitrary set value (greater than default 4k) to allow receiving
+	// from kernel more verbose messages e.g. for statistics,
+	// tc rules or filters, or other more memory requiring data.
+	RECEIVE_BUFFER_SIZE = 65536
 )
 
 // SupportedNlFamilies contains the list of netlink families this netlink package supports
@@ -615,7 +619,7 @@ func (s *NetlinkSocket) Receive() ([]syscall.NetlinkMessage, error) {
 	if fd < 0 {
 		return nil, fmt.Errorf("Receive called on a closed socket")
 	}
-	rb := make([]byte, unix.Getpagesize())
+	rb := make([]byte, RECEIVE_BUFFER_SIZE)
 	nr, _, err := unix.Recvfrom(fd, rb, 0)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Closes #354

Previous attemt to fix #354 was only hiding a true issue with too small buffer to pick up the message from kernel.
According to https://github.com/vishvananda/netlink/issues/354#issuecomment-401559441
such situation could occur not only during dump of VF list, but also when we are asking for:
 * statistics
 * tc rules and tc filters
 * large conn track dump
 * rdma resource details dump for debugging
or any other place where kernel can return more data than default (4kB) sized buffer could hold.

iproute2 in this case for rtnl_dump_filter_l has buffer with size of 16kB, but we don't have distinction between different receiving funcs, so I'm proposing to stick with original issue cause finder (kudos to Parav Pandit aka paravmellanox) who is proposing 64kB as a buffer size.

That's improvement in handling of received packets which should keep us safe with issues like #354 but the real solution should be to add in future handling of truncate flag (msg.msg_flags & MSG_TRUNC) if kernel wants to sent us something even bigger than 64k.