### PR TITLE
Fix incompatible interface to linux implement

### DIFF
--- a/handle_unspecified.go
+++ b/handle_unspecified.go
@@ -85,7 +85,7 @@ func (h *Handle) LinkSetVfRate(link Link, vf, minRate, maxRate int) error {
 	return ErrNotImplemented
 }
 
-func (h *Handle) LinkSetMaster(link Link, master *Bridge) error {
+func (h *Handle) LinkSetMaster(link Link, master Link) error {
 	return ErrNotImplemented
 }
 

--- a/netlink_unspecified.go
+++ b/netlink_unspecified.go
@@ -16,7 +16,7 @@ func LinkSetMTU(link Link, mtu int) error {
 	return ErrNotImplemented
 }
 
-func LinkSetMaster(link Link, master *Bridge) error {
+func LinkSetMaster(link Link, master Link) error {
 	return ErrNotImplemented
 }
 


### PR DESCRIPTION
https://github.com/vishvananda/netlink/pull/491 changed `LinkSetMaster` interface for Linux, but not changed the interface for unspecified.

This PR change to a compatible interface.