### PR TITLE
Avoid 64K allocation on the heap with each Receive

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	SizeofLinkStats32 = 0x5c
-	SizeofLinkStats64 = 0xd8
+	SizeofLinkStats64 = 0xb8
 )
 
 const (

--- a/nl/nl_linux.go
+++ b/nl/nl_linux.go
@@ -622,16 +622,17 @@ func (s *NetlinkSocket) Receive() ([]syscall.NetlinkMessage, error) {
 	if fd < 0 {
 		return nil, fmt.Errorf("Receive called on a closed socket")
 	}
-	rb := make([]byte, RECEIVE_BUFFER_SIZE)
-	nr, _, err := unix.Recvfrom(fd, rb, 0)
+	var rb [RECEIVE_BUFFER_SIZE]byte
+	nr, _, err := unix.Recvfrom(fd, rb[:], 0)
 	if err != nil {
 		return nil, err
 	}
 	if nr < unix.NLMSG_HDRLEN {
 		return nil, fmt.Errorf("Got short response from netlink")
 	}
-	rb = rb[:nr]
-	return syscall.ParseNetlinkMessage(rb)
+	rb2 := make([]byte, nr)
+	copy(rb2, rb[:nr])
+	return syscall.ParseNetlinkMessage(rb2)
 }
 
 // SetSendTimeout allows to set a send timeout on the socket


### PR DESCRIPTION
Currently each call to Receive() allocates 64K buffer on the heap
for the data to receive from a netlink socket. This is rather costly
considering that in most cases only fraction of this memory is actually
needed.

A quick fix is to make sure that the large buffer does not "escape" -
i.e. that it is sufficient to have it allocated on the stack.
Then only the prefix of the buffer that was actually used
is copied to the heap.

Fix for issue: https://github.com/vishvananda/netlink/issues/379

A side benefit of the change is that parsing beyond the received
data gets immediately exposed via panic since there are no trailing
zero bytes anymore. For example the constant SizeofLinkStats64
used an invalid value but it wasn't detected (minor issue in this case).

**Simple benchmark:**

```
package main

import (
	"fmt"

	"github.com/vishvananda/netlink"
	"github.com/pkg/profile"
)

func main() {
	defer profile.Start().Stop() // comment out for run-time measurement

	for i := 0; i < 100000; i++ {
		_, err := netlink.LinkList()
		if err != nil {
			fmt.Printf("Error: %v\n", err)
		}
	}
}
```

**_Without_** optimalization:
- avg. runtime: `22s`

- CPU profile (lot's of GC):
```
(pprof) top
Showing nodes accounting for 20300ms, 63.70% of 31870ms total
Dropped 158 nodes (cum <= 159.35ms)
Showing top 10 nodes out of 120
      flat  flat%   sum%        cum   cum%
    6580ms 20.65% 20.65%     6760ms 21.21%  syscall.Syscall6
    2830ms  8.88% 29.53%     2830ms  8.88%  runtime.memclrNoHeapPointers
    2530ms  7.94% 37.46%     3870ms 12.14%  runtime.scanobject
    1860ms  5.84% 43.30%     1860ms  5.84%  runtime.futex
    1710ms  5.37% 48.67%     2010ms  6.31%  runtime.findObject
    1440ms  4.52% 53.18%     1580ms  4.96%  runtime.heapBitsSetType
     930ms  2.92% 56.10%     1020ms  3.20%  syscall.Syscall
     830ms  2.60% 58.71%     2210ms  6.93%  runtime.wbBufFlush1
     800ms  2.51% 61.22%      800ms  2.51%  syscall.RawSyscall
     790ms  2.48% 63.70%     1350ms  4.24%  runtime.scanblock
```

- memory profile:
```
File: netlink
Type: inuse_space
Time: Jan 2, 2019 at 1:11pm (CET)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 200.08kB, 100% of 200.08kB total
      flat  flat%   sum%        cum   cum%
  196.05kB 97.99% 97.99%   196.05kB 97.99%  github.com/contiv/vpp/vendor/github.com/vishvananda/netlink/nl.(*NetlinkSocket).Receive
    4.03kB  2.01%   100%     4.03kB  2.01%  runtime.systemstack
         0     0%   100%   196.05kB 97.99%  github.com/contiv/vpp/vendor/github.com/vishvananda/netlink.(*Handle).LinkList
         0     0%   100%   196.05kB 97.99%  github.com/contiv/vpp/vendor/github.com/vishvananda/netlink.LinkList
         0     0%   100%   196.05kB 97.99%  github.com/contiv/vpp/vendor/github.com/vishvananda/netlink/nl.(*NetlinkRequest).Execute
         0     0%   100%   196.05kB 97.99%  main.main
         0     0%   100%   196.05kB 97.99%  runtime.main
         0     0%   100%     4.03kB  2.01%  runtime.mstart
```

**_With_** optimalization:
- avg. runtime: `13s`

- CPU profile:
```
File: netlink
Type: cpu
Time: Jan 2, 2019 at 12:58pm (CET)
Duration: 15.28s, Total samples = 15.08s (98.71%)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 11270ms, 74.73% of 15080ms total
Dropped 112 nodes (cum <= 75.40ms)
Showing top 10 nodes out of 95
      flat  flat%   sum%        cum   cum%
    5670ms 37.60% 37.60%     5840ms 38.73%  syscall.Syscall6
    1530ms 10.15% 47.75%     1610ms 10.68%  runtime.heapBitsSetType
     790ms  5.24% 52.98%     5340ms 35.41%  github.com/contiv/vpp/vendor/github.com/vishvananda/netlink/nl.(*NetlinkSocket).Receive
     690ms  4.58% 57.56%      690ms  4.58%  syscall.RawSyscall
     680ms  4.51% 62.07%     4090ms 27.12%  runtime.mallocgc
     530ms  3.51% 65.58%      630ms  4.18%  syscall.Syscall
     460ms  3.05% 68.63%      460ms  3.05%  runtime.memclrNoHeapPointers
     340ms  2.25% 70.89%     3810ms 25.27%  runtime.growslice
     290ms  1.92% 72.81%     4210ms 27.92%  github.com/contiv/vpp/vendor/github.com/vishvananda/netlink.LinkDeserialize
     290ms  1.92% 74.73%     3390ms 22.48%  github.com/contiv/vpp/vendor/github.com/vishvananda/netlink/nl.ParseRouteAttr
```

- memory profile:
```
File: netlink
Type: inuse_space
Time: Jan 2, 2019 at 1:02pm (CET)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 29.50kB, 100% of 29.50kB total
Showing top 10 nodes out of 17
      flat  flat%   sum%        cum   cum%
   12.01kB 40.72% 40.72%    12.01kB 40.72%  github.com/contiv/vpp/vendor/github.com/vishvananda/netlink/nl.(*NetlinkSocket).Receive
    8.91kB 30.19% 70.91%     8.91kB 30.19%  runtime.allocm
    8.58kB 29.09%   100%     8.58kB 29.09%  github.com/contiv/vpp/vendor/github.com/vishvananda/netlink/nl.ParseRouteAttr
         0     0%   100%    20.60kB 69.81%  github.com/contiv/vpp/vendor/github.com/vishvananda/netlink.(*Handle).LinkList
         0     0%   100%     8.58kB 29.09%  github.com/contiv/vpp/vendor/github.com/vishvananda/netlink.LinkDeserialize
         0     0%   100%    20.60kB 69.81%  github.com/contiv/vpp/vendor/github.com/vishvananda/netlink.LinkList
         0     0%   100%    12.01kB 40.72%  github.com/contiv/vpp/vendor/github.com/vishvananda/netlink/nl.(*NetlinkRequest).Execute
         0     0%   100%    20.60kB 69.81%  main.main
         0     0%   100%     4.45kB 15.09%  runtime.gcMarkTermination.func3
         0     0%   100%    25.05kB 84.91%  runtime.main

```

Signed-off-by: Milan Lenco <milan.lenco@pantheon.tech>


