### PR TITLE
Ability to set multicast attribute on a link

### DIFF
--- a/link.go
+++ b/link.go
@@ -36,6 +36,7 @@ type LinkAttrs struct {
 	Statistics   *LinkStatistics
 	Promisc      int
 	Allmulti     int
+	Multi        int
 	Xdp          *LinkXdp
 	EncapType    string
 	Protinfo     *Protinfo

--- a/link_test.go
+++ b/link_test.go
@@ -2663,6 +2663,56 @@ func TestLinkSetAllmulticast(t *testing.T) {
 	}
 }
 
+func TestLinkSetMulticast(t *testing.T) {
+	tearDown := setUpNetlinkTest(t)
+	defer tearDown()
+
+	iface := &Veth{LinkAttrs: LinkAttrs{Name: "foo"}, PeerName: "bar"}
+	if err := LinkAdd(iface); err != nil {
+		t.Fatal(err)
+	}
+
+	link, err := LinkByName("foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := LinkSetUp(link); err != nil {
+		t.Fatal(err)
+	}
+
+	link, err = LinkByName("foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := LinkSetMulticastOn(link); err != nil {
+		t.Fatal(err)
+	}
+
+	link, err = LinkByName("foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if link.Attrs().Multi != 1 {
+		t.Fatal("IFF_MULTICAST was not set")
+	}
+
+	if err := LinkSetMulticastOff(link); err != nil {
+		t.Fatal(err)
+	}
+
+	link, err = LinkByName("foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if link.Attrs().Multi != 0 {
+		t.Fatal("IFF_MULTICAST is still set")
+	}
+}
+
 func TestLinkSetMacvlanMode(t *testing.T) {
 	tearDown := setUpNetlinkTest(t)
 	defer tearDown()


### PR DESCRIPTION
We are able to set the ALLMULTI attribute on a link, via LinkSetAllmulticast(). This change allows you to set the regular multicast attribute with LinkSetMulticast()