### PR TITLE
Make IPSet actually support hash set types

### DIFF
--- a/ipset_linux.go
+++ b/ipset_linux.go
@@ -1,6 +1,7 @@
 package netlink
 
 import (
+	"encoding/binary"
 	"log"
 	"net"
 	"syscall"
@@ -11,12 +12,19 @@ import (
 
 // IPSetEntry is used for adding, updating, retreiving and deleting entries
 type IPSetEntry struct {
-	Comment string
-	MAC     net.HardwareAddr
-	IP      net.IP
-	Timeout *uint32
-	Packets *uint64
-	Bytes   *uint64
+	Comment  string
+	MAC      net.HardwareAddr
+	IP       net.IP
+	CIDR     uint8
+	Timeout  *uint32
+	Packets  *uint64
+	Bytes    *uint64
+	Protocol *uint8
+	Port     *uint16
+	IP2      net.IP
+	CIDR2    uint8
+	IFace    string
+	Mark     *uint32
 
 	Replace bool // replace existing entry
 }
@@ -32,6 +40,12 @@ type IPSetResult struct {
 	SetName            string
 	TypeName           string
 	Comment            string
+	MarkMask           uint32
+
+	IPFrom   net.IP
+	IPTo     net.IP
+	PortFrom uint16
+	PortTo   uint16
 
 	HashSize     uint32
 	NumEntries   uint32
@@ -52,6 +66,12 @@ type IpsetCreateOptions struct {
 	Counters bool
 	Comments bool
 	Skbinfo  bool
+
+	Revision uint8
+	IPFrom   net.IP
+	IPTo     net.IP
+	PortFrom uint16
+	PortTo   uint16
 }
 
 // IpsetProtocol returns the ipset protocol version from the kernel
@@ -86,12 +106,12 @@ func IpsetListAll() ([]IPSetResult, error) {
 
 // IpsetAdd adds an entry to an existing ipset.
 func IpsetAdd(setname string, entry *IPSetEntry) error {
-	return pkgHandle.ipsetAddDel(nl.IPSET_CMD_ADD, setname, entry)
+	return pkgHandle.IpsetAdd(setname, entry)
 }
 
 // IpsetDel deletes an entry from an existing ipset.
 func IpsetDel(setname string, entry *IPSetEntry) error {
-	return pkgHandle.ipsetAddDel(nl.IPSET_CMD_DEL, setname, entry)
+	return pkgHandle.IpsetDel(setname, entry)
 }
 
 func (h *Handle) IpsetProtocol() (protocol uint8, minVersion uint8, err error) {
@@ -114,10 +134,29 @@ func (h *Handle) IpsetCreate(setname, typename string, options IpsetCreateOption
 
 	req.AddData(nl.NewRtAttr(nl.IPSET_ATTR_SETNAME, nl.ZeroTerminated(setname)))
 	req.AddData(nl.NewRtAttr(nl.IPSET_ATTR_TYPENAME, nl.ZeroTerminated(typename)))
-	req.AddData(nl.NewRtAttr(nl.IPSET_ATTR_REVISION, nl.Uint8Attr(0)))
-	req.AddData(nl.NewRtAttr(nl.IPSET_ATTR_FAMILY, nl.Uint8Attr(2))) // 2 == inet
+
+	revision := options.Revision
+	if revision == 0 {
+		revision = getIpsetDefaultWithTypeName(typename)
+	}
+	req.AddData(nl.NewRtAttr(nl.IPSET_ATTR_REVISION, nl.Uint8Attr(revision)))
 
 	data := nl.NewRtAttr(nl.IPSET_ATTR_DATA|int(nl.NLA_F_NESTED), nil)
+
+	var family uint8
+	switch typename {
+	case "hash:mac":
+	case "bitmap:port":
+		buf := make([]byte, 4)
+		binary.BigEndian.PutUint16(buf, options.PortFrom)
+		binary.BigEndian.PutUint16(buf[2:], options.PortTo)
+		data.AddChild(nl.NewRtAttr(nl.IPSET_ATTR_PORT_FROM|int(nl.NLA_F_NET_BYTEORDER), buf[:2]))
+		data.AddChild(nl.NewRtAttr(nl.IPSET_ATTR_PORT_TO|int(nl.NLA_F_NET_BYTEORDER), buf[2:]))
+	default:
+		family = unix.AF_INET
+	}
+
+	req.AddData(nl.NewRtAttr(nl.IPSET_ATTR_FAMILY, nl.Uint8Attr(family)))
 
 	if timeout := options.Timeout; timeout != nil {
 		data.AddChild(&nl.Uint32Attribute{Type: nl.IPSET_ATTR_TIMEOUT | nl.NLA_F_NET_BYTEORDER, Value: *timeout})
@@ -187,6 +226,16 @@ func (h *Handle) IpsetListAll() ([]IPSetResult, error) {
 	return result, nil
 }
 
+// IpsetAdd adds an entry to an existing ipset.
+func (h *Handle) IpsetAdd(setname string, entry *IPSetEntry) error {
+	return h.ipsetAddDel(nl.IPSET_CMD_ADD, setname, entry)
+}
+
+// IpsetDel deletes an entry from an existing ipset.
+func (h *Handle) IpsetDel(setname string, entry *IPSetEntry) error {
+	return h.ipsetAddDel(nl.IPSET_CMD_DEL, setname, entry)
+}
+
 func (h *Handle) ipsetAddDel(nlCmd int, setname string, entry *IPSetEntry) error {
 	req := h.newIpsetRequest(nlCmd)
 	req.AddData(nl.NewRtAttr(nl.IPSET_ATTR_SETNAME, nl.ZeroTerminated(setname)))
@@ -204,13 +253,47 @@ func (h *Handle) ipsetAddDel(nlCmd int, setname string, entry *IPSetEntry) error
 	if entry.Timeout != nil {
 		data.AddChild(&nl.Uint32Attribute{Type: nl.IPSET_ATTR_TIMEOUT | nl.NLA_F_NET_BYTEORDER, Value: *entry.Timeout})
 	}
-	if entry.MAC != nil {
-		nestedData := nl.NewRtAttr(nl.IPSET_ATTR_ETHER|int(nl.NLA_F_NET_BYTEORDER), entry.MAC)
-		data.AddChild(nl.NewRtAttr(nl.IPSET_ATTR_ETHER|int(nl.NLA_F_NESTED), nestedData.Serialize()))
-	}
+
 	if entry.IP != nil {
 		nestedData := nl.NewRtAttr(nl.IPSET_ATTR_IP|int(nl.NLA_F_NET_BYTEORDER), entry.IP)
 		data.AddChild(nl.NewRtAttr(nl.IPSET_ATTR_IP|int(nl.NLA_F_NESTED), nestedData.Serialize()))
+	}
+
+	if entry.MAC != nil {
+		data.AddChild(nl.NewRtAttr(nl.IPSET_ATTR_ETHER, entry.MAC))
+	}
+
+	if entry.CIDR != 0 {
+		data.AddChild(nl.NewRtAttr(nl.IPSET_ATTR_CIDR, nl.Uint8Attr(entry.CIDR)))
+	}
+
+	if entry.IP2 != nil {
+		nestedData := nl.NewRtAttr(nl.IPSET_ATTR_IP|int(nl.NLA_F_NET_BYTEORDER), entry.IP2)
+		data.AddChild(nl.NewRtAttr(nl.IPSET_ATTR_IP2|int(nl.NLA_F_NESTED), nestedData.Serialize()))
+	}
+
+	if entry.CIDR2 != 0 {
+		data.AddChild(nl.NewRtAttr(nl.IPSET_ATTR_CIDR2, nl.Uint8Attr(entry.CIDR2)))
+	}
+
+	if entry.Port != nil {
+		if entry.Protocol == nil {
+			// use tcp protocol as default
+			val := uint8(unix.IPPROTO_TCP)
+			entry.Protocol = &val
+		}
+		data.AddChild(nl.NewRtAttr(nl.IPSET_ATTR_PROTO, nl.Uint8Attr(*entry.Protocol)))
+		buf := make([]byte, 2)
+		binary.BigEndian.PutUint16(buf, *entry.Port)
+		data.AddChild(nl.NewRtAttr(int(nl.IPSET_ATTR_PORT|nl.NLA_F_NET_BYTEORDER), buf))
+	}
+
+	if entry.IFace != "" {
+		data.AddChild(nl.NewRtAttr(nl.IPSET_ATTR_IFACE, nl.ZeroTerminated(entry.IFace)))
+	}
+
+	if entry.Mark != nil {
+		data.AddChild(&nl.Uint32Attribute{Type: nl.IPSET_ATTR_MARK | nl.NLA_F_NET_BYTEORDER, Value: *entry.Mark})
 	}
 
 	data.AddChild(&nl.Uint32Attribute{Type: nl.IPSET_ATTR_LINENO | nl.NLA_F_NET_BYTEORDER, Value: 0})
@@ -233,6 +316,17 @@ func (h *Handle) newIpsetRequest(cmd int) *nl.NetlinkRequest {
 	req.AddData(nl.NewRtAttr(nl.IPSET_ATTR_PROTOCOL, nl.Uint8Attr(nl.IPSET_PROTOCOL)))
 
 	return req
+}
+
+func getIpsetDefaultWithTypeName(typename string) uint8 {
+	switch typename {
+	case "hash:ip,port",
+		"hash:ip,port,ip",
+		"hash:ip,port,net",
+		"hash:net,port":
+		return 1
+	}
+	return 0
 }
 
 func ipsetExecute(req *nl.NetlinkRequest) (msgs [][]byte, err error) {
@@ -278,6 +372,8 @@ func (result *IPSetResult) unserialize(msg []byte) {
 			result.parseAttrADT(attr.Value)
 		case nl.IPSET_ATTR_PROTOCOL_MIN:
 			result.ProtocolMinVersion = attr.Value[0]
+		case nl.IPSET_ATTR_MARKMASK:
+			result.MarkMask = attr.Uint32()
 		default:
 			log.Printf("unknown ipset attribute from kernel: %+v %v", attr, attr.Type&nl.NLA_TYPE_MASK)
 		}
@@ -307,12 +403,31 @@ func (result *IPSetResult) parseAttrData(data []byte) {
 				switch nested.Type {
 				case nl.IPSET_ATTR_IP | nl.NLA_F_NET_BYTEORDER:
 					result.Entries = append(result.Entries, IPSetEntry{IP: nested.Value})
+				case nl.IPSET_ATTR_IP:
+					result.IPFrom = nested.Value
+				default:
+					log.Printf("unknown nested ipset data attribute from kernel: %+v %v", nested, nested.Type&nl.NLA_TYPE_MASK)
 				}
 			}
+		case nl.IPSET_ATTR_IP_TO | nl.NLA_F_NESTED:
+			for nested := range nl.ParseAttributes(attr.Value) {
+				switch nested.Type {
+				case nl.IPSET_ATTR_IP:
+					result.IPTo = nested.Value
+				default:
+					log.Printf("unknown nested ipset data attribute from kernel: %+v %v", nested, nested.Type&nl.NLA_TYPE_MASK)
+				}
+			}
+		case nl.IPSET_ATTR_PORT_FROM | nl.NLA_F_NET_BYTEORDER:
+			result.PortFrom = networkOrder.Uint16(attr.Value)
+		case nl.IPSET_ATTR_PORT_TO | nl.NLA_F_NET_BYTEORDER:
+			result.PortTo = networkOrder.Uint16(attr.Value)
 		case nl.IPSET_ATTR_CADT_LINENO | nl.NLA_F_NET_BYTEORDER:
 			result.LineNo = attr.Uint32()
 		case nl.IPSET_ATTR_COMMENT:
 			result.Comment = nl.BytesToString(attr.Value)
+		case nl.IPSET_ATTR_MARKMASK:
+			result.MarkMask = attr.Uint32()
 		default:
 			log.Printf("unknown ipset data attribute from kernel: %+v %v", attr, attr.Type&nl.NLA_TYPE_MASK)
 		}
@@ -357,6 +472,30 @@ func parseIPSetEntry(data []byte) (entry IPSetEntry) {
 					log.Printf("unknown nested ADT attribute from kernel: %+v", attr)
 				}
 			}
+		case nl.IPSET_ATTR_IP2 | nl.NLA_F_NESTED:
+			for attr := range nl.ParseAttributes(attr.Value) {
+				switch attr.Type {
+				case nl.IPSET_ATTR_IP:
+					entry.IP2 = net.IP(attr.Value)
+				default:
+					log.Printf("unknown nested ADT attribute from kernel: %+v", attr)
+				}
+			}
+		case nl.IPSET_ATTR_CIDR:
+			entry.CIDR = attr.Value[0]
+		case nl.IPSET_ATTR_CIDR2:
+			entry.CIDR2 = attr.Value[0]
+		case nl.IPSET_ATTR_PORT | nl.NLA_F_NET_BYTEORDER:
+			val := networkOrder.Uint16(attr.Value)
+			entry.Port = &val
+		case nl.IPSET_ATTR_PROTO:
+			val := attr.Value[0]
+			entry.Protocol = &val
+		case nl.IPSET_ATTR_IFACE:
+			entry.IFace = nl.BytesToString(attr.Value)
+		case nl.IPSET_ATTR_MARK | nl.NLA_F_NET_BYTEORDER:
+			val := attr.Uint32()
+			entry.Mark = &val
 		default:
 			log.Printf("unknown ADT attribute from kernel: %+v", attr)
 		}


### PR DESCRIPTION
- support hash set types:
  - `hash:ip`
  - `hash:ip,mac`
  - `hash:ip,mark`
  - `hash:ip,port`
  - `hash:ip,port,ip`
  - `hash:ip,port,net`
  - `hash:net`
  - `hash:net,iface`
  - `hash:net,net`
  - `hash:net,port`
  - `hash:net,port,net`
- add support for `bitmap:port` set type
