### PR TITLE
Fix non-linux build

### DIFF
--- a/route.go
+++ b/route.go
@@ -3,31 +3,11 @@ package netlink
 import (
 	"fmt"
 	"net"
-	"strconv"
 	"strings"
-
-	"golang.org/x/sys/unix"
 )
 
 // Scope is an enum representing a route scope.
 type Scope uint8
-
-func (s Scope) String() string {
-	switch s {
-	case SCOPE_UNIVERSE:
-		return "universe"
-	case SCOPE_SITE:
-		return "site"
-	case SCOPE_LINK:
-		return "link"
-	case SCOPE_HOST:
-		return "host"
-	case SCOPE_NOWHERE:
-		return "nowhere"
-	default:
-		return "unknown"
-	}
-}
 
 type NextHopFlag int
 
@@ -49,57 +29,6 @@ type Encap interface {
 
 //Protocol describe what was the originator of the route
 type RouteProtocol int
-
-func (p RouteProtocol) String() string {
-	switch int(p) {
-	case unix.RTPROT_BABEL:
-		return "babel"
-	case unix.RTPROT_BGP:
-		return "bgp"
-	case unix.RTPROT_BIRD:
-		return "bird"
-	case unix.RTPROT_BOOT:
-		return "boot"
-	case unix.RTPROT_DHCP:
-		return "dhcp"
-	case unix.RTPROT_DNROUTED:
-		return "dnrouted"
-	case unix.RTPROT_EIGRP:
-		return "eigrp"
-	case unix.RTPROT_GATED:
-		return "gated"
-	case unix.RTPROT_ISIS:
-		return "isis"
-	//case unix.RTPROT_KEEPALIVED:
-	//	return "keepalived"
-	case unix.RTPROT_KERNEL:
-		return "kernel"
-	case unix.RTPROT_MROUTED:
-		return "mrouted"
-	case unix.RTPROT_MRT:
-		return "mrt"
-	case unix.RTPROT_NTK:
-		return "ntk"
-	case unix.RTPROT_OSPF:
-		return "ospf"
-	case unix.RTPROT_RA:
-		return "ra"
-	case unix.RTPROT_REDIRECT:
-		return "redirect"
-	case unix.RTPROT_RIP:
-		return "rip"
-	case unix.RTPROT_STATIC:
-		return "static"
-	case unix.RTPROT_UNSPEC:
-		return "unspec"
-	case unix.RTPROT_XORP:
-		return "xorp"
-	case unix.RTPROT_ZEBRA:
-		return "zebra"
-	default:
-		return strconv.Itoa(int(p))
-	}
-}
 
 // Route represents a netlink route.
 type Route struct {

--- a/route_linux.go
+++ b/route_linux.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -22,6 +23,23 @@ const (
 	SCOPE_HOST     Scope = unix.RT_SCOPE_HOST
 	SCOPE_NOWHERE  Scope = unix.RT_SCOPE_NOWHERE
 )
+
+func (s Scope) String() string {
+	switch s {
+	case SCOPE_UNIVERSE:
+		return "universe"
+	case SCOPE_SITE:
+		return "site"
+	case SCOPE_LINK:
+		return "link"
+	case SCOPE_HOST:
+		return "host"
+	case SCOPE_NOWHERE:
+		return "nowhere"
+	default:
+		return "unknown"
+	}
+}
 
 const (
 	RT_FILTER_PROTOCOL uint64 = 1 << (1 + iota)
@@ -1306,4 +1324,55 @@ func routeSubscribeAt(newNs, curNs netns.NsHandle, ch chan<- RouteUpdate, done <
 	}()
 
 	return nil
+}
+
+func (p RouteProtocol) String() string {
+	switch int(p) {
+	case unix.RTPROT_BABEL:
+		return "babel"
+	case unix.RTPROT_BGP:
+		return "bgp"
+	case unix.RTPROT_BIRD:
+		return "bird"
+	case unix.RTPROT_BOOT:
+		return "boot"
+	case unix.RTPROT_DHCP:
+		return "dhcp"
+	case unix.RTPROT_DNROUTED:
+		return "dnrouted"
+	case unix.RTPROT_EIGRP:
+		return "eigrp"
+	case unix.RTPROT_GATED:
+		return "gated"
+	case unix.RTPROT_ISIS:
+		return "isis"
+	//case unix.RTPROT_KEEPALIVED:
+	//	return "keepalived"
+	case unix.RTPROT_KERNEL:
+		return "kernel"
+	case unix.RTPROT_MROUTED:
+		return "mrouted"
+	case unix.RTPROT_MRT:
+		return "mrt"
+	case unix.RTPROT_NTK:
+		return "ntk"
+	case unix.RTPROT_OSPF:
+		return "ospf"
+	case unix.RTPROT_RA:
+		return "ra"
+	case unix.RTPROT_REDIRECT:
+		return "redirect"
+	case unix.RTPROT_RIP:
+		return "rip"
+	case unix.RTPROT_STATIC:
+		return "static"
+	case unix.RTPROT_UNSPEC:
+		return "unspec"
+	case unix.RTPROT_XORP:
+		return "xorp"
+	case unix.RTPROT_ZEBRA:
+		return "zebra"
+	default:
+		return strconv.Itoa(int(p))
+	}
 }

--- a/route_unspecified.go
+++ b/route_unspecified.go
@@ -2,10 +2,20 @@
 
 package netlink
 
+import "strconv"
+
 func (r *Route) ListFlags() []string {
 	return []string{}
 }
 
 func (n *NexthopInfo) ListFlags() []string {
 	return []string{}
+}
+
+func (s Scope) String() string {
+	return "unknown"
+}
+
+func (p RouteProtocol) String() string {
+	return strconv.Itoa(int(p))
 }


### PR DESCRIPTION
Commit ec93726159ae ("Adds strings translation methods") broke non-Linux
builds by relying on unix constants that are only declared on the linux
platform in the upstream x/sys/unix package.

Other platforms report undefined variables, such as the following:

```
  $ GOOS=darwin go build .
  # github.com/vishvananda/netlink
  ./route.go:17:7: undefined: SCOPE_UNIVERSE
  ./route.go:19:7: undefined: SCOPE_SITE
  ./route.go:21:7: undefined: SCOPE_LINK
  ./route.go:23:7: undefined: SCOPE_HOST
  ./route.go:25:7: undefined: SCOPE_NOWHERE
  ./route.go:55:7: undefined: unix.RTPROT_BABEL
  ./route.go:57:7: undefined: unix.RTPROT_BGP
  ./route.go:59:7: undefined: unix.RTPROT_BIRD
  ./route.go:61:7: undefined: unix.RTPROT_BOOT
  ./route.go:63:7: undefined: unix.RTPROT_DHCP
  ./route.go:63:7: too many errors
```

Move the platform-specific implementations to platform-specific files
and add stubs to satisfy other platforms.

Fixes: ec93726159ae ("Adds strings translation methods")

CC @RiccardoManfrin @aboch
