### PR TITLE
Add support for setting VLAN QoS for VF links

### DIFF
--- a/handle_unspecified.go
+++ b/handle_unspecified.go
@@ -73,6 +73,10 @@ func (h *Handle) LinkSetVfVlan(link Link, vf, vlan int) error {
 	return ErrNotImplemented
 }
 
+func (h *Handle) LinkSetVfVlanQos(link Link, vf, vlan, qos int) error {
+	return ErrNotImplemented
+}
+
 func (h *Handle) LinkSetVfTxRate(link Link, vf, rate int) error {
 	return ErrNotImplemented
 }

--- a/netlink_unspecified.go
+++ b/netlink_unspecified.go
@@ -48,6 +48,10 @@ func LinkSetVfVlan(link Link, vf, vlan int) error {
 	return ErrNotImplemented
 }
 
+func LinkSetVfVlanQos(link Link, vf, vlan, qos int) error {
+	return ErrNotImplemented
+}
+
 func LinkSetVfTxRate(link Link, vf, rate int) error {
 	return ErrNotImplemented
 }


### PR DESCRIPTION
This change adds support for setting VLAN QoS (priority) field for the
SR-IOV Virtual Function links.