### PR TITLE
neigh_linux: Fix failure on deleted link neighs updates

### DIFF
--- a/neigh_linux.go
+++ b/neigh_linux.go
@@ -253,14 +253,6 @@ func NeighDeserialize(m []byte) (*Neigh, error) {
 		return nil, err
 	}
 
-	// This should be cached for perfomance
-	// once per table dump
-	link, err := LinkByIndex(neigh.LinkIndex)
-	if err != nil {
-		return nil, err
-	}
-	encapType := link.Attrs().EncapType
-
 	for _, attr := range attrs {
 		switch attr.Attr.Type {
 		case NDA_DST:
@@ -270,13 +262,16 @@ func NeighDeserialize(m []byte) (*Neigh, error) {
 			// #define RTA_LENGTH(len) (RTA_ALIGN(sizeof(struct rtattr)) + (len))
 			// #define RTA_PAYLOAD(rta) ((int)((rta)->rta_len) - RTA_LENGTH(0))
 			attrLen := attr.Attr.Len - unix.SizeofRtAttr
-			if attrLen == 4 && (encapType == "ipip" ||
-				encapType == "sit" ||
-				encapType == "gre") {
+			if attrLen == 4 {
 				neigh.LLIPAddr = net.IP(attr.Value)
-			} else if attrLen == 16 &&
-				encapType == "tunnel6" {
-				neigh.IP = net.IP(attr.Value)
+			} else if attrLen == 16 {
+				// Can be IPv6 or FireWire HWAddr
+				link, err := LinkByIndex(neigh.LinkIndex)
+				if err == nil && link.Attrs().EncapType == "tunnel6" {
+					neigh.IP = net.IP(attr.Value)
+				} else {
+					neigh.HardwareAddr = net.HardwareAddr(attr.Value)
+				}
 			} else {
 				neigh.HardwareAddr = net.HardwareAddr(attr.Value)
 			}


### PR DESCRIPTION
The kernel sends a RTM_DELNEIGH for every neighbours on link
deletion by the time the message is deserialized, the interface
no longer exists so we cannot call LinkByIndex on it.

This call to LinkByIndex is only used to get the encapType to be
able to set either IP or HardwareAddr correctly. The attrLen
attribute can be used here as only ipv4 are used with a size of 4,
and only ipv6 and FireWire HWaddr have a size of 16.

As such this change decrease the number of calls to LinkByIndex,
so it is called only when needed to choose between ipv6 or
FireWire Hwaddr, it also fallback to HWaddr in case of error with
LinkByIndex.

Fix: 921f7441f1ad68ebc6bbebe00664dfad83a7dbc6
Fix #409

Signed-off-by: Nicolas Belouin <nicolas.belouin@gandi.net>