### PR TITLE
Adding support for RTA_VIA

### DIFF
--- a/route.go
+++ b/route.go
@@ -45,6 +45,7 @@ type Route struct {
 	MPLSDst          *int
 	NewDst           Destination
 	Encap            Encap
+	Via              Destination
 	MTU              int
 	Window           int
 	Rtt              int
@@ -79,6 +80,9 @@ func (r Route) String() string {
 	if r.Encap != nil {
 		elems = append(elems, fmt.Sprintf("Encap: %s", r.Encap))
 	}
+	if r.Via != nil {
+		elems = append(elems, fmt.Sprintf("Via: %s", r.Via))
+	}
 	elems = append(elems, fmt.Sprintf("Src: %s", r.Src))
 	if len(r.MultiPath) > 0 {
 		elems = append(elems, fmt.Sprintf("Gw: %s", r.MultiPath))
@@ -107,6 +111,7 @@ func (r Route) Equal(x Route) bool {
 		r.Flags == x.Flags &&
 		(r.MPLSDst == x.MPLSDst || (r.MPLSDst != nil && x.MPLSDst != nil && *r.MPLSDst == *x.MPLSDst)) &&
 		(r.NewDst == x.NewDst || (r.NewDst != nil && r.NewDst.Equal(x.NewDst))) &&
+		(r.Via == x.Via || (r.Via != nil && r.Via.Equal(x.Via))) &&
 		(r.Encap == x.Encap || (r.Encap != nil && r.Encap.Equal(x.Encap)))
 }
 
@@ -136,6 +141,7 @@ type NexthopInfo struct {
 	Flags     int
 	NewDst    Destination
 	Encap     Encap
+	Via       Destination
 }
 
 func (n *NexthopInfo) String() string {
@@ -146,6 +152,9 @@ func (n *NexthopInfo) String() string {
 	}
 	if n.Encap != nil {
 		elems = append(elems, fmt.Sprintf("Encap: %s", n.Encap))
+	}
+	if n.Via != nil {
+		elems = append(elems, fmt.Sprintf("Via: %s", n.Via))
 	}
 	elems = append(elems, fmt.Sprintf("Weight: %d", n.Hops+1))
 	elems = append(elems, fmt.Sprintf("Gw: %s", n.Gw))

--- a/route_test.go
+++ b/route_test.go
@@ -1339,3 +1339,69 @@ func TestMTURouteAddDel(t *testing.T) {
 		t.Fatal("Route not removed properly")
 	}
 }
+
+func TestRouteViaAddDel(t *testing.T) {
+	minKernelRequired(t, 5, 4)
+	tearDown := setUpNetlinkTest(t)
+	defer tearDown()
+
+	_, err := RouteList(nil, FAMILY_V4)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	link, err := LinkByName("lo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := LinkSetUp(link); err != nil {
+		t.Fatal(err)
+	}
+
+	route := &Route{
+		LinkIndex: link.Attrs().Index,
+		Dst: &net.IPNet{
+			IP:   net.IPv4(192, 168, 0, 0),
+			Mask: net.CIDRMask(24, 32),
+		},
+		MultiPath: []*NexthopInfo{
+			{
+				LinkIndex: link.Attrs().Index,
+				Via: &Via{
+					AddrFamily: FAMILY_V6,
+					Addr:       net.ParseIP("2001::1"),
+				},
+			},
+		},
+	}
+
+	if err := RouteAdd(route); err != nil {
+		t.Fatalf("route: %v, err: %v", route, err)
+	}
+
+	routes, err := RouteList(link, FAMILY_V4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(routes) != 1 {
+		t.Fatal("Route not added properly")
+	}
+
+	got := routes[0].Via
+	want := route.MultiPath[0].Via
+	if !want.Equal(got) {
+		t.Fatalf("Route Via attribute does not match; got: %s, want: %s", got, want)
+	}
+
+	if err := RouteDel(route); err != nil {
+		t.Fatal(err)
+	}
+	routes, err = RouteList(link, FAMILY_V4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(routes) != 0 {
+		t.Fatal("Route not removed properly")
+	}
+}


### PR DESCRIPTION
RTA_VIA is the netlink attribute type used to specify a gateway for a route using a different address family than said route. An example of this is using a IPv4 next hop for an IPv6 route. This PR adds support to set/get routes containing the RTA netlink attribute type.

Signed-off-by: Steve Shaw <shaw38@gmail.com>