### PR TITLE
Fix Race Condition in TestXfrmMonitorExpire

### DIFF
--- a/xfrm_monitor_test.go
+++ b/xfrm_monitor_test.go
@@ -27,13 +27,24 @@ func TestXfrmMonitorExpire(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	hardFound := false
+	softFound := false
+
 	msg := (<-ch).(*XfrmMsgExpire)
-	if msg.XfrmState.Spi != state.Spi || msg.Hard {
-		t.Fatal("Received unexpected msg")
+	if msg.XfrmState.Spi != state.Spi {
+		t.Fatal("Received unexpected msg, spi does not match")
 	}
+	hardFound = msg.Hard || hardFound
+	softFound = !msg.Hard || softFound
 
 	msg = (<-ch).(*XfrmMsgExpire)
-	if msg.XfrmState.Spi != state.Spi || !msg.Hard {
-		t.Fatal("Received unexpected msg")
+	if msg.XfrmState.Spi != state.Spi {
+		t.Fatal("Received unexpected msg, spi does not match")
+	}
+	hardFound = msg.Hard || hardFound
+	softFound = !msg.Hard || softFound
+
+	if !hardFound || !softFound {
+		t.Fatal("Missing expire msg: hard found:", hardFound, "soft found:", softFound)
 	}
 }


### PR DESCRIPTION
This fixes the TestXfrmMonitorExpire test, which previously exhibited a race-condition. 

Since netlink messages are asynchronous and order is not guaranteed by the Kernel, the order of the expire messages could not be assumed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vishvananda/netlink/418)
<!-- Reviewable:end -->
