### PR TITLE
Service curves fix + expansion

### DIFF
--- a/class.go
+++ b/class.go
@@ -154,33 +154,48 @@ type HfscClass struct {
 
 // SetUsc sets the Usc curve
 func (hfsc *HfscClass) SetUsc(m1 uint32, d uint32, m2 uint32) {
-	hfsc.Usc = ServiceCurve{m1: m1 / 8, d: d, m2: m2 / 8}
+	hfsc.Usc = ServiceCurve{m1: m1, d: d, m2: m2}
 }
 
 // SetFsc sets the Fsc curve
 func (hfsc *HfscClass) SetFsc(m1 uint32, d uint32, m2 uint32) {
-	hfsc.Fsc = ServiceCurve{m1: m1 / 8, d: d, m2: m2 / 8}
+	hfsc.Fsc = ServiceCurve{m1: m1, d: d, m2: m2}
 }
 
 // SetRsc sets the Rsc curve
 func (hfsc *HfscClass) SetRsc(m1 uint32, d uint32, m2 uint32) {
-	hfsc.Rsc = ServiceCurve{m1: m1 / 8, d: d, m2: m2 / 8}
+	hfsc.Rsc = ServiceCurve{m1: m1, d: d, m2: m2}
 }
 
 // SetSC implements the SC from the tc CLI
 func (hfsc *HfscClass) SetSC(m1 uint32, d uint32, m2 uint32) {
-	hfsc.Rsc = ServiceCurve{m1: m1 / 8, d: d, m2: m2 / 8}
-	hfsc.Fsc = ServiceCurve{m1: m1 / 8, d: d, m2: m2 / 8}
+	hfsc.Rsc = ServiceCurve{m1: m1, d: d, m2: m2}
+	hfsc.Fsc = ServiceCurve{m1: m1, d: d, m2: m2}
+}
+
+// SetSCRate is the tc implementation tc cli hfsc sc rate <vale>
+func (hfsc *HfscClass) SetSCRate(rate uint32) {
+	hfsc.SetSC(0, 0, rate)
 }
 
 // SetUL implements the UL from the tc CLI
 func (hfsc *HfscClass) SetUL(m1 uint32, d uint32, m2 uint32) {
-	hfsc.Usc = ServiceCurve{m1: m1 / 8, d: d, m2: m2 / 8}
+	hfsc.Usc = ServiceCurve{m1: m1, d: d, m2: m2}
+}
+
+// SetULRate is the tc implementation tc cli hfsc ul rate <vale>
+func (hfsc *HfscClass) SetULRate(rate uint32) {
+	hfsc.SetUL(0, 0, rate)
 }
 
 // SetLS implemtens the LS from the tc CLI
 func (hfsc *HfscClass) SetLS(m1 uint32, d uint32, m2 uint32) {
-	hfsc.Fsc = ServiceCurve{m1: m1 / 8, d: d, m2: m2 / 8}
+	hfsc.Fsc = ServiceCurve{m1: m1, d: d, m2: m2}
+}
+
+// SetLSRate is the tc implementation tc cli hfsc ls rate <vale>
+func (hfsc *HfscClass) SetLSRate(rate uint32) {
+	hfsc.SetLS(0, 0, rate)
 }
 
 // NewHfscClass returns a new HFSC struct with the set parameters

--- a/class_linux.go
+++ b/class_linux.go
@@ -179,9 +179,12 @@ func classPayload(req *nl.NetlinkRequest, class Class) error {
 	case "hfsc":
 		hfsc := class.(*HfscClass)
 		opt := nl.HfscCopt{}
-		opt.Rsc.Set(hfsc.Rsc.Attrs())
-		opt.Fsc.Set(hfsc.Fsc.Attrs())
-		opt.Usc.Set(hfsc.Usc.Attrs())
+		rm1, rd, rm2 := hfsc.Rsc.Attrs()
+		opt.Rsc.Set(rm1/8, rd/8, rm2/8)
+		fm1, fd, fm2 := hfsc.Rsc.Attrs()
+		opt.Fsc.Set(fm1/8, fd/8, fm2/8)
+		um1, ud, um2 := hfsc.Rsc.Attrs()
+		opt.Usc.Set(um1/8, ud/8, um2/8)
 		nl.NewRtAttrChild(options, nl.TCA_HFSC_RSC, nl.SerializeHfscCurve(&opt.Rsc))
 		nl.NewRtAttrChild(options, nl.TCA_HFSC_FSC, nl.SerializeHfscCurve(&opt.Fsc))
 		nl.NewRtAttrChild(options, nl.TCA_HFSC_USC, nl.SerializeHfscCurve(&opt.Usc))
@@ -315,11 +318,11 @@ func parseHfscClassData(class Class, data []syscall.NetlinkRouteAttr) (bool, err
 		m1, d, m2 := nl.DeserializeHfscCurve(datum.Value).Attrs()
 		switch datum.Attr.Type {
 		case nl.TCA_HFSC_RSC:
-			hfsc.Rsc = ServiceCurve{m1: m1, d: d, m2: m2}
+			hfsc.Rsc = ServiceCurve{m1: m1 * 8, d: d, m2: m2 * 8}
 		case nl.TCA_HFSC_FSC:
-			hfsc.Fsc = ServiceCurve{m1: m1, d: d, m2: m2}
+			hfsc.Fsc = ServiceCurve{m1: m1 * 8, d: d, m2: m2 * 8}
 		case nl.TCA_HFSC_USC:
-			hfsc.Usc = ServiceCurve{m1: m1, d: d, m2: m2}
+			hfsc.Usc = ServiceCurve{m1: m1 * 8, d: d, m2: m2 * 8}
 		}
 	}
 	return detailed, nil

--- a/class_test.go
+++ b/class_test.go
@@ -499,12 +499,13 @@ func TestClassHfsc(t *testing.T) {
 	}
 
 	// Adding some HFSC classes
-	classAttrs := ClassAttrs{
-		LinkIndex: link.Attrs().Index,
-		Parent:    MakeHandle(1, 0),
-		Handle:    MakeHandle(1, 1),
+	hfscClass := &HfscClass{
+		ClassAttrs: ClassAttrs{
+			LinkIndex: link.Attrs().Index,
+			Handle:    MakeHandle(1, 1),
+			Parent:    MakeHandle(1, 0),
+		},
 	}
-	hfscClass := NewHfscClass(classAttrs)
 	hfscClass.SetLS(5e6, 10, 5e6)
 
 	err = ClassAdd(hfscClass)


### PR DESCRIPTION
Added a function that simply sets a rate on a curve, so the behaviour oc tc class add .. sc/ls/ul rate is mimmicked.

There was something of with the math for the ServiceCurves. The set value was 8 times to large and the returned one was 8 times to small. This is now fixed in class_linux.go so the user can just set the rate in bit and it will match the tc show output

I know this is kinda breaking the previous service curves, but this makes more sense. The end user shouldn't have to calculate the need values, the unerlaying layers should do that.