### PR TITLE
Add TxBytes to VFStats collection

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -3001,6 +3001,7 @@ func parseVfInfo(data []syscall.NetlinkRouteAttr, id int) VfInfo {
 			vf.RxPackets = vfstats.RxPackets
 			vf.TxPackets = vfstats.TxPackets
 			vf.RxBytes = vfstats.RxBytes
+			vf.TxBytes = vfstats.TxBytes
 			vf.Multicast = vfstats.Multicast
 			vf.Broadcast = vfstats.Broadcast
 			vf.RxDropped = vfstats.RxDropped


### PR DESCRIPTION
A mistake in #578  meant that txBytes  not included in the stats returned. This commit fixes that error.