### PR TITLE
Fix unit test failure: TestNeighAddDelLLIPAddr

### DIFF
--- a/neigh_test.go
+++ b/neigh_test.go
@@ -57,17 +57,16 @@ func dumpContainsProxy(dump []Neigh, p proxyEntry) bool {
 }
 
 func TestNeighAddDelLLIPAddr(t *testing.T) {
-	t.Skipf("NeighList is only returning cacheinfo in travis")
-	setUpNetlinkTestWithKModule(t, "ipip")
+	setUpNetlinkTestWithKModule(t, "ip_gre")
 
 	tearDown := setUpNetlinkTest(t)
 	defer tearDown()
 
-	dummy := Iptun{
+	dummy := Gretun{
 		LinkAttrs: LinkAttrs{Name: "neigh0"},
-		PMtuDisc:  1,
 		Local:     net.IPv4(127, 0, 0, 1),
-		Remote:    net.IPv4(127, 0, 0, 1)}
+		IKey:      1234,
+		OKey:      1234}
 	if err := LinkAdd(&dummy); err != nil {
 		t.Errorf("Failed to create link: %v", err)
 	}
@@ -93,7 +92,6 @@ func TestNeighAddDelLLIPAddr(t *testing.T) {
 
 	if !dumpContainsNeigh(dump, entry) {
 		t.Errorf("Dump does not contain: %v: %v", entry, dump)
-
 	}
 
 	// Delete the entry


### PR DESCRIPTION
TestNeighAddDelLLIPAddr was failing due to the Neighbour table
not getting properly populated when using a ipip tunnel.
This matches the behaviour in the latest kernel when using
the ip command.

Switch the tunnel type to a gre point to multi-point tunnel.
The neighbour table gets properly populated in this case.

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>