### PR TITLE
Add support for hoplimit metric in routes

### DIFF
--- a/route.go
+++ b/route.go
@@ -47,6 +47,7 @@ type Route struct {
 	Encap      Encap
 	MTU        int
 	AdvMSS     int
+	Hoplimit   int
 }
 
 func (r Route) String() string {
@@ -89,6 +90,7 @@ func (r Route) Equal(x Route) bool {
 		r.Table == x.Table &&
 		r.Type == x.Type &&
 		r.Tos == x.Tos &&
+		r.Hoplimit == x.Hoplimit &&
 		r.Flags == x.Flags &&
 		(r.MPLSDst == x.MPLSDst || (r.MPLSDst != nil && x.MPLSDst != nil && *r.MPLSDst == *x.MPLSDst)) &&
 		(r.NewDst == x.NewDst || (r.NewDst != nil && r.NewDst.Equal(x.NewDst))) &&

--- a/route_test.go
+++ b/route_test.go
@@ -509,19 +509,21 @@ func TestRouteFilterAllTables(t *testing.T) {
 			Table:     table,
 			Type:      unix.RTN_UNICAST,
 			Tos:       14,
+			Hoplimit:  100,
 		}
 		if err := RouteAdd(&route); err != nil {
 			t.Fatal(err)
 		}
 	}
 	routes, err := RouteListFiltered(FAMILY_V4, &Route{
-		Dst:   dst,
-		Src:   src,
-		Scope: unix.RT_SCOPE_LINK,
-		Table: unix.RT_TABLE_UNSPEC,
-		Type:  unix.RTN_UNICAST,
-		Tos:   14,
-	}, RT_FILTER_DST|RT_FILTER_SRC|RT_FILTER_SCOPE|RT_FILTER_TABLE|RT_FILTER_TYPE|RT_FILTER_TOS)
+		Dst:      dst,
+		Src:      src,
+		Scope:    unix.RT_SCOPE_LINK,
+		Table:    unix.RT_TABLE_UNSPEC,
+		Type:     unix.RTN_UNICAST,
+		Tos:      14,
+		Hoplimit: 100,
+	}, RT_FILTER_DST|RT_FILTER_SRC|RT_FILTER_SCOPE|RT_FILTER_TABLE|RT_FILTER_TYPE|RT_FILTER_TOS|RT_FILTER_HOPLIMIT)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -544,6 +546,9 @@ func TestRouteFilterAllTables(t *testing.T) {
 		}
 		if route.Tos != 14 {
 			t.Fatal("Invalid Tos. Route not added properly")
+		}
+		if route.Hoplimit != 100 {
+			t.Fatal("Invalid Hoplimit. Route not added properly")
 		}
 	}
 }
@@ -587,18 +592,20 @@ func TestRouteExtraFields(t *testing.T) {
 		Table:     unix.RT_TABLE_MAIN,
 		Type:      unix.RTN_UNICAST,
 		Tos:       14,
+		Hoplimit:  100,
 	}
 	if err := RouteAdd(&route); err != nil {
 		t.Fatal(err)
 	}
 	routes, err := RouteListFiltered(FAMILY_V4, &Route{
-		Dst:   dst,
-		Src:   src,
-		Scope: unix.RT_SCOPE_LINK,
-		Table: unix.RT_TABLE_MAIN,
-		Type:  unix.RTN_UNICAST,
-		Tos:   14,
-	}, RT_FILTER_DST|RT_FILTER_SRC|RT_FILTER_SCOPE|RT_FILTER_TABLE|RT_FILTER_TYPE|RT_FILTER_TOS)
+		Dst:      dst,
+		Src:      src,
+		Scope:    unix.RT_SCOPE_LINK,
+		Table:    unix.RT_TABLE_MAIN,
+		Type:     unix.RTN_UNICAST,
+		Tos:      14,
+		Hoplimit: 100,
+	}, RT_FILTER_DST|RT_FILTER_SRC|RT_FILTER_SCOPE|RT_FILTER_TABLE|RT_FILTER_TYPE|RT_FILTER_TOS|RT_FILTER_HOPLIMIT)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -620,6 +627,9 @@ func TestRouteExtraFields(t *testing.T) {
 	}
 	if routes[0].Tos != 14 {
 		t.Fatal("Invalid Tos. Route not added properly")
+	}
+	if routes[0].Hoplimit != 100 {
+		t.Fatal("Invalid Hoplimit. Route not added properly")
 	}
 }
 
@@ -842,6 +852,12 @@ func TestRouteEqual(t *testing.T) {
 		{
 			LinkIndex: 20,
 			Dst:       nil,
+			Hoplimit:  1,
+			Gw:        net.IPv4(1, 1, 1, 1),
+		},
+		{
+			LinkIndex: 20,
+			Dst:       nil,
 			Flags:     int(FLAG_ONLINK),
 			Gw:        net.IPv4(1, 1, 1, 1),
 		},
@@ -874,6 +890,19 @@ func TestRouteEqual(t *testing.T) {
 			Table:    unix.RT_TABLE_MAIN,
 			Type:     unix.RTN_UNICAST,
 			Tos:      14,
+		},
+		{
+			LinkIndex: 3,
+			Dst: &net.IPNet{
+				IP:   net.IPv4(1, 1, 1, 1),
+				Mask: net.CIDRMask(32, 32),
+			},
+			Src:      net.IPv4(127, 3, 3, 3),
+			Scope:    unix.RT_SCOPE_LINK,
+			Priority: 13,
+			Table:    unix.RT_TABLE_MAIN,
+			Type:     unix.RTN_UNICAST,
+			Hoplimit: 100,
 		},
 		{
 			LinkIndex: 10,


### PR DESCRIPTION
Using Hoplimit in routes is a much lesser used functionality in linux. The default hoplimit is 0 which means use system defaults: net.ipv4.ip_default_ttl for ipv4 and net.ipv6.conf.all.hop_limit for ipv6

Equivalent in iproute2: ip route add 192.168.0.0/24 via 192.168.10.1 hoplimit 2