### PR TITLE
rule_linux: convert IIFNAME and OIFNAME to null terminated string

### DIFF
--- a/rule_linux.go
+++ b/rule_linux.go
@@ -142,10 +142,10 @@ func ruleHandle(rule *Rule, req *nl.NetlinkRequest) error {
 		}
 	}
 	if rule.IifName != "" {
-		req.AddData(nl.NewRtAttr(nl.FRA_IIFNAME, []byte(rule.IifName)))
+		req.AddData(nl.NewRtAttr(nl.FRA_IIFNAME, []byte(rule.IifName+"\x00")))
 	}
 	if rule.OifName != "" {
-		req.AddData(nl.NewRtAttr(nl.FRA_OIFNAME, []byte(rule.OifName)))
+		req.AddData(nl.NewRtAttr(nl.FRA_OIFNAME, []byte(rule.OifName+"\x00")))
 	}
 	if rule.Goto >= 0 {
 		msg.Type = nl.FR_ACT_GOTO


### PR DESCRIPTION
Strings in GO is not null-terminated while linux is written by
C and strings in C is null-terminated. Request will fail if we
perform rule request with not null-terminated iifname or ofiname,
with error message "no such file or directory".

It has been tested on CentOS 7.x while in newer kernel version such
as 4.19 this issue doesn't exist

Signed-off-by: Wu Zongyong <wuzongyong@linux.alibaba.com>