### PR TITLE
Fix parsing of IFLA_IPTUN_COLLECT_METADATA

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -2592,7 +2592,7 @@ func parseIptunData(link Link, data []syscall.NetlinkRouteAttr) {
 		case nl.IFLA_IPTUN_ENCAP_FLAGS:
 			iptun.EncapFlags = native.Uint16(datum.Value[0:2])
 		case nl.IFLA_IPTUN_COLLECT_METADATA:
-			iptun.FlowBased = int8(datum.Value[0]) != 0
+			iptun.FlowBased = true
 		}
 	}
 }


### PR DESCRIPTION
IFLA_IPTUN_COLLECT_METADATA are used as flags and
therefore have no content