### PR TITLE
Don't re-initialize package level var native in `(*Handle).RouteGetWithOptions`

### DIFF
--- a/route_linux.go
+++ b/route_linux.go
@@ -1200,10 +1200,7 @@ func (h *Handle) RouteGetWithOptions(destination net.IP, options *RouteGetOption
 				return nil, err
 			}
 
-			var (
-				b      = make([]byte, 4)
-				native = nl.NativeEndian()
-			)
+			b := make([]byte, 4)
 			native.PutUint32(b, uint32(link.Attrs().Index))
 
 			req.AddData(nl.NewRtAttr(unix.RTA_IIF, b))


### PR DESCRIPTION
This was missed in #637 due to it being introduced by #623, which was
merged just recently.