### PR TITLE
Fixes Issue #509 more generically

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -2139,6 +2139,13 @@ func parseVlanData(link Link, data []syscall.NetlinkRouteAttr) {
 func parseVxlanData(link Link, data []syscall.NetlinkRouteAttr) {
 	vxlan := link.(*Vxlan)
 	for _, datum := range data {
+		// NOTE(vish): Apparently some messages can be sent with no value.
+		//             We special case GBP here to not change existing
+		//             functionality. It appears that GBP sends a datum.Value
+		//             of null.
+		if len(datum.Value) == 0 && datum.Attr.Type != nl.IFLA_VXLAN_GBP {
+			continue
+		}
 		switch datum.Attr.Type {
 		case nl.IFLA_VXLAN_ID:
 			vxlan.VxlanId = int(native.Uint32(datum.Value[0:4]))
@@ -2175,11 +2182,7 @@ func parseVxlanData(link Link, data []syscall.NetlinkRouteAttr) {
 		case nl.IFLA_VXLAN_GBP:
 			vxlan.GBP = true
 		case nl.IFLA_VXLAN_FLOWBASED:
-			// NOTE(vish): Apparently this message can be sent with no value.
-			//             Unclear if the others  be sent that way as well.
-			if len(datum.Value) > 0 {
-				vxlan.FlowBased = int8(datum.Value[0]) != 0
-			}
+			vxlan.FlowBased = int8(datum.Value[0]) != 0
 		case nl.IFLA_VXLAN_AGEING:
 			vxlan.Age = int(native.Uint32(datum.Value[0:4]))
 			vxlan.NoAge = vxlan.Age == 0


### PR DESCRIPTION
The first fix #512 apparently didn't solve all cases. This generically
skips values that are null to solve the problem. Also closes #548.