### PR TITLE
genetlink: Add missing error check

### DIFF
--- a/genetlink_linux.go
+++ b/genetlink_linux.go
@@ -157,6 +157,9 @@ func (h *Handle) GenlFamilyGet(name string) (*GenlFamily, error) {
 		return nil, err
 	}
 	families, err := parseFamilies(msgs)
+	if err != nil {
+		return nil, err
+	}
 	if len(families) != 1 {
 		return nil, fmt.Errorf("invalid response for GENL_CTRL_CMD_GETFAMILY")
 	}


### PR DESCRIPTION
Before this change, error returned by `parseFamilies` was silently
ignored.

Signed-off-by: Michal Rostecki <mrostecki@suse.de>