### PR TITLE
Add support for configuring bridge ageing time

### DIFF
--- a/link.go
+++ b/link.go
@@ -247,6 +247,7 @@ func (ifb *Ifb) Type() string {
 type Bridge struct {
 	LinkAttrs
 	MulticastSnooping *bool
+	AgeingTime        *uint32
 	HelloTime         *uint32
 	VlanFiltering     *bool
 }

--- a/link_linux.go
+++ b/link_linux.go
@@ -2825,6 +2825,9 @@ func addBridgeAttrs(bridge *Bridge, linkInfo *nl.RtAttr) {
 	if bridge.MulticastSnooping != nil {
 		data.AddRtAttr(nl.IFLA_BR_MCAST_SNOOPING, boolToByte(*bridge.MulticastSnooping))
 	}
+	if bridge.AgeingTime != nil {
+		data.AddRtAttr(nl.IFLA_BR_AGEING_TIME, nl.Uint32Attr(*bridge.AgeingTime))
+	}
 	if bridge.HelloTime != nil {
 		data.AddRtAttr(nl.IFLA_BR_HELLO_TIME, nl.Uint32Attr(*bridge.HelloTime))
 	}
@@ -2837,6 +2840,9 @@ func parseBridgeData(bridge Link, data []syscall.NetlinkRouteAttr) {
 	br := bridge.(*Bridge)
 	for _, datum := range data {
 		switch datum.Attr.Type {
+		case nl.IFLA_BR_AGEING_TIME:
+			ageingTime := native.Uint32(datum.Value[0:4])
+			br.AgeingTime = &ageingTime
 		case nl.IFLA_BR_HELLO_TIME:
 			helloTime := native.Uint32(datum.Value[0:4])
 			br.HelloTime = &helloTime

--- a/link_test.go
+++ b/link_test.go
@@ -1876,6 +1876,52 @@ func expectVlanFiltering(t *testing.T, linkName string, expected bool) {
 	}
 }
 
+func TestBridgeCreationWithAgeingTime(t *testing.T) {
+	minKernelRequired(t, 3, 18)
+
+	tearDown := setUpNetlinkTest(t)
+	defer tearDown()
+
+	bridgeWithSpecifiedAgeingTimeName := "foo"
+	ageingTime := uint32(20000)
+	bridgeWithSpecifiedAgeingTime := &Bridge{LinkAttrs: LinkAttrs{Name: bridgeWithSpecifiedAgeingTimeName}, AgeingTime: &ageingTime}
+	if err := LinkAdd(bridgeWithSpecifiedAgeingTime); err != nil {
+		t.Fatal(err)
+	}
+
+	retrievedBridge, err := LinkByName(bridgeWithSpecifiedAgeingTimeName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actualAgeingTime := *retrievedBridge.(*Bridge).AgeingTime
+	if actualAgeingTime != ageingTime {
+		t.Fatalf("expected %d got %d", ageingTime, actualAgeingTime)
+	}
+	if err := LinkDel(bridgeWithSpecifiedAgeingTime); err != nil {
+		t.Fatal(err)
+	}
+
+	bridgeWithDefaultAgeingTimeName := "bar"
+	bridgeWithDefaultAgeingTime := &Bridge{LinkAttrs: LinkAttrs{Name: bridgeWithDefaultAgeingTimeName}}
+	if err := LinkAdd(bridgeWithDefaultAgeingTime); err != nil {
+		t.Fatal(err)
+	}
+
+	retrievedBridge, err = LinkByName(bridgeWithDefaultAgeingTimeName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actualAgeingTime = *retrievedBridge.(*Bridge).AgeingTime
+	if actualAgeingTime != 30000 {
+		t.Fatalf("expected %d got %d", 30000, actualAgeingTime)
+	}
+	if err := LinkDel(bridgeWithDefaultAgeingTime); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestBridgeCreationWithHelloTime(t *testing.T) {
 	minKernelRequired(t, 3, 18)
 


### PR DESCRIPTION
Adds support for configuring the ageing time of `netlink.Bridge` links and provides a unit test. This is used in [Ignite](https://github.com/weaveworks/ignite) to disable ageing since it causes issues in the isolation container.