### PR TITLE
Make IPSet actually support IPs, and fix protocol errors for newer kernels

### DIFF
--- a/cmd/ipset-test/main.go
+++ b/cmd/ipset-test/main.go
@@ -26,8 +26,8 @@ var (
 		"destroy":  {cmdDestroy, "creates a new ipset", 1},
 		"list":     {cmdList, "list specific ipset", 1},
 		"listall":  {cmdListAll, "list all ipsets", 0},
-		"add":      {cmdAddDel(netlink.IpsetAdd), "add entry", 1},
-		"del":      {cmdAddDel(netlink.IpsetDel), "delete entry", 1},
+		"add":      {cmdAddDel(netlink.IpsetAdd), "add entry", 2},
+		"del":      {cmdAddDel(netlink.IpsetDel), "delete entry", 2},
 	}
 
 	timeoutVal   *uint32
@@ -89,9 +89,9 @@ func printUsage() {
 }
 
 func cmdProtocol(_ []string) {
-	protocol, err := netlink.IpsetProtocol()
+	protocol, minProto, err := netlink.IpsetProtocol()
 	check(err)
-	log.Println("Protocol:", protocol)
+	log.Println("Protocol:", protocol, "min:", minProto)
 }
 
 func cmdCreate(args []string) {

--- a/ipset_linux.go
+++ b/ipset_linux.go
@@ -23,13 +23,15 @@ type IPSetEntry struct {
 
 // IPSetResult is the result of a dump request for a set
 type IPSetResult struct {
-	Nfgenmsg *nl.Nfgenmsg
-	Protocol uint8
-	Revision uint8
-	Family   uint8
-	Flags    uint8
-	SetName  string
-	TypeName string
+	Nfgenmsg           *nl.Nfgenmsg
+	Protocol           uint8
+	ProtocolMinVersion uint8
+	Revision           uint8
+	Family             uint8
+	Flags              uint8
+	SetName            string
+	TypeName           string
+	Comment            string
 
 	HashSize     uint32
 	NumEntries   uint32
@@ -38,6 +40,7 @@ type IPSetResult struct {
 	SizeInMemory uint32
 	CadtFlags    uint32
 	Timeout      *uint32
+	LineNo       uint32
 
 	Entries []IPSetEntry
 }
@@ -52,7 +55,7 @@ type IpsetCreateOptions struct {
 }
 
 // IpsetProtocol returns the ipset protocol version from the kernel
-func IpsetProtocol() (uint8, error) {
+func IpsetProtocol() (uint8, uint8, error) {
 	return pkgHandle.IpsetProtocol()
 }
 
@@ -86,20 +89,20 @@ func IpsetAdd(setname string, entry *IPSetEntry) error {
 	return pkgHandle.ipsetAddDel(nl.IPSET_CMD_ADD, setname, entry)
 }
 
-// IpsetDele deletes an entry from an existing ipset.
+// IpsetDel deletes an entry from an existing ipset.
 func IpsetDel(setname string, entry *IPSetEntry) error {
 	return pkgHandle.ipsetAddDel(nl.IPSET_CMD_DEL, setname, entry)
 }
 
-func (h *Handle) IpsetProtocol() (uint8, error) {
+func (h *Handle) IpsetProtocol() (protocol uint8, minVersion uint8, err error) {
 	req := h.newIpsetRequest(nl.IPSET_CMD_PROTOCOL)
 	msgs, err := req.Execute(unix.NETLINK_NETFILTER, 0)
 
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
-
-	return ipsetUnserialize(msgs).Protocol, nil
+	response := ipsetUnserialize(msgs)
+	return response.Protocol, response.ProtocolMinVersion, nil
 }
 
 func (h *Handle) IpsetCreate(setname, typename string, options IpsetCreateOptions) error {
@@ -112,7 +115,7 @@ func (h *Handle) IpsetCreate(setname, typename string, options IpsetCreateOption
 	req.AddData(nl.NewRtAttr(nl.IPSET_ATTR_SETNAME, nl.ZeroTerminated(setname)))
 	req.AddData(nl.NewRtAttr(nl.IPSET_ATTR_TYPENAME, nl.ZeroTerminated(typename)))
 	req.AddData(nl.NewRtAttr(nl.IPSET_ATTR_REVISION, nl.Uint8Attr(0)))
-	req.AddData(nl.NewRtAttr(nl.IPSET_ATTR_FAMILY, nl.Uint8Attr(0)))
+	req.AddData(nl.NewRtAttr(nl.IPSET_ATTR_FAMILY, nl.Uint8Attr(2))) // 2 == inet
 
 	data := nl.NewRtAttr(nl.IPSET_ATTR_DATA|int(nl.NLA_F_NESTED), nil)
 
@@ -187,6 +190,11 @@ func (h *Handle) IpsetListAll() ([]IPSetResult, error) {
 func (h *Handle) ipsetAddDel(nlCmd int, setname string, entry *IPSetEntry) error {
 	req := h.newIpsetRequest(nlCmd)
 	req.AddData(nl.NewRtAttr(nl.IPSET_ATTR_SETNAME, nl.ZeroTerminated(setname)))
+
+	if entry.Comment != "" {
+		req.AddData(nl.NewRtAttr(nl.IPSET_ATTR_COMMENT, nl.ZeroTerminated(entry.Comment)))
+	}
+
 	data := nl.NewRtAttr(nl.IPSET_ATTR_DATA|int(nl.NLA_F_NESTED), nil)
 
 	if !entry.Replace {
@@ -197,7 +205,12 @@ func (h *Handle) ipsetAddDel(nlCmd int, setname string, entry *IPSetEntry) error
 		data.AddChild(&nl.Uint32Attribute{Type: nl.IPSET_ATTR_TIMEOUT | nl.NLA_F_NET_BYTEORDER, Value: *entry.Timeout})
 	}
 	if entry.MAC != nil {
-		data.AddChild(nl.NewRtAttr(nl.IPSET_ATTR_ETHER, entry.MAC))
+		nestedData := nl.NewRtAttr(nl.IPSET_ATTR_ETHER|int(nl.NLA_F_NET_BYTEORDER), entry.MAC)
+		data.AddChild(nl.NewRtAttr(nl.IPSET_ATTR_ETHER|int(nl.NLA_F_NESTED), nestedData.Serialize()))
+	}
+	if entry.IP != nil {
+		nestedData := nl.NewRtAttr(nl.IPSET_ATTR_IP|int(nl.NLA_F_NET_BYTEORDER), entry.IP)
+		data.AddChild(nl.NewRtAttr(nl.IPSET_ATTR_IP|int(nl.NLA_F_NESTED), nestedData.Serialize()))
 	}
 
 	data.AddChild(&nl.Uint32Attribute{Type: nl.IPSET_ATTR_LINENO | nl.NLA_F_NET_BYTEORDER, Value: 0})
@@ -249,6 +262,8 @@ func (result *IPSetResult) unserialize(msg []byte) {
 			result.Protocol = attr.Value[0]
 		case nl.IPSET_ATTR_SETNAME:
 			result.SetName = nl.BytesToString(attr.Value)
+		case nl.IPSET_ATTR_COMMENT:
+			result.Comment = nl.BytesToString(attr.Value)
 		case nl.IPSET_ATTR_TYPENAME:
 			result.TypeName = nl.BytesToString(attr.Value)
 		case nl.IPSET_ATTR_REVISION:
@@ -261,6 +276,8 @@ func (result *IPSetResult) unserialize(msg []byte) {
 			result.parseAttrData(attr.Value)
 		case nl.IPSET_ATTR_ADT | nl.NLA_F_NESTED:
 			result.parseAttrADT(attr.Value)
+		case nl.IPSET_ATTR_PROTOCOL_MIN:
+			result.ProtocolMinVersion = attr.Value[0]
 		default:
 			log.Printf("unknown ipset attribute from kernel: %+v %v", attr, attr.Type&nl.NLA_TYPE_MASK)
 		}
@@ -285,6 +302,17 @@ func (result *IPSetResult) parseAttrData(data []byte) {
 			result.SizeInMemory = attr.Uint32()
 		case nl.IPSET_ATTR_CADT_FLAGS | nl.NLA_F_NET_BYTEORDER:
 			result.CadtFlags = attr.Uint32()
+		case nl.IPSET_ATTR_IP | nl.NLA_F_NESTED:
+			for nested := range nl.ParseAttributes(attr.Value) {
+				switch nested.Type {
+				case nl.IPSET_ATTR_IP | nl.NLA_F_NET_BYTEORDER:
+					result.Entries = append(result.Entries, IPSetEntry{IP: nested.Value})
+				}
+			}
+		case nl.IPSET_ATTR_CADT_LINENO | nl.NLA_F_NET_BYTEORDER:
+			result.LineNo = attr.Uint32()
+		case nl.IPSET_ATTR_COMMENT:
+			result.Comment = nl.BytesToString(attr.Value)
 		default:
 			log.Printf("unknown ipset data attribute from kernel: %+v %v", attr, attr.Type&nl.NLA_TYPE_MASK)
 		}
@@ -316,6 +344,8 @@ func parseIPSetEntry(data []byte) (entry IPSetEntry) {
 			entry.Packets = &val
 		case nl.IPSET_ATTR_ETHER:
 			entry.MAC = net.HardwareAddr(attr.Value)
+		case nl.IPSET_ATTR_IP:
+			entry.IP = net.IP(attr.Value)
 		case nl.IPSET_ATTR_COMMENT:
 			entry.Comment = nl.BytesToString(attr.Value)
 		case nl.IPSET_ATTR_IP | nl.NLA_F_NESTED:


### PR DESCRIPTION
Fixes https://github.com/vishvananda/netlink/issues/609

Added support for IPSets based on IP rather than just MAC address.

With the release of IPSet v7, the protocol response for `PROTOCOL_MIN` is now potentially more relevant, so the `IpsetProtocol()` function has been updated to return this too.

I'd like to improve the protocol testing of all functions this area to ensure protocol parity with the userland ipset binary at some point (I built a debug version of http://git.netfilter.org/ipset/ using `-DIPSET_DEBUG` and this patch:
```patch
Index: lib/debug.c
===================================================================
diff --git a/lib/debug.c b/lib/debug.c
--- a/lib/debug.c	(revision 258b4c0e7fc5e3365a113d6d80c7d6770e55cc4a)
+++ b/lib/debug.c	(date 1614930673366)
@@ -292,6 +292,12 @@
 			;
 		}
 		cmd = ipset_get_nlmsg_type(nlh);
+                fprintf(stderr, "Message payload: \n");
+                for (int i = 0; i < len; i++) {
+                  fprintf(stderr, "%02X", ((uint8_t*)buffer)[i]);
+                }
+
+                fprintf(stderr, "\n");
 		fprintf(stderr, "Message header: %s cmd  %s (%d)\n"
 				"\tlen %d\n"
 				"\tflag %s\n"

```
which prints out the serialised payloads being sent, but this package will need some refactoring to make the request generation independent of the request execution - I might put that into a separate PR