### PR TITLE
Netlink: Fix non-linux builds for FOU

### DIFF
--- a/fou.go
+++ b/fou.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package netlink
 
 import (


### PR DESCRIPTION
Having fou.go build only for linux breaks builds for darwin:
```
$ go build main.go
src/github.com/vishvananda/netlink/fou_unspecified.go:5:15: undefined: Fou
src/github.com/vishvananda/netlink/fou_unspecified.go:9:15: undefined: Fou
src/github.com/vishvananda/netlink/fou_unspecified.go:13:26: undefined: Fou
```

Instead, build fou.go for all platforms since it doesn't have platform-specific code:
```
$ go build main.go
$ ./main
not implemented
```