### PR TITLE
Correct value of SizeofXfrmUsersaFlush

### DIFF
--- a/nl/xfrm_state_linux.go
+++ b/nl/xfrm_state_linux.go
@@ -13,7 +13,7 @@ const (
 	SizeofXfrmAlgoAuth       = 0x48
 	SizeofXfrmAlgoAEAD       = 0x48
 	SizeofXfrmEncapTmpl      = 0x18
-	SizeofXfrmUsersaFlush    = 0x8
+	SizeofXfrmUsersaFlush    = 0x1
 	SizeofXfrmReplayStateEsn = 0x18
 )
 


### PR DESCRIPTION
`struct xfrm_usersa_flush` contains a single `u8`, thus `sizeof(struct
xfrm_usersa_flush) == 1` as can be verified by running the following
code through `go tool cgo -godefs`:

    package xfrm_test

    // #include <linux/xfrm.h>
    import "C"

    const SizeofXfrmUsersaFlush = C.sizeof_struct_xfrm_usersa_flush

which results in

    // Code generated by cmd/cgo -godefs; DO NOT EDIT.
    // cgo -godefs foo.go

    package xfrm_test

    const SizeofXfrmUsersaFlush = 0x1

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>