### PR TITLE
remove redundant type assertions in type switch

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -1120,12 +1120,12 @@ func (h *Handle) linkModify(link Link, flags int) error {
 
 	if base.Namespace != nil {
 		var attr *nl.RtAttr
-		switch base.Namespace.(type) {
+		switch ns := base.Namespace.(type) {
 		case NsPid:
-			val := nl.Uint32Attr(uint32(base.Namespace.(NsPid)))
+			val := nl.Uint32Attr(uint32(ns))
 			attr = nl.NewRtAttr(unix.IFLA_NET_NS_PID, val)
 		case NsFd:
-			val := nl.Uint32Attr(uint32(base.Namespace.(NsFd)))
+			val := nl.Uint32Attr(uint32(ns))
 			attr = nl.NewRtAttr(unix.IFLA_NET_NS_FD, val)
 		}
 


### PR DESCRIPTION
Use type switch var to get properly-typed value
inside case clauses.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>