### PR TITLE
Remove unused *_PROTO constants

### DIFF
--- a/conntrack_linux.go
+++ b/conntrack_linux.go
@@ -22,11 +22,7 @@ const (
 	// https://github.com/torvalds/linux/blob/master/include/uapi/linux/netfilter/nfnetlink.h -> #define NFNL_SUBSYS_CTNETLINK_EXP 2
 	ConntrackExpectTable = 2
 )
-const (
-	// For Parsing Mark
-	TCP_PROTO = 6
-	UDP_PROTO = 17
-)
+
 const (
 	// backward compatibility with golang 1.6 which does not have io.SeekCurrent
 	seekCurrent = 1


### PR DESCRIPTION
These are unused since commit 941b4de9e151f1c3662f3f1fa23ec263999f09de

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>