### PR TITLE
[non linux: netlink/xdp] Add dummy function for LinkSetXdpFdWithFlags

### DIFF
--- a/netlink_unspecified.go
+++ b/netlink_unspecified.go
@@ -72,6 +72,10 @@ func LinkSetXdpFd(link Link, fd int) error {
 	return ErrNotImplemented
 }
 
+func LinkSetXdpFdWithFlags(link Link, fd, flags int) error {
+	return ErrNotImplemented
+}
+
 func LinkSetARPOff(link Link) error {
 	return ErrNotImplemented
 }


### PR DESCRIPTION
Otherwise it fails to install on Mac:
```
somefile.go:10:1: undefined: netlink.LinkSetXdpFdWithFlags
```