### PR TITLE
Set Link TX / RX Queues on Deserialization

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -1571,6 +1571,10 @@ func LinkDeserialize(hdr *unix.NlMsghdr, m []byte) (Link, error) {
 				return nil, err
 			}
 			base.Vfs = vfs
+		case unix.IFLA_NUM_TX_QUEUES:
+			base.NumTxQueues = int(native.Uint32(attr.Value[0:4]))
+		case unix.IFLA_NUM_RX_QUEUES:
+			base.NumRxQueues = int(native.Uint32(attr.Value[0:4]))
 		}
 	}
 

--- a/link_test.go
+++ b/link_test.go
@@ -18,8 +18,8 @@ import (
 const (
 	testTxQLen    int = 100
 	defaultTxQLen int = 1000
-	testTxQueues  int = 1
-	testRxQueues  int = 1
+	testTxQueues  int = 4
+	testRxQueues  int = 8
 )
 
 func testLinkAddDel(t *testing.T, link Link) {
@@ -61,6 +61,15 @@ func testLinkAddDel(t *testing.T, link Link) {
 		if rBase.TxQLen != base.TxQLen {
 			t.Fatalf("qlen is %d, should be %d", rBase.TxQLen, base.TxQLen)
 		}
+
+		if rBase.NumTxQueues != base.NumTxQueues {
+			t.Fatalf("txQueues is %d, should be %d", rBase.NumTxQueues, base.NumTxQueues)
+		}
+
+		if rBase.NumRxQueues != base.NumRxQueues {
+			t.Fatalf("rxQueues is %d, should be %d", rBase.NumRxQueues, base.NumRxQueues)
+		}
+
 		if rBase.MTU != base.MTU {
 			t.Fatalf("MTU is %d, should be %d", rBase.MTU, base.MTU)
 		}


### PR DESCRIPTION
This deserializes the tx queue, and rx queue count on link
deserialization. We already supported it on serialization.

Signed-off-by: Sargun Dhillon <sargun@sargun.me>