### PR TITLE
Refactoring

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -1524,7 +1524,8 @@ func LinkDeserialize(hdr *unix.NlMsghdr, m []byte) (Link, error) {
 				if err != nil {
 					return nil, err
 				}
-				base.Protinfo = parseProtinfo(attrs)
+				protinfo := parseProtinfo(attrs)
+				base.Protinfo = &protinfo
 			}
 		case unix.IFLA_OPERSTATE:
 			base.OperState = LinkOperState(uint8(attr.Value[0]))

--- a/nl/nl_linux.go
+++ b/nl/nl_linux.go
@@ -364,16 +364,12 @@ func (req *NetlinkRequest) Serialize() []byte {
 }
 
 func (req *NetlinkRequest) AddData(data NetlinkRequestData) {
-	if data != nil {
-		req.Data = append(req.Data, data)
-	}
+	req.Data = append(req.Data, data)
 }
 
 // AddRawData adds raw bytes to the end of the NetlinkRequest object during serialization
 func (req *NetlinkRequest) AddRawData(data []byte) {
-	if data != nil {
-		req.RawData = append(req.RawData, data...)
-	}
+	req.RawData = append(req.RawData, data...)
 }
 
 // Execute the request against a the given sockType.

--- a/protinfo_linux.go
+++ b/protinfo_linux.go
@@ -41,7 +41,7 @@ func (h *Handle) LinkGetProtinfo(link Link) (Protinfo, error) {
 			if err != nil {
 				return pi, err
 			}
-			pi = *parseProtinfo(infos)
+			pi = parseProtinfo(infos)
 
 			return pi, nil
 		}
@@ -49,8 +49,7 @@ func (h *Handle) LinkGetProtinfo(link Link) (Protinfo, error) {
 	return pi, fmt.Errorf("Device with index %d not found", base.Index)
 }
 
-func parseProtinfo(infos []syscall.NetlinkRouteAttr) *Protinfo {
-	var pi Protinfo
+func parseProtinfo(infos []syscall.NetlinkRouteAttr) (pi Protinfo) {
 	for _, info := range infos {
 		switch info.Attr.Type {
 		case nl.IFLA_BRPORT_MODE:
@@ -71,5 +70,5 @@ func parseProtinfo(infos []syscall.NetlinkRouteAttr) *Protinfo {
 			pi.ProxyArpWiFi = byteToBool(info.Value[0])
 		}
 	}
-	return &pi
+	return
 }

--- a/xfrm_policy_linux.go
+++ b/xfrm_policy_linux.go
@@ -199,12 +199,7 @@ func (h *Handle) xfrmPolicyGetOrDelete(policy *XfrmPolicy, nlProto int) (*XfrmPo
 		return nil, err
 	}
 
-	p, err := parseXfrmPolicy(msgs[0], FAMILY_ALL)
-	if err != nil {
-		return nil, err
-	}
-
-	return p, nil
+	return parseXfrmPolicy(msgs[0], FAMILY_ALL)
 }
 
 func parseXfrmPolicy(m []byte, family int) (*XfrmPolicy, error) {

--- a/xfrm_state_linux.go
+++ b/xfrm_state_linux.go
@@ -184,12 +184,7 @@ func (h *Handle) xfrmStateAllocSpi(state *XfrmState) (*XfrmState, error) {
 		return nil, err
 	}
 
-	s, err := parseXfrmState(msgs[0], FAMILY_ALL)
-	if err != nil {
-		return nil, err
-	}
-
-	return s, err
+	return parseXfrmState(msgs[0], FAMILY_ALL)
 }
 
 // XfrmStateDel will delete an xfrm state from the system. Note that
@@ -394,11 +389,7 @@ func (h *Handle) XfrmStateFlush(proto Proto) error {
 	req.AddData(&nl.XfrmUsersaFlush{Proto: uint8(proto)})
 
 	_, err := req.Execute(unix.NETLINK_XFRM, 0)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func limitsToLft(lmts XfrmStateLimits, lft *nl.XfrmLifetimeCfg) {


### PR DESCRIPTION
This might break external code using `nl.NewRtAttrChild()`.