### PR TITLE
Make the RoutingTable a uint32. It's defined that way in the kernel.

### DIFF
--- a/route.go
+++ b/route.go
@@ -38,7 +38,7 @@ type Route struct {
 	MultiPath  []*NexthopInfo
 	Protocol   int
 	Priority   int
-	Table      int
+	Table      uint32
 	Type       int
 	Tos        int
 	Flags      int

--- a/route_linux.go
+++ b/route_linux.go
@@ -266,7 +266,7 @@ type SEG6LocalEncap struct {
 	Flags    [nl.SEG6_LOCAL_MAX]bool
 	Action   int
 	Segments []net.IP // from SRH in seg6_local_lwt
-	Table    int      // table id for End.T and End.DT6
+	Table    uint32   // table id for End.T and End.DT6
 	InAddr   net.IP
 	In6Addr  net.IP
 	Iif      int
@@ -291,7 +291,7 @@ func (e *SEG6LocalEncap) Decode(buf []byte) error {
 			e.Segments, err = nl.DecodeSEG6Srh(attr.Value[:])
 			e.Flags[nl.SEG6_LOCAL_SRH] = true
 		case nl.SEG6_LOCAL_TABLE:
-			e.Table = int(native.Uint32(attr.Value[0:4]))
+			e.Table = native.Uint32(attr.Value[0:4])
 			e.Flags[nl.SEG6_LOCAL_TABLE] = true
 		case nl.SEG6_LOCAL_NH4:
 			e.InAddr = net.IP(attr.Value[0:4])
@@ -781,7 +781,7 @@ func deserializeRoute(m []byte) (Route, error) {
 	route := Route{
 		Scope:    Scope(msg.Scope),
 		Protocol: int(msg.Protocol),
-		Table:    int(msg.Table),
+		Table:    uint32(msg.Table),
 		Type:     int(msg.Type),
 		Tos:      int(msg.Tos),
 		Flags:    int(msg.Flags),
@@ -815,7 +815,7 @@ func deserializeRoute(m []byte) (Route, error) {
 		case unix.RTA_PRIORITY:
 			route.Priority = int(native.Uint32(attr.Value[0:4]))
 		case unix.RTA_TABLE:
-			route.Table = int(native.Uint32(attr.Value[0:4]))
+			route.Table = native.Uint32(attr.Value[0:4])
 		case unix.RTA_MULTIPATH:
 			parseRtNexthop := func(value []byte) (*NexthopInfo, []byte, error) {
 				if len(value) < unix.SizeofRtNexthop {

--- a/route_test.go
+++ b/route_test.go
@@ -497,7 +497,7 @@ func TestRouteFilterAllTables(t *testing.T) {
 		Mask: net.CIDRMask(32, 32),
 	}
 
-	tables := []int{1000, 1001, 1002}
+	tables := []uint32{1000, 1001, 1002}
 	src := net.IPv4(127, 3, 3, 3)
 	for _, table := range tables {
 		route := Route{
@@ -553,7 +553,7 @@ func TestRouteFilterAllTables(t *testing.T) {
 	}
 }
 
-func tableIDIn(ids []int, id int) bool {
+func tableIDIn(ids []uint32, id uint32) bool {
 	for _, v := range ids {
 		if v == id {
 			return true

--- a/rule.go
+++ b/rule.go
@@ -9,7 +9,7 @@ import (
 type Rule struct {
 	Priority          int
 	Family            int
-	Table             int
+	Table             uint32
 	Mark              int
 	Mask              int
 	TunID             uint

--- a/rule_linux.go
+++ b/rule_linux.go
@@ -188,7 +188,7 @@ func (h *Handle) RuleList(family int) ([]Rule, error) {
 		for j := range attrs {
 			switch attrs[j].Attr.Type {
 			case unix.RTA_TABLE:
-				rule.Table = int(native.Uint32(attrs[j].Value[0:4]))
+				rule.Table = native.Uint32(attrs[j].Value[0:4])
 			case nl.FRA_SRC:
 				rule.Src = &net.IPNet{
 					IP:   attrs[j].Value,


### PR DESCRIPTION
The Kernel defines the routing table as an uint32_t, so should we do in
our go implementation.
Not sure if i catched everything here, but a grep looks promising.
Unfortunately the tests are failing on my machine. Looks like some
kernel options aren't supported by my kernel. Let's see what the CI says
about this commit :)