### PR TITLE
Fix LinkSetVfGUID to not reverse the GUID

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -681,7 +681,7 @@ func (h *Handle) LinkSetVfGUID(link Link, vf int, vfGuid net.HardwareAddr, guidT
 	var guid uint64
 
 	buf := bytes.NewBuffer(vfGuid)
-	err = binary.Read(buf, binary.LittleEndian, &guid)
+	err = binary.Read(buf, binary.BigEndian, &guid)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
when call netlink.LinkSetVfGUID for port or node, with guid like 00:11:22:33:44:55:66:77 the actual GUID will be 77:66:55:44:33:22:11:00.

This is due to using LittleEndian instead of BigEndian