### PR TITLE
Remove "=======" characters left over from merge

### DIFF
--- a/route_linux.go
+++ b/route_linux.go
@@ -550,7 +550,6 @@ func (h *Handle) RouteAppend(route *Route) error {
 	return h.routeHandle(route, req, nl.NewRtMsg())
 }
 
-=======
 // RouteAddEcmp will add a route to the system.
 func RouteAddEcmp(route *Route) error {
         return pkgHandle.RouteAddEcmp(route)


### PR DESCRIPTION

Remove "=======" characters left over from merge

Signed-off-by: Michael Cambria <mcambria@redhat.com>