### PR TITLE
Use IfaCacheinfo and IFA_* consts from golang.org/x/sys/unix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.12
 
 require (
 	github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df
-	golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444
+	golang.org/x/sys v0.0.0-20200121082415-34d275377bf9
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7ZovXvuNyL3XQl8UFofeikI1NW1Gypu7k=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
-golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444 h1:/d2cWp6PSamH4jDPFLyO150psQdqvtoNX8Zjg3AQ31g=
-golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200121082415-34d275377bf9 h1:N19i1HjUnR7TF7rMt8O4p3dLvqvmYyzB6ifMFmrbY50=
+golang.org/x/sys v0.0.0-20200121082415-34d275377bf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/nl/addr_linux.go
+++ b/nl/addr_linux.go
@@ -54,24 +54,18 @@ func (msg *IfAddrmsg) Len() int {
 // 	__u32	tstamp; /* updated timestamp, hundredths of seconds */
 // };
 
-const IFA_CACHEINFO = 6
-const SizeofIfaCacheInfo = 0x10
-
 type IfaCacheInfo struct {
-	IfaPrefered uint32
-	IfaValid    uint32
-	Cstamp      uint32
-	Tstamp      uint32
+	unix.IfaCacheinfo
 }
 
 func (msg *IfaCacheInfo) Len() int {
-	return SizeofIfaCacheInfo
+	return unix.SizeofIfaCacheinfo
 }
 
 func DeserializeIfaCacheInfo(b []byte) *IfaCacheInfo {
-	return (*IfaCacheInfo)(unsafe.Pointer(&b[0:SizeofIfaCacheInfo][0]))
+	return (*IfaCacheInfo)(unsafe.Pointer(&b[0:unix.SizeofIfaCacheinfo][0]))
 }
 
 func (msg *IfaCacheInfo) Serialize() []byte {
-	return (*(*[SizeofIfaCacheInfo]byte)(unsafe.Pointer(msg)))[:]
+	return (*(*[unix.SizeofIfaCacheinfo]byte)(unsafe.Pointer(msg)))[:]
 }

--- a/nl/addr_linux_test.go
+++ b/nl/addr_linux_test.go
@@ -41,14 +41,14 @@ func TestIfAddrmsgDeserializeSerialize(t *testing.T) {
 
 func (msg *IfaCacheInfo) write(b []byte) {
 	native := NativeEndian()
-	native.PutUint32(b[0:4], uint32(msg.IfaPrefered))
-	native.PutUint32(b[4:8], uint32(msg.IfaValid))
+	native.PutUint32(b[0:4], uint32(msg.Prefered))
+	native.PutUint32(b[4:8], uint32(msg.Valid))
 	native.PutUint32(b[8:12], uint32(msg.Cstamp))
 	native.PutUint32(b[12:16], uint32(msg.Tstamp))
 }
 
 func (msg *IfaCacheInfo) serializeSafe() []byte {
-	length := SizeofIfaCacheInfo
+	length := unix.SizeofIfaCacheinfo
 	b := make([]byte, length)
 	msg.write(b)
 	return b
@@ -56,12 +56,12 @@ func (msg *IfaCacheInfo) serializeSafe() []byte {
 
 func deserializeIfaCacheInfoSafe(b []byte) *IfaCacheInfo {
 	var msg = IfaCacheInfo{}
-	binary.Read(bytes.NewReader(b[0:SizeofIfaCacheInfo]), NativeEndian(), &msg)
+	binary.Read(bytes.NewReader(b[0:unix.SizeofIfaCacheinfo]), NativeEndian(), &msg)
 	return &msg
 }
 
 func TestIfaCacheInfoDeserializeSerialize(t *testing.T) {
-	var orig = make([]byte, SizeofIfaCacheInfo)
+	var orig = make([]byte, unix.SizeofIfaCacheinfo)
 	rand.Read(orig)
 	safemsg := deserializeIfaCacheInfoSafe(orig)
 	msg := DeserializeIfaCacheInfo(orig)


### PR DESCRIPTION
Use the IfaCacheinfo type and the IFA_* consts from
golang.org/x/sys/unix instead of locally duplicating them.
