### PR TITLE
Add support for getting all RDMA devices in the system

### DIFF
--- a/rdma_link_linux.go
+++ b/rdma_link_linux.go
@@ -77,28 +77,39 @@ func executeOneGetRdmaLink(data []byte) (*RdmaLink, error) {
 	return &link, nil
 }
 
-func execRdmaGetLink(req *nl.NetlinkRequest, name string) (*RdmaLink, error) {
+func execRdmaSetLink(req *nl.NetlinkRequest) error {
+
+	_, err := req.Execute(unix.NETLINK_RDMA, 0)
+	return err
+}
+
+// RdmaLinkList gets a list of RDMA link devices.
+// Equivalent to: `rdma dev show`
+func RdmaLinkList() ([]*RdmaLink, error) {
+	return pkgHandle.RdmaLinkList()
+}
+
+// RdmaLinkList gets a list of RDMA link devices.
+// Equivalent to: `rdma dev show`
+func (h *Handle) RdmaLinkList() ([]*RdmaLink, error) {
+	proto := getProtoField(nl.RDMA_NL_NLDEV, nl.RDMA_NLDEV_CMD_GET)
+	req := h.newNetlinkRequest(proto, unix.NLM_F_ACK|unix.NLM_F_DUMP)
 
 	msgs, err := req.Execute(unix.NETLINK_RDMA, 0)
 	if err != nil {
 		return nil, err
 	}
+
+	var res []*RdmaLink
 	for _, m := range msgs {
 		link, err := executeOneGetRdmaLink(m)
 		if err != nil {
 			return nil, err
 		}
-		if link.Attrs.Name == name {
-			return link, nil
-		}
+		res = append(res, link)
 	}
-	return nil, fmt.Errorf("Rdma device %v not found", name)
-}
 
-func execRdmaSetLink(req *nl.NetlinkRequest) error {
-
-	_, err := req.Execute(unix.NETLINK_RDMA, 0)
-	return err
+	return res, nil
 }
 
 // RdmaLinkByName finds a link by name and returns a pointer to the object if
@@ -110,11 +121,16 @@ func RdmaLinkByName(name string) (*RdmaLink, error) {
 // RdmaLinkByName finds a link by name and returns a pointer to the object if
 // found and nil error, otherwise returns error code.
 func (h *Handle) RdmaLinkByName(name string) (*RdmaLink, error) {
-
-	proto := getProtoField(nl.RDMA_NL_NLDEV, nl.RDMA_NLDEV_CMD_GET)
-	req := h.newNetlinkRequest(proto, unix.NLM_F_ACK|unix.NLM_F_DUMP)
-
-	return execRdmaGetLink(req, name)
+	links, err := h.RdmaLinkList()
+	if err != nil {
+		return nil, err
+	}
+	for _, link := range links {
+		if link.Attrs.Name == name {
+			return link, nil
+		}
+	}
+	return nil, fmt.Errorf("Rdma device %v not found", name)
 }
 
 // RdmaLinkSetName sets the name of the rdma link device. Return nil on success

--- a/rdma_link_test.go
+++ b/rdma_link_test.go
@@ -152,3 +152,16 @@ func TestRdmaLinkSetNsFd(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestRdmaLinkList(t *testing.T) {
+	minKernelRequired(t, 4, 16)
+	setupRdmaKModule(t, "ib_core")
+	links, err := RdmaLinkList()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log("RDMA devices:")
+	for _, link := range links {
+		t.Logf("%d: %s", link.Attrs.Index, link.Attrs.Name)
+	}
+}


### PR DESCRIPTION
- Add RdmaLinkList() method that retrieves RDMA devices
  in the system.

- Modify RdmaLinkByName() to use RdmaLinkList() to avoid code
  duplication.

- Add unit test that demonstrates how to use RdmaLinkList()

Signed-off-by: Adrian Chiris <adrianc@mellanox.com>