### PR TITLE
fix: BRIDGE_FLAGS_* constants off-by-one

### DIFF
--- a/nl/bridge_linux.go
+++ b/nl/bridge_linux.go
@@ -11,8 +11,8 @@ const (
 
 /* Bridge Flags */
 const (
-	BRIDGE_FLAGS_MASTER = iota /* Bridge command to/from master */
-	BRIDGE_FLAGS_SELF          /* Bridge command to/from lowerdev */
+	BRIDGE_FLAGS_MASTER = iota + 1 /* Bridge command to/from master */
+	BRIDGE_FLAGS_SELF              /* Bridge command to/from lowerdev */
 )
 
 /* Bridge management nested attributes


### PR DESCRIPTION
These flags are off-by-one because iota starts at 0.

See https://github.com/torvalds/linux/blob/master/include/uapi/linux/if_bridge.h#L104 for expected values.

The result is that it becomes impossible to modify VLANs on the bridge interface itself, where the `self=true` flag is required.