### PR TITLE
Provide the allmulticast option as own link attribute

### DIFF
--- a/link.go
+++ b/link.go
@@ -35,6 +35,7 @@ type LinkAttrs struct {
 	Alias        string
 	Statistics   *LinkStatistics
 	Promisc      int
+	Allmulti     int
 	Xdp          *LinkXdp
 	EncapType    string
 	Protinfo     *Protinfo

--- a/link_linux.go
+++ b/link_linux.go
@@ -153,7 +153,6 @@ func (h *Handle) LinkSetAllmulticastOn(link Link) error {
 	msg := nl.NewIfInfomsg(unix.AF_UNSPEC)
 	msg.Change = unix.IFF_ALLMULTI
 	msg.Flags = unix.IFF_ALLMULTI
-
 	msg.Index = int32(base.Index)
 	req.AddData(msg)
 
@@ -1624,7 +1623,7 @@ func execGetLink(req *nl.NetlinkRequest) (Link, error) {
 	}
 }
 
-// linkDeserialize deserializes a raw message received from netlink into
+// LinkDeserialize deserializes a raw message received from netlink into
 // a link object.
 func LinkDeserialize(hdr *unix.NlMsghdr, m []byte) (Link, error) {
 	msg := nl.DeserializeIfInfomsg(m)
@@ -1641,6 +1640,9 @@ func LinkDeserialize(hdr *unix.NlMsghdr, m []byte) (Link, error) {
 	base.EncapType = msg.EncapType()
 	if msg.Flags&unix.IFF_PROMISC != 0 {
 		base.Promisc = 1
+	}
+	if msg.Flags&unix.IFF_ALLMULTI != 0 {
+		base.Allmulti = 1
 	}
 	var (
 		link      Link

--- a/link_test.go
+++ b/link_test.go
@@ -2636,8 +2636,6 @@ func TestLinkSetAllmulticast(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rawFlagsStart := link.Attrs().RawFlags
-
 	if err := LinkSetAllmulticastOn(link); err != nil {
 		t.Fatal(err)
 	}
@@ -2647,7 +2645,7 @@ func TestLinkSetAllmulticast(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if link.Attrs().RawFlags&unix.IFF_ALLMULTI != uint32(unix.IFF_ALLMULTI) {
+	if link.Attrs().Allmulti != 1 {
 		t.Fatal("IFF_ALLMULTI was not set")
 	}
 
@@ -2660,13 +2658,8 @@ func TestLinkSetAllmulticast(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if link.Attrs().RawFlags&unix.IFF_ALLMULTI != 0 {
+	if link.Attrs().Allmulti != 0 {
 		t.Fatal("IFF_ALLMULTI is still set")
-	}
-
-	rawFlagsEnd := link.Attrs().RawFlags
-	if rawFlagsStart != rawFlagsEnd {
-		t.Fatalf("RawFlags start value:%d differs from end value:%d", rawFlagsStart, rawFlagsEnd)
 	}
 }
 


### PR DESCRIPTION
The `ip link` option allmulticast enables or disables the reception of all hardware multicast packets.

This PR provide the status of the allmulticast option via a highlevel link attribute instead of requiring raw flag handling. This also hides the dependencies to platform specific files for the user of this library.