### PR TITLE
Add ipvtap link support

### DIFF
--- a/link.go
+++ b/link.go
@@ -456,6 +456,19 @@ func (ipvlan *IPVlan) Type() string {
 	return "ipvlan"
 }
 
+// IPVtap - IPVtap is a virtual interfaces based on ipvlan
+type IPVtap struct {
+	IPVlan
+}
+
+func (ipvtap *IPVtap) Attrs() *LinkAttrs {
+	return &ipvtap.LinkAttrs
+}
+
+func (ipvtap IPVtap) Type() string {
+	return "ipvtap"
+}
+
 // VlanProtocol type
 type VlanProtocol int
 


### PR DESCRIPTION
ipvtap is a similar link type as ipvlan with tap interface.

This patch enables it just like macvtap.

Signed-off-by: Wei Yang <richard.weiyang@gmail.com>