### PR TITLE
Replace redundant copied u32 types with type aliases

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -182,51 +182,6 @@ func NewMirredAction(redirIndex int) *MirredAction {
 	}
 }
 
-// Sel of the U32 filters that contains multiple TcU32Key. This is the copy
-// and the frontend representation of nl.TcU32Sel. It is serialized into canonical
-// nl.TcU32Sel with the appropriate endianness.
-type TcU32Sel struct {
-	Flags    uint8
-	Offshift uint8
-	Nkeys    uint8
-	Pad      uint8
-	Offmask  uint16
-	Off      uint16
-	Offoff   int16
-	Hoff     int16
-	Hmask    uint32
-	Keys     []TcU32Key
-}
-
-// TcU32Key contained of Sel in the U32 filters. This is the copy and the frontend
-// representation of nl.TcU32Key. It is serialized into chanonical nl.TcU32Sel
-// with the appropriate endianness.
-type TcU32Key struct {
-	Mask    uint32
-	Val     uint32
-	Off     int32
-	OffMask int32
-}
-
-// U32 filters on many packet related properties
-type U32 struct {
-	FilterAttrs
-	ClassId    uint32
-	Divisor    uint32 // Divisor MUST be power of 2.
-	Hash       uint32
-	RedirIndex int
-	Sel        *TcU32Sel
-	Actions    []Action
-}
-
-func (filter *U32) Attrs() *FilterAttrs {
-	return &filter.FilterAttrs
-}
-
-func (filter *U32) Type() string {
-	return "u32"
-}
-
 // MatchAll filters match all packets
 type MatchAll struct {
 	FilterAttrs

--- a/filter_linux.go
+++ b/filter_linux.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"syscall"
-	"unsafe"
 
 	"github.com/vishvananda/netlink/nl"
 	"golang.org/x/sys/unix"
@@ -19,6 +18,35 @@ const (
 	TC_U32_VAROFFSET = nl.TC_U32_VAROFFSET
 	TC_U32_EAT       = nl.TC_U32_EAT
 )
+
+// Sel of the U32 filters that contains multiple TcU32Key. This is the type
+// alias and the frontend representation of nl.TcU32Sel. It is serialized into
+// canonical nl.TcU32Sel with the appropriate endianness.
+type TcU32Sel = nl.TcU32Sel
+
+// TcU32Key contained of Sel in the U32 filters. This is the type alias and the
+// frontend representation of nl.TcU32Key. It is serialized into chanonical
+// nl.TcU32Sel with the appropriate endianness.
+type TcU32Key = nl.TcU32Key
+
+// U32 filters on many packet related properties
+type U32 struct {
+	FilterAttrs
+	ClassId    uint32
+	Divisor    uint32 // Divisor MUST be power of 2.
+	Hash       uint32
+	RedirIndex int
+	Sel        *TcU32Sel
+	Actions    []Action
+}
+
+func (filter *U32) Attrs() *FilterAttrs {
+	return &filter.FilterAttrs
+}
+
+func (filter *U32) Type() string {
+	return "u32"
+}
 
 // Fw filter filters on firewall marks
 // NOTE: this is in filter_linux because it refers to nl.TcPolice which
@@ -140,8 +168,7 @@ func (h *Handle) FilterAdd(filter Filter) error {
 
 	switch filter := filter.(type) {
 	case *U32:
-		// Convert TcU32Sel into nl.TcU32Sel as it is without copy.
-		sel := (*nl.TcU32Sel)(unsafe.Pointer(filter.Sel))
+		sel := filter.Sel
 		if sel == nil {
 			// match all
 			sel = &nl.TcU32Sel{
@@ -483,7 +510,7 @@ func parseU32Data(filter Filter, data []syscall.NetlinkRouteAttr) (bool, error) 
 		case nl.TCA_U32_SEL:
 			detailed = true
 			sel := nl.DeserializeTcU32Sel(datum.Value)
-			u32.Sel = (*TcU32Sel)(unsafe.Pointer(sel))
+			u32.Sel = sel
 			if native != networkOrder {
 				// Handle the endianness of attributes
 				u32.Sel.Offmask = native.Uint16(htons(sel.Offmask))


### PR DESCRIPTION
This patch replaces TcU32Sel and TcU32Key that are copied from nl
package with type aliases for the original types. This eliminates the
usages of unsafe packages and redundant copied structs that are
identical to the original ones.

Type aliases are newly introduced in Go 1.9 and it is not backward
compatibile. Therefore this patch shall be merged only if the project is
entirely migrated to Go 1.9. Currently we are building this project
with Go 1.10 and Go 1.11, so it is reasonable to require Go version
greater than 1.9.

See #206 and #261, which is the previous life of this patch.

This patch also moves TcU32Sel, TcU32Key and U32 structs from filter.go
to filter_linux.go to make it possible to build on macOS. See #243 for
more details.

Signed-off-by: Taku Fukushima <taku@soracom.jp>