### PR TITLE
Correct panic when IPv4 lacks IFA_ADDRESS address

### DIFF
--- a/addr_linux.go
+++ b/addr_linux.go
@@ -268,7 +268,7 @@ func parseAddr(m []byte) (addr Addr, family int, err error) {
 	// But obviously, as there are IPv6 PtP addresses, too,
 	// IFA_LOCAL should also be handled for IPv6.
 	if local != nil {
-		if family == FAMILY_V4 && local.IP.Equal(dst.IP) {
+		if family == FAMILY_V4 && dst != nil && local.IP.Equal(dst.IP) {
 			addr.IPNet = dst
 		} else {
 			addr.IPNet = local


### PR DESCRIPTION
IFA_ADDRESS is to be used as the peer address if it differs from IFA_LOCAL.
Therefore, include the check for "no IFA_ADDRESS" in the difference check.

Example: ppp interfaces can contain IFA_LOCAL and no IFA_ADDRESS attribute

Signed-off-by: Joe Swantek <joseph.swantek@northwestern.edu>