### PR TITLE
[RFC] protinfo: Check if object is nil

### DIFF
--- a/protinfo.go
+++ b/protinfo.go
@@ -18,6 +18,10 @@ type Protinfo struct {
 
 // String returns a list of enabled flags
 func (prot *Protinfo) String() string {
+	if prot == nil {
+		return "<nil>"
+	}
+
 	var boolStrings []string
 	if prot.Hairpin {
 		boolStrings = append(boolStrings, "Hairpin")


### PR DESCRIPTION
Avoid segfaults in certain environments by checking if the Stringer
interface pointer receiver function is `nil`.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>