### PR TITLE
Add encap fields to Ip6tnl

### DIFF
--- a/link.go
+++ b/link.go
@@ -896,6 +896,10 @@ type Ip6tnl struct {
 	Flags      uint32
 	Proto      uint8
 	FlowInfo   uint32
+	EncapSport uint16
+	EncapDport uint16
+	EncapType  uint16
+	EncapFlags uint16
 }
 
 func (ip6tnl *Ip6tnl) Attrs() *LinkAttrs {

--- a/link_linux.go
+++ b/link_linux.go
@@ -2669,6 +2669,10 @@ func addIp6tnlAttrs(ip6tnl *Ip6tnl, linkInfo *nl.RtAttr) {
 	data.AddRtAttr(nl.IFLA_IPTUN_FLAGS, nl.Uint32Attr(ip6tnl.Flags))
 	data.AddRtAttr(nl.IFLA_IPTUN_PROTO, nl.Uint8Attr(ip6tnl.Proto))
 	data.AddRtAttr(nl.IFLA_IPTUN_FLOWINFO, nl.Uint32Attr(ip6tnl.FlowInfo))
+	data.AddRtAttr(nl.IFLA_IPTUN_ENCAP_TYPE, nl.Uint16Attr(ip6tnl.EncapType))
+	data.AddRtAttr(nl.IFLA_IPTUN_ENCAP_FLAGS, nl.Uint16Attr(ip6tnl.EncapFlags))
+	data.AddRtAttr(nl.IFLA_IPTUN_ENCAP_SPORT, htons(ip6tnl.EncapSport))
+	data.AddRtAttr(nl.IFLA_IPTUN_ENCAP_DPORT, htons(ip6tnl.EncapDport))
 }
 
 func parseIp6tnlData(link Link, data []syscall.NetlinkRouteAttr) {


### PR DESCRIPTION
Adds encap type, sport, and dport fields to ip6tnls. Used for fou & gre encap ip6tnls. 