### PR TITLE
Sittun: add Proto field

### DIFF
--- a/link.go
+++ b/link.go
@@ -905,6 +905,7 @@ type Sittun struct {
 	EncapFlags uint16
 	EncapSport uint16
 	EncapDport uint16
+	Proto      uint8
 }
 
 func (sittun *Sittun) Attrs() *LinkAttrs {

--- a/link_linux.go
+++ b/link_linux.go
@@ -2674,6 +2674,7 @@ func addSittunAttrs(sittun *Sittun, linkInfo *nl.RtAttr) {
 	data.AddRtAttr(nl.IFLA_IPTUN_ENCAP_FLAGS, nl.Uint16Attr(sittun.EncapFlags))
 	data.AddRtAttr(nl.IFLA_IPTUN_ENCAP_SPORT, htons(sittun.EncapSport))
 	data.AddRtAttr(nl.IFLA_IPTUN_ENCAP_DPORT, htons(sittun.EncapDport))
+	data.AddRtAttr(nl.IFLA_IPTUN_PROTO, nl.Uint8Attr(sittun.Proto))
 }
 
 func parseSittunData(link Link, data []syscall.NetlinkRouteAttr) {


### PR DESCRIPTION
This corresponds to the `mode` parameter of the ip link command.

The options are:
  mode { ip6ip | ipip | any }

Where:
 - any: 0
 - ip6ip: IPPROTO_IPV6
 - ipip: IPPROTO_IPIP

Signed-off-by: Gregory Detal <gregory.detal@tessares.net>