### PR TITLE
Add an API to rename rdma device name

### DIFF
--- a/nl/rdma_link_linux.go
+++ b/nl/rdma_link_linux.go
@@ -10,6 +10,7 @@ const (
 
 const (
 	RDMA_NLDEV_CMD_GET = 1
+	RDMA_NLDEV_CMD_SET = 2
 )
 
 const (

--- a/rdma_link_test.go
+++ b/rdma_link_test.go
@@ -32,3 +32,22 @@ func TestRdmaGetRdmaLink(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestRdmaSetRdmaLinkName(t *testing.T) {
+	minKernelRequired(t, 4, 19)
+	setupRdmaKModule(t, "ib_core")
+	link, err := RdmaLinkByName("foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Set new name
+	err = RdmaLinkSetName(link, "bar")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Revert back to old name
+	err = RdmaLinkSetName(link, "foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Add an API RdmaLinkSetName() and test case to rename a
rdma device name.

Signed-off-by: Parav Pandit <parav@mellanox.com>