### PR TITLE
Avoid serializing empty TCA_OPTIONS in qdisc messages

### DIFF
--- a/qdisc_linux.go
+++ b/qdisc_linux.go
@@ -278,9 +278,13 @@ func qdiscPayload(req *nl.NetlinkRequest, qdisc Qdisc) error {
 		if qdisc.FlowDefaultRate > 0 {
 			nl.NewRtAttrChild(options, nl.TCA_FQ_FLOW_DEFAULT_RATE, nl.Uint32Attr((uint32(qdisc.FlowDefaultRate))))
 		}
+	default:
+		options = nil
 	}
 
-	req.AddData(options)
+	if options != nil {
+		req.AddData(options)
+	}
 	return nil
 }
 


### PR DESCRIPTION
This was causing a QdiscReplace() call for a generic qdisc
(QdiscType="clsact", Parent=HANDLE_CLSACT) to fail with the error
"invalid argument" after the qdisc was first created.