### PR TITLE
rule: add support for ipproto

### DIFF
--- a/rule.go
+++ b/rule.go
@@ -25,6 +25,7 @@ type Rule struct {
 	Invert            bool
 	Dport             *RulePortRange
 	Sport             *RulePortRange
+	IPProto           int
 }
 
 func (r Rule) String() string {

--- a/rule_linux.go
+++ b/rule_linux.go
@@ -162,6 +162,12 @@ func ruleHandle(rule *Rule, req *nl.NetlinkRequest) error {
 		req.AddData(nl.NewRtAttr(nl.FRA_SPORT_RANGE, b))
 	}
 
+	if rule.IPProto > 0 {
+		b := make([]byte, 4)
+		native.PutUint32(b, uint32(rule.IPProto))
+		req.AddData(nl.NewRtAttr(nl.FRA_IP_PROTO, b))
+	}
+
 	_, err := req.Execute(unix.NETLINK_ROUTE, 0)
 	return err
 }

--- a/rule_test.go
+++ b/rule_test.go
@@ -33,6 +33,7 @@ func TestRuleAddDel(t *testing.T) {
 	rule.Tos = 0x10
 	rule.Dport = NewRulePortRange(80, 80)
 	rule.Sport = NewRulePortRange(1000, 1024)
+	rule.IPProto = unix.IPPROTO_UDP
 	if err := RuleAdd(rule); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This is similar to https://github.com/vishvananda/netlink/pull/511, but this time for the `ipproto` option:
```
ip rule add ipproto xxx table main
```