### PR TITLE
Add support for output-mark

### DIFF
--- a/nl/xfrm_linux.go
+++ b/nl/xfrm_linux.go
@@ -86,6 +86,8 @@ const (
 	XFRMA_MAX = iota - 1
 )
 
+const XFRMA_OUTPUT_MARK = XFRMA_SET_MARK
+
 const (
 	SizeofXfrmAddress     = 0x10
 	SizeofXfrmSelector    = 0x38

--- a/xfrm_state.go
+++ b/xfrm_state.go
@@ -94,6 +94,7 @@ type XfrmState struct {
 	Limits       XfrmStateLimits
 	Statistics   XfrmStateStats
 	Mark         *XfrmMark
+	OutputMark   int
 	Ifid         int
 	Auth         *XfrmStateAlgo
 	Crypt        *XfrmStateAlgo
@@ -103,8 +104,8 @@ type XfrmState struct {
 }
 
 func (sa XfrmState) String() string {
-	return fmt.Sprintf("Dst: %v, Src: %v, Proto: %s, Mode: %s, SPI: 0x%x, ReqID: 0x%x, ReplayWindow: %d, Mark: %v, Ifid: %d, Auth: %v, Crypt: %v, Aead: %v, Encap: %v, ESN: %t",
-		sa.Dst, sa.Src, sa.Proto, sa.Mode, sa.Spi, sa.Reqid, sa.ReplayWindow, sa.Mark, sa.Ifid, sa.Auth, sa.Crypt, sa.Aead, sa.Encap, sa.ESN)
+	return fmt.Sprintf("Dst: %v, Src: %v, Proto: %s, Mode: %s, SPI: 0x%x, ReqID: 0x%x, ReplayWindow: %d, Mark: %v, OutputMark: %d, Ifid: %d, Auth: %v, Crypt: %v, Aead: %v, Encap: %v, ESN: %t",
+		sa.Dst, sa.Src, sa.Proto, sa.Mode, sa.Spi, sa.Reqid, sa.ReplayWindow, sa.Mark, sa.OutputMark, sa.Ifid, sa.Auth, sa.Crypt, sa.Aead, sa.Encap, sa.ESN)
 }
 func (sa XfrmState) Print(stats bool) string {
 	if !stats {

--- a/xfrm_state_linux.go
+++ b/xfrm_state_linux.go
@@ -158,6 +158,10 @@ func (h *Handle) xfrmStateAddOrUpdate(state *XfrmState, nlProto int) error {
 		out := nl.NewRtAttr(nl.XFRMA_REPLAY_ESN_VAL, writeReplayEsn(state.ReplayWindow))
 		req.AddData(out)
 	}
+	if state.OutputMark != 0 {
+		out := nl.NewRtAttr(nl.XFRMA_OUTPUT_MARK, nl.Uint32Attr(uint32(state.OutputMark)))
+		req.AddData(out)
+	}
 
 	ifId := nl.NewRtAttr(nl.XFRMA_IF_ID, nl.Uint32Attr(uint32(state.Ifid)))
 	req.AddData(ifId)
@@ -373,6 +377,8 @@ func parseXfrmState(m []byte, family int) (*XfrmState, error) {
 			state.Mark = new(XfrmMark)
 			state.Mark.Value = mark.Value
 			state.Mark.Mask = mark.Mask
+		case nl.XFRMA_OUTPUT_MARK:
+			state.OutputMark = int(native.Uint32(attr.Value))
 		case nl.XFRMA_IF_ID:
 			state.Ifid = int(native.Uint32(attr.Value))
 		}

--- a/xfrm_state_test.go
+++ b/xfrm_state_test.go
@@ -222,6 +222,27 @@ func TestXfrmStateWithIfid(t *testing.T) {
 	}
 }
 
+func TestXfrmStateWithOutputMark(t *testing.T) {
+	minKernelRequired(t, 4, 14)
+	defer setUpNetlinkTest(t)()
+
+	state := getBaseState()
+	state.OutputMark = 10
+	if err := XfrmStateAdd(state); err != nil {
+		t.Fatal(err)
+	}
+	s, err := XfrmStateGet(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !compareStates(state, s) {
+		t.Fatalf("unexpected state returned.\nExpected: %v.\nGot %v", state, s)
+	}
+	if err = XfrmStateDel(s); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func getBaseState() *XfrmState {
 	return &XfrmState{
 		// Force 4 byte notation for the IPv4 addresses
@@ -273,6 +294,7 @@ func compareStates(a, b *XfrmState) bool {
 	return a.Src.Equal(b.Src) && a.Dst.Equal(b.Dst) &&
 		a.Mode == b.Mode && a.Spi == b.Spi && a.Proto == b.Proto &&
 		a.Ifid == b.Ifid &&
+		a.OutputMark == b.OutputMark &&
 		compareAlgo(a.Auth, b.Auth) &&
 		compareAlgo(a.Crypt, b.Crypt) &&
 		compareAlgo(a.Aead, b.Aead) &&


### PR DESCRIPTION
Support for output-mark in xfrm states
I tried to have an implementation very close to the iproute one

I have tested it and had no problem with it but I may still have forgotten something. More than happy to update the PR if this is the case