### PR TITLE
Allow placing veth peer into a namespace

### DIFF
--- a/link.go
+++ b/link.go
@@ -339,6 +339,7 @@ type Veth struct {
 	LinkAttrs
 	PeerName         string // veth on create only
 	PeerHardwareAddr net.HardwareAddr
+	PeerNamespace    interface{}
 }
 
 func (veth *Veth) Attrs() *LinkAttrs {

--- a/link_linux.go
+++ b/link_linux.go
@@ -1335,6 +1335,16 @@ func (h *Handle) linkModify(link Link, flags int) error {
 		if link.PeerHardwareAddr != nil {
 			peer.AddRtAttr(unix.IFLA_ADDRESS, []byte(link.PeerHardwareAddr))
 		}
+		if link.PeerNamespace != nil {
+			switch ns := link.PeerNamespace.(type) {
+			case NsPid:
+				val := nl.Uint32Attr(uint32(ns))
+				peer.AddRtAttr(unix.IFLA_NET_NS_PID, val)
+			case NsFd:
+				val := nl.Uint32Attr(uint32(ns))
+				peer.AddRtAttr(unix.IFLA_NET_NS_FD, val)
+			}
+		}
 	case *Vxlan:
 		addVxlanAttrs(link, linkInfo)
 	case *Bond:


### PR DESCRIPTION
Creating a veth pair across namespaces now is a multistep process.
Doing it in one shot with this change is clearer as current
namespace never sees peer IF. Also, moving peer into a namespace
may be rather slow, so better avoided.