### PR TITLE
Add Enums of Timestamp, Timeout to netlink/conntrack

### DIFF
--- a/nl/conntrack_linux.go
+++ b/nl/conntrack_linux.go
@@ -79,11 +79,14 @@ const (
 	CTA_TUPLE_ORIG     = 1
 	CTA_TUPLE_REPLY    = 2
 	CTA_STATUS         = 3
+	CTA_PROTOINFO      = 4
 	CTA_TIMEOUT        = 7
 	CTA_MARK           = 8
 	CTA_COUNTERS_ORIG  = 9
 	CTA_COUNTERS_REPLY = 10
-	CTA_PROTOINFO      = 4
+	CTA_USE            = 11
+	CTA_ID             = 12
+	CTA_TIMESTAMP      = 20
 )
 
 // enum ctattr_tuple {
@@ -178,6 +181,14 @@ const (
 const (
 	CTA_COUNTERS_PACKETS = 1
 	CTA_COUNTERS_BYTES   = 2
+)
+
+// enum CTA TIMESTAMP TLVs
+// CTA_TIMESTAMP_START       /* 64bit value */
+// CTA_TIMESTAMP_STOP        /* 64bit value */
+const (
+	CTA_TIMESTAMP_START = 1
+	CTA_TIMESTAMP_STOP  = 2
 )
 
 // /* General form of address family dependent message.


### PR DESCRIPTION
Signed-off-by: Naiming Shen <naiming@zededa.com>

This patch is to add Some Enums to support of Conntrack Timestamp, Timeout, and make the query flow more efficient when walk through items in the conntrack returned objects.