### PR TITLE
Make test suite more deterministic

### DIFF
--- a/route_test.go
+++ b/route_test.go
@@ -227,6 +227,7 @@ func TestRouteAddIncomplete(t *testing.T) {
 	}
 }
 
+// expectNeighUpdate returns whether the expected updated is received within one minute.
 func expectRouteUpdate(ch <-chan RouteUpdate, t uint16, dst net.IP) bool {
 	for {
 		timeout := time.After(time.Minute)


### PR DESCRIPTION
expectNeighUpdate might fail on unexpected updates:
```
=== RUN   TestNeighSubscribeWithOptions
--- FAIL: TestNeighSubscribeWithOptions (0.22s)
	neigh_test.go:371: Add update not received as expected: want 28 got 0
	neigh_test.go:337: Fatal error received during subscription: Link not found
```