### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/handle_linux.go
+++ b/handle_linux.go
@@ -91,7 +91,7 @@ func (h *Handle) GetSocketReceiveBufferSize() ([]int, error) {
 	return results, nil
 }
 
-// NewHandle returns a netlink handle on the network namespace
+// NewHandleAt returns a netlink handle on the network namespace
 // specified by ns. If ns=netns.None(), current network namespace
 // will be assumed
 func NewHandleAt(ns netns.NsHandle, nlFamilies ...int) (*Handle, error) {

--- a/link_linux.go
+++ b/link_linux.go
@@ -501,7 +501,7 @@ func LinkSetVfSpoofchk(link Link, vf int, check bool) error {
 	return pkgHandle.LinkSetVfSpoofchk(link, vf, check)
 }
 
-// LinkSetVfSpookfchk enables/disables spoof check on a vf for the link.
+// LinkSetVfSpoofchk enables/disables spoof check on a vf for the link.
 // Equivalent to: `ip link set $link vf $vf spoofchk $check`
 func (h *Handle) LinkSetVfSpoofchk(link Link, vf int, check bool) error {
 	var setting uint32

--- a/netns_linux.go
+++ b/netns_linux.go
@@ -51,14 +51,14 @@ func SetNetNsIdByPid(pid, nsid int) error {
 	return pkgHandle.SetNetNsIdByPid(pid, nsid)
 }
 
-// GetNetNsIdByPid looks up the network namespace ID for a given fd.
+// GetNetNsIdByFd looks up the network namespace ID for a given fd.
 // fd must be an open file descriptor to a namespace file.
 // Returns -1 if the namespace does not have an ID set.
 func (h *Handle) GetNetNsIdByFd(fd int) (int, error) {
 	return h.getNetNsId(NETNSA_FD, uint32(fd))
 }
 
-// GetNetNsIdByPid looks up the network namespace ID for a given fd.
+// GetNetNsIdByFd looks up the network namespace ID for a given fd.
 // fd must be an open file descriptor to a namespace file.
 // Returns -1 if the namespace does not have an ID set.
 func GetNetNsIdByFd(fd int) (int, error) {

--- a/nl/nl_linux.go
+++ b/nl/nl_linux.go
@@ -46,7 +46,7 @@ func GetIPFamily(ip net.IP) int {
 
 var nativeEndian binary.ByteOrder
 
-// Get native endianness for the system
+// NativeEndian gets native endianness for the system
 func NativeEndian() binary.ByteOrder {
 	if nativeEndian == nil {
 		var x uint32 = 0x01020304


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, _but this is automated so feel free to close it and just say "**opt out**" to opt out of future CodeLingo outreach PRs._