### PR TITLE
add simple subscription functions to listen to neighbor table change

### DIFF
--- a/neigh.go
+++ b/neigh.go
@@ -23,3 +23,9 @@ type Neigh struct {
 func (neigh *Neigh) String() string {
 	return fmt.Sprintf("%s %s", neigh.IP, neigh.HardwareAddr)
 }
+
+//a struct to record neighbor table change 
+type NeighUpdate struct {
+     Type uint16
+     Neigh
+}

--- a/neigh_linux.go
+++ b/neigh_linux.go
@@ -299,7 +299,7 @@ func NeighSubscribe(ch chan<- NeighUpdate, done <-chan struct{}) error {
 
 func neighSubscribeAt(newNs, curNs netns.NsHandle, ch chan<- NeighUpdate, done <-chan struct{}, cberr func(error)) error {
 
-     	s, err := nl.SubscribeAt(newNs, curNs, unix.RTNLGRP_NEIGH)
+     	s, err := nl.SubscribeAt(newNs, curNs, unix.NETLINK_ROUTE, unix.RTNLGRP_NEIGH)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I am trying to add subscription functions to enable a neighbor table listener. The code added is similar to the subscription functions for route listener. I have tested the addition by using the following example:

package main

import (
        "fmt"
        "golang.org/x/sys/unix"
        "github.com/vishvananda/netlink"

)

func main() {

        netlinkNeigh()

}

func netlinkNeigh() {

        ch := make(chan netlink.NeighUpdate)
        done := make(chan struct{})

        defer close(done)

        if err := netlink.NeighSubscribe(ch, done); err != nil {
           fmt.Println("Cannot subscribe:")
        }

        for {
                select {
                case update := <-ch:
                        if update.Type == unix.RTM_NEWNEIGH {
                           fmt.Println(update.Neigh)
                                                }
                        if update.Type == unix.RTM_DELNEIGH {
                           fmt.Println("del arp")
                        }
                }
        }
}

The changes I made are not complete enough to create neighbor listener in different scenarios (e.g. namespaces). I created this pull request just to have your comments on this change first. From a user's perspective, I think it is useful to have handy subscription methods for neighbor table. I am willing to continue work on this to make it complete if you think it is worth to do.     