### PR TITLE
Parse and expose conntrack timestamps

### DIFF
--- a/nl/conntrack_linux.go
+++ b/nl/conntrack_linux.go
@@ -44,6 +44,7 @@ const (
 	NLA_F_NESTED        uint16 = (1 << 15) // #define NLA_F_NESTED (1 << 15)
 	NLA_F_NET_BYTEORDER uint16 = (1 << 14) // #define NLA_F_NESTED (1 << 14)
 	NLA_TYPE_MASK              = ^(NLA_F_NESTED | NLA_F_NET_BYTEORDER)
+	NLA_ALIGNTO         uint16 = 4 // #define NLA_ALIGNTO 4
 )
 
 // enum ctattr_type {


### PR DESCRIPTION
This PR makes `parseRawData` from `conntrack_linux.go` a bit more robust by properly skipping all unhandled NLAs and also adds support to parse timeout and [timestamps](https://patchwork.ozlabs.org/project/netdev/patch/1295464519-21763-79-git-send-email-kaber@trash.net/) from the conntrack data if present. A unit test was added to validate that the function works as expected.
Contributors: @naiming-zededa, @gkodali-zededa and me.