### PR TITLE
Support mask for XfrmState's output mark

### DIFF
--- a/xfrm_state.go
+++ b/xfrm_state.go
@@ -94,7 +94,7 @@ type XfrmState struct {
 	Limits       XfrmStateLimits
 	Statistics   XfrmStateStats
 	Mark         *XfrmMark
-	OutputMark   int
+	OutputMark   *XfrmMark
 	Ifid         int
 	Auth         *XfrmStateAlgo
 	Crypt        *XfrmStateAlgo
@@ -104,7 +104,7 @@ type XfrmState struct {
 }
 
 func (sa XfrmState) String() string {
-	return fmt.Sprintf("Dst: %v, Src: %v, Proto: %s, Mode: %s, SPI: 0x%x, ReqID: 0x%x, ReplayWindow: %d, Mark: %v, OutputMark: %d, Ifid: %d, Auth: %v, Crypt: %v, Aead: %v, Encap: %v, ESN: %t",
+	return fmt.Sprintf("Dst: %v, Src: %v, Proto: %s, Mode: %s, SPI: 0x%x, ReqID: 0x%x, ReplayWindow: %d, Mark: %v, OutputMark: %v, Ifid: %d, Auth: %v, Crypt: %v, Aead: %v, Encap: %v, ESN: %t",
 		sa.Dst, sa.Src, sa.Proto, sa.Mode, sa.Spi, sa.Reqid, sa.ReplayWindow, sa.Mark, sa.OutputMark, sa.Ifid, sa.Auth, sa.Crypt, sa.Aead, sa.Encap, sa.ESN)
 }
 func (sa XfrmState) Print(stats bool) string {

--- a/xfrm_state_linux.go
+++ b/xfrm_state_linux.go
@@ -158,9 +158,13 @@ func (h *Handle) xfrmStateAddOrUpdate(state *XfrmState, nlProto int) error {
 		out := nl.NewRtAttr(nl.XFRMA_REPLAY_ESN_VAL, writeReplayEsn(state.ReplayWindow))
 		req.AddData(out)
 	}
-	if state.OutputMark != 0 {
-		out := nl.NewRtAttr(nl.XFRMA_OUTPUT_MARK, nl.Uint32Attr(uint32(state.OutputMark)))
+	if state.OutputMark != nil {
+		out := nl.NewRtAttr(nl.XFRMA_SET_MARK, nl.Uint32Attr(state.OutputMark.Value))
 		req.AddData(out)
+		if state.OutputMark.Mask != 0 {
+			out = nl.NewRtAttr(nl.XFRMA_SET_MARK_MASK, nl.Uint32Attr(state.OutputMark.Mask))
+			req.AddData(out)
+		}
 	}
 
 	ifId := nl.NewRtAttr(nl.XFRMA_IF_ID, nl.Uint32Attr(uint32(state.Ifid)))
@@ -377,8 +381,19 @@ func parseXfrmState(m []byte, family int) (*XfrmState, error) {
 			state.Mark = new(XfrmMark)
 			state.Mark.Value = mark.Value
 			state.Mark.Mask = mark.Mask
-		case nl.XFRMA_OUTPUT_MARK:
-			state.OutputMark = int(native.Uint32(attr.Value))
+		case nl.XFRMA_SET_MARK:
+			if state.OutputMark == nil {
+				state.OutputMark = new(XfrmMark)
+			}
+			state.OutputMark.Value = native.Uint32(attr.Value)
+		case nl.XFRMA_SET_MARK_MASK:
+			if state.OutputMark == nil {
+				state.OutputMark = new(XfrmMark)
+			}
+			state.OutputMark.Mask = native.Uint32(attr.Value)
+			if state.OutputMark.Mask == 0xffffffff {
+				state.OutputMark.Mask = 0
+			}
 		case nl.XFRMA_IF_ID:
 			state.Ifid = int(native.Uint32(attr.Value))
 		}


### PR DESCRIPTION
XfrmState currently doesn't allow setting the mask for the output mark. As a result, setting an output mark always clears all bits. This pull request adds support for the mask value.