### PR TITLE
Add support for action and ifindex in XFRM policy

### DIFF
--- a/xfrm_policy.go
+++ b/xfrm_policy.go
@@ -35,6 +35,25 @@ func (d Dir) String() string {
 	return fmt.Sprintf("socket %d", d-XFRM_SOCKET_IN)
 }
 
+// PolicyAction is an enum representing an ipsec policy action.
+type PolicyAction uint8
+
+const (
+	XFRM_POLICY_ALLOW PolicyAction = 0
+	XFRM_POLICY_BLOCK PolicyAction = 1
+)
+
+func (a PolicyAction) String() string {
+	switch a {
+	case XFRM_POLICY_ALLOW:
+		return "allow"
+	case XFRM_POLICY_BLOCK:
+		return "block"
+	default:
+		return fmt.Sprintf("action %d", a)
+	}
+}
+
 // XfrmPolicyTmpl encapsulates a rule for the base addresses of an ipsec
 // policy. These rules are matched with XfrmState to determine encryption
 // and authentication algorithms.
@@ -64,11 +83,13 @@ type XfrmPolicy struct {
 	Dir      Dir
 	Priority int
 	Index    int
+	Action   PolicyAction
+	Ifindex  int
 	Mark     *XfrmMark
 	Tmpls    []XfrmPolicyTmpl
 }
 
 func (p XfrmPolicy) String() string {
-	return fmt.Sprintf("{Dst: %v, Src: %v, Proto: %s, DstPort: %d, SrcPort: %d, Dir: %s, Priority: %d, Index: %d, Mark: %s, Tmpls: %s}",
-		p.Dst, p.Src, p.Proto, p.DstPort, p.SrcPort, p.Dir, p.Priority, p.Index, p.Mark, p.Tmpls)
+	return fmt.Sprintf("{Dst: %v, Src: %v, Proto: %s, DstPort: %d, SrcPort: %d, Dir: %s, Priority: %d, Index: %d, Action: %s, Ifindex: %d, Mark: %s, Tmpls: %s}",
+		p.Dst, p.Src, p.Proto, p.DstPort, p.SrcPort, p.Dir, p.Priority, p.Index, p.Action, p.Ifindex, p.Mark, p.Tmpls)
 }

--- a/xfrm_policy_linux.go
+++ b/xfrm_policy_linux.go
@@ -27,6 +27,7 @@ func selFromPolicy(sel *nl.XfrmSelector, policy *XfrmPolicy) {
 	if sel.Sport != 0 {
 		sel.SportMask = ^uint16(0)
 	}
+	sel.Ifindex = int32(policy.Ifindex)
 }
 
 // XfrmPolicyAdd will add an xfrm policy to the system.
@@ -61,6 +62,7 @@ func (h *Handle) xfrmPolicyAddOrUpdate(policy *XfrmPolicy, nlProto int) error {
 	msg.Priority = uint32(policy.Priority)
 	msg.Index = uint32(policy.Index)
 	msg.Dir = uint8(policy.Dir)
+	msg.Action = uint8(policy.Action)
 	msg.Lft.SoftByteLimit = nl.XFRM_INF
 	msg.Lft.HardByteLimit = nl.XFRM_INF
 	msg.Lft.SoftPacketLimit = nl.XFRM_INF
@@ -220,9 +222,11 @@ func parseXfrmPolicy(m []byte, family int) (*XfrmPolicy, error) {
 	policy.Proto = Proto(msg.Sel.Proto)
 	policy.DstPort = int(nl.Swap16(msg.Sel.Dport))
 	policy.SrcPort = int(nl.Swap16(msg.Sel.Sport))
+	policy.Ifindex = int(msg.Sel.Ifindex)
 	policy.Priority = int(msg.Priority)
 	policy.Index = int(msg.Index)
 	policy.Dir = Dir(msg.Dir)
+	policy.Action = PolicyAction(msg.Action)
 
 	attrs, err := nl.ParseRouteAttr(m[msg.Len():])
 	if err != nil {


### PR DESCRIPTION
The purpose of this PR is to allow the user to create "block" action IPSec policies and/or IPSec policies that apply only to packets traversing a specific interface.

The action and ifindex fields aren't represented in the netlink.XfrmPolicy struct although they exist in the the linux equivalent data structures and are, of course, represented in the serialized versions of those datatypes.  So this patch simply exposes those fields to the user-consumable side of the API.  

This patch makes the policy's action a specific type in the same style as the Dir field in XfrmPolicy.

Signed-off-by: Chris Telfer <ctelfer@docker.com>