### PR TITLE
Add support for IFLA_VF_RATE

### DIFF
--- a/handle_unspecified.go
+++ b/handle_unspecified.go
@@ -81,6 +81,10 @@ func (h *Handle) LinkSetVfTxRate(link Link, vf, rate int) error {
 	return ErrNotImplemented
 }
 
+func (h *Handle) LinkSetVfRate(link Link, vf, minRate, maxRate int) error {
+	return ErrNotImplemented
+}
+
 func (h *Handle) LinkSetMaster(link Link, master *Bridge) error {
 	return ErrNotImplemented
 }

--- a/link.go
+++ b/link.go
@@ -53,9 +53,11 @@ type VfInfo struct {
 	Mac       net.HardwareAddr
 	Vlan      int
 	Qos       int
-	TxRate    int
+	TxRate    int // IFLA_VF_TX_RATE  Max TxRate
 	Spoofchk  bool
 	LinkState uint32
+	MaxTxRate uint32 // IFLA_VF_RATE Max TxRate
+	MinTxRate uint32 // IFLA_VF_RATE Min TxRate
 }
 
 // LinkOperState represents the values of the IFLA_OPERSTATE link

--- a/link_linux.go
+++ b/link_linux.go
@@ -528,6 +528,37 @@ func (h *Handle) LinkSetVfTxRate(link Link, vf, rate int) error {
 	return err
 }
 
+// LinkSetVfRate sets the min and max tx rate of a vf for the link.
+// Equivalent to: `ip link set $link vf $vf min_tx_rate $min_rate max_tx_rate $max_rate`
+func LinkSetVfRate(link Link, vf, minRate, maxRate int) error {
+	return pkgHandle.LinkSetVfRate(link, vf, minRate, maxRate)
+}
+
+// LinkSetVfRate sets the min and max tx rate of a vf for the link.
+// Equivalent to: `ip link set $link vf $vf min_tx_rate $min_rate max_tx_rate $max_rate`
+func (h *Handle) LinkSetVfRate(link Link, vf, minRate, maxRate int) error {
+	base := link.Attrs()
+	h.ensureIndex(base)
+	req := h.newNetlinkRequest(unix.RTM_SETLINK, unix.NLM_F_ACK)
+
+	msg := nl.NewIfInfomsg(unix.AF_UNSPEC)
+	msg.Index = int32(base.Index)
+	req.AddData(msg)
+
+	data := nl.NewRtAttr(unix.IFLA_VFINFO_LIST, nil)
+	info := data.AddRtAttr(nl.IFLA_VF_INFO, nil)
+	vfmsg := nl.VfRate{
+		Vf:        uint32(vf),
+		MinTxRate: uint32(minRate),
+		MaxTxRate: uint32(maxRate),
+	}
+	info.AddRtAttr(nl.IFLA_VF_RATE, vfmsg.Serialize())
+	req.AddData(data)
+
+	_, err := req.Execute(unix.NETLINK_ROUTE, 0)
+	return err
+}
+
 // LinkSetVfSpoofchk enables/disables spoof check on a vf for the link.
 // Equivalent to: `ip link set $link vf $vf spoofchk $check`
 func LinkSetVfSpoofchk(link Link, vf int, check bool) error {
@@ -2636,6 +2667,10 @@ func parseVfInfo(data []syscall.NetlinkRouteAttr, id int) VfInfo {
 		case nl.IFLA_VF_LINK_STATE:
 			ls := nl.DeserializeVfLinkState(element.Value[:])
 			vf.LinkState = ls.LinkState
+		case nl.IFLA_VF_RATE:
+			vfr := nl.DeserializeVfRate(element.Value[:])
+			vf.MaxTxRate = vfr.MaxTxRate
+			vf.MinTxRate = vfr.MinTxRate
 		}
 	}
 	return vf

--- a/netlink_unspecified.go
+++ b/netlink_unspecified.go
@@ -56,6 +56,10 @@ func LinkSetVfTxRate(link Link, vf, rate int) error {
 	return ErrNotImplemented
 }
 
+func LinkSetVfRate(link Link, vf, minRate, maxRate int) error {
+	return ErrNotImplemented
+}
+
 func LinkSetNoMaster(link Link) error {
 	return ErrNotImplemented
 }


### PR DESCRIPTION
Today netlink package supports Get/Set of a VF's max TX rate
via IFLA_VF_TX_RATE netlink attribute.

This patch adds support to Get/Set of a VFs min and max TX rate
via IFLA_VF_RATE netlink attribute.

- Add support to set min/max tx rate for VF via IFLA_VF_RATE
- Added IFLA_VF_RATE min/max tx rate attributes to netlink.VfInfo
  including parsing support in netlink.parseVfInfo()

NOTE: According to [1] IFLA_VF_RATE takes precedence over
      IFLA_VF_TX_RATE. Dealing with the coexistence of these
      netlink attributes is left for the user to handle.

[1]https://lists.openwall.net/netdev/2014/05/22/42