### PR TITLE
Set default values for link attributes

### DIFF
--- a/link.go
+++ b/link.go
@@ -103,7 +103,8 @@ func (s LinkOperState) String() string {
 // NewLinkAttrs returns LinkAttrs structure filled with default values
 func NewLinkAttrs() LinkAttrs {
 	return LinkAttrs{
-		TxQLen: -1,
+		NetNsID: -1,
+		TxQLen:  -1,
 	}
 }
 

--- a/link_linux.go
+++ b/link_linux.go
@@ -1566,7 +1566,11 @@ func LinkDeserialize(hdr *unix.NlMsghdr, m []byte) (Link, error) {
 		return nil, err
 	}
 
-	base := LinkAttrs{Index: int(msg.Index), RawFlags: msg.Flags, Flags: linkFlags(msg.Flags), EncapType: msg.EncapType()}
+	base := NewLinkAttrs()
+	base.Index = int(msg.Index)
+	base.RawFlags = msg.Flags
+	base.Flags = linkFlags(msg.Flags)
+	base.EncapType = msg.EncapType()
 	if msg.Flags&unix.IFF_PROMISC != 0 {
 		base.Promisc = 1
 	}


### PR DESCRIPTION
When deserializing a link related netlink message, if no network namespace id
attribute is specified, we need to set it to -1 otherwise it defaults to 0
which is a valid id. Using NewLinkAttrs sets the default values and allows
the user to distinguish an empty value from a missing value