### PR TITLE
Mirred and connmark clobber their ActionAttrs

### DIFF
--- a/filter_linux.go
+++ b/filter_linux.go
@@ -483,8 +483,8 @@ func parseActions(tables []syscall.NetlinkRouteAttr) ([]Action, error) {
 						switch adatum.Attr.Type {
 						case nl.TCA_MIRRED_PARMS:
 							mirred := *nl.DeserializeTcMirred(adatum.Value)
-							toAttrs(&mirred.TcGen, action.Attrs())
 							action.(*MirredAction).ActionAttrs = ActionAttrs{}
+							toAttrs(&mirred.TcGen, action.Attrs())
 							action.(*MirredAction).Ifindex = int(mirred.Ifindex)
 							action.(*MirredAction).MirredAction = MirredAct(mirred.Eaction)
 						}
@@ -502,8 +502,8 @@ func parseActions(tables []syscall.NetlinkRouteAttr) ([]Action, error) {
 						switch adatum.Attr.Type {
 						case nl.TCA_CONNMARK_PARMS:
 							connmark := *nl.DeserializeTcConnmark(adatum.Value)
-							toAttrs(&connmark.TcGen, action.Attrs())
 							action.(*ConnmarkAction).ActionAttrs = ActionAttrs{}
+							toAttrs(&connmark.TcGen, action.Attrs())
 							action.(*ConnmarkAction).Zone = connmark.Zone
 						}
 					case "gact":

--- a/filter_test.go
+++ b/filter_test.go
@@ -672,17 +672,30 @@ func TestFilterU32ConnmarkAddDel(t *testing.T) {
 	if u32.ClassId != classId {
 		t.Fatalf("ClassId of the filter is the wrong value")
 	}
+
 	// actions can be returned in reverse order
-	if _, ok := u32.Actions[0].(*ConnmarkAction); !ok {
-		if _, ok := u32.Actions[1].(*ConnmarkAction); !ok {
-			t.Fatal("Action is the wrong type")
+	cma, ok := u32.Actions[0].(*ConnmarkAction)
+	if !ok {
+		cma, ok = u32.Actions[1].(*ConnmarkAction)
+		if !ok {
+			t.Fatal("Unable to find connmark action")
 		}
 	}
 
-	if _, ok := u32.Actions[0].(*MirredAction); !ok {
-		if _, ok := u32.Actions[1].(*MirredAction); !ok {
-			t.Fatal("Action is the wrong type")
+	if cma.Attrs().Action != TC_ACT_PIPE {
+		t.Fatal("Connmark action isn't TC_ACT_PIPE")
+	}
+
+	mia, ok := u32.Actions[0].(*MirredAction)
+	if !ok {
+		mia, ok = u32.Actions[1].(*MirredAction)
+		if !ok {
+			t.Fatal("Unable to find mirred action")
 		}
+	}
+
+	if mia.Attrs().Action != TC_ACT_STOLEN {
+		t.Fatal("Mirred action isn't TC_ACT_STOLEN")
 	}
 
 	if err := FilterDel(filter); err != nil {


### PR DESCRIPTION
Encountered this in a local test.  It turns out that in parseActions
mirred has a bug where it parses the action attributes but then on the
very next line overwrites this hard work by assigning an empty
ActionAttrs struct on top.  I copy pasta'd this into connmark.  Fix both
instances and amend the unit tests to catch this going forward.

Signed-off-by: Krister Johansen <krister.johansen@oracle.com>