### PR TITLE
Properly handle uint64 for HTB class rate/ceil

### DIFF
--- a/class_linux.go
+++ b/class_linux.go
@@ -176,6 +176,12 @@ func classPayload(req *nl.NetlinkRequest, class Class) error {
 		options.AddRtAttr(nl.TCA_HTB_PARMS, opt.Serialize())
 		options.AddRtAttr(nl.TCA_HTB_RTAB, SerializeRtab(rtab))
 		options.AddRtAttr(nl.TCA_HTB_CTAB, SerializeRtab(ctab))
+		if htb.Rate >= uint64(1<<32) {
+			options.AddRtAttr(nl.TCA_HTB_RATE64, nl.Uint64Attr(htb.Rate))
+		}
+		if htb.Ceil >= uint64(1<<32) {
+			options.AddRtAttr(nl.TCA_HTB_CEIL64, nl.Uint64Attr(htb.Ceil))
+		}
 	case "hfsc":
 		hfsc := class.(*HfscClass)
 		opt := nl.HfscCopt{}
@@ -306,6 +312,10 @@ func parseHtbClassData(class Class, data []syscall.NetlinkRouteAttr) (bool, erro
 			htb.Quantum = opt.Quantum
 			htb.Level = opt.Level
 			htb.Prio = opt.Prio
+		case nl.TCA_HTB_RATE64:
+			htb.Rate = native.Uint64(datum.Value[0:8])
+		case nl.TCA_HTB_CEIL64:
+			htb.Ceil = native.Uint64(datum.Value[0:8])
 		}
 	}
 	return detailed, nil

--- a/class_test.go
+++ b/class_test.go
@@ -268,7 +268,8 @@ func TestHtbClassAddHtbClassChangeDel(t *testing.T) {
 	}
 
 	htbclassattrs := HtbClassAttrs{
-		Rate:    1234000,
+		Rate:    uint64(1<<32) + 10,
+		Ceil:    uint64(1<<32) + 20,
 		Cbuffer: 1690,
 	}
 	class := NewHtbClass(classattrs, htbclassattrs)


### PR DESCRIPTION
Currently, providing a rate or a ceil with a value higher than the `uint32` max results in the value overflowing and a HTB class with wrong ceil/rate is created without any errors. The kernel already supports `uint64` values so adding support for it to the library was relatively easy.

I also adjusted the test to use large values to verify that it works properly. With the old implementation, the same test would fail