### PR TITLE
Fix parsing of IFLA_GRE_COLLECT_METADATA

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -2280,9 +2280,7 @@ func parseGretapData(link Link, data []syscall.NetlinkRouteAttr) {
 		case nl.IFLA_GRE_ENCAP_FLAGS:
 			gre.EncapFlags = native.Uint16(datum.Value[0:2])
 		case nl.IFLA_GRE_COLLECT_METADATA:
-			if len(datum.Value) > 0 {
-				gre.FlowBased = int8(datum.Value[0]) != 0
-			}
+			gre.FlowBased = true
 		}
 	}
 }


### PR DESCRIPTION
Documentation of user space  Netlink Protocol Library Suite (libnl)  at http://www.infradead.org/~tgr/libnl statesunder section  6.4. Attribute Data Types  at http://www.infradead.org/~tgr/libnl/doc/core.html#core_attr_types :

"6.4.3. Flag Attributes

The flag attribute represents a boolean datatype. The presence of the attribute implies a value of true,  the absence of the attribute implies the value false. Therefore the payload length of flag attributes is always 0."