### PR TITLE
Provide handle Close() and deprecate Delete()

### DIFF
--- a/handle_linux.go
+++ b/handle_linux.go
@@ -15,7 +15,7 @@ var pkgHandle = &Handle{}
 // Handle is an handle for the netlink requests on a
 // specific network namespace. All the requests on the
 // same netlink family share the same netlink socket,
-// which gets released when the handle is deleted.
+// which gets released when the handle is Close'd.
 type Handle struct {
 	sockets      map[int]*nl.SocketHandle
 	lookupByDump bool
@@ -136,12 +136,20 @@ func newHandle(newNs, curNs netns.NsHandle, nlFamilies ...int) (*Handle, error) 
 	return h, nil
 }
 
-// Delete releases the resources allocated to this handle
-func (h *Handle) Delete() {
+// Close releases the resources allocated to this handle
+func (h *Handle) Close() {
 	for _, sh := range h.sockets {
 		sh.Close()
 	}
 	h.sockets = nil
+}
+
+// Delete releases the resources allocated to this handle
+//
+// Deprecated: use Close instead which is in line with typical resource release
+// patterns for files and other resources.
+func (h *Handle) Delete() {
+	h.Close()
 }
 
 func (h *Handle) newNetlinkRequest(proto, flags int) *nl.NetlinkRequest {

--- a/handle_linux_test.go
+++ b/handle_linux_test.go
@@ -12,6 +12,6 @@ func TestSetGetSocketTimeout(t *testing.T) {
 	}
 
 	if val := GetSocketTimeout(); val != timeout {
-		t.Fatalf("Unexpcted socket timeout value: got=%v, expected=%v", val, timeout)
+		t.Fatalf("Unexpected socket timeout value: got=%v, expected=%v", val, timeout)
 	}
 }

--- a/handle_test.go
+++ b/handle_test.go
@@ -19,7 +19,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func TestHandleCreateDelete(t *testing.T) {
+func TestHandleCreateClose(t *testing.T) {
 	h, err := NewHandle()
 	if err != nil {
 		t.Fatal(err)
@@ -34,9 +34,9 @@ func TestHandleCreateDelete(t *testing.T) {
 		}
 	}
 
-	h.Delete()
+	h.Close()
 	if h.sockets != nil {
-		t.Fatalf("Handle socket(s) were not destroyed")
+		t.Fatalf("Handle socket(s) were not closed")
 	}
 }
 
@@ -60,7 +60,7 @@ func TestHandleCreateNetns(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer ch.Delete()
+	defer ch.Close()
 
 	// Create an handle on a custom netns
 	newNs, err := netns.New()
@@ -73,7 +73,7 @@ func TestHandleCreateNetns(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer nh.Delete()
+	defer nh.Close()
 
 	// Create an interface using the current handle
 	err = ch.LinkAdd(&Dummy{LinkAttrs{Name: ifName}})
@@ -119,7 +119,7 @@ func TestHandleTimeout(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer h.Delete()
+	defer h.Close()
 
 	for _, sh := range h.sockets {
 		verifySockTimeVal(t, sh.Socket.GetFd(), unix.Timeval{Sec: 0, Usec: 0})
@@ -137,7 +137,7 @@ func TestHandleReceiveBuffer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer h.Delete()
+	defer h.Close()
 	if err := h.SetSocketReceiveBufferSize(65536, false); err != nil {
 		t.Fatal(err)
 	}
@@ -255,10 +255,10 @@ func parallelDone() {
 			ns2.Close()
 		}
 		if handle1 != nil {
-			handle1.Delete()
+			handle1.Close()
 		}
 		if handle2 != nil {
-			handle2.Delete()
+			handle2.Close()
 		}
 	}
 }

--- a/handle_unspecified.go
+++ b/handle_unspecified.go
@@ -23,6 +23,8 @@ func NewHandleAtFrom(newNs, curNs netns.NsHandle) (*Handle, error) {
 	return nil, ErrNotImplemented
 }
 
+func (h *Handle) Close() {}
+
 func (h *Handle) Delete() {}
 
 func (h *Handle) SupportsNetlinkFamily(nlFamily int) bool {

--- a/link_test.go
+++ b/link_test.go
@@ -1830,7 +1830,7 @@ func TestLinkSubscribeAt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer nh.Delete()
+	defer nh.Close()
 
 	// Subscribe for Link events on the custom netns
 	ch := make(chan LinkUpdate)
@@ -1880,7 +1880,7 @@ func TestLinkSubscribeListExisting(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer nh.Delete()
+	defer nh.Close()
 
 	link := &Veth{LinkAttrs{Name: "test", TxQLen: testTxQLen, MTU: 1400}, "bar", nil, nil}
 	if err := nh.LinkAdd(link); err != nil {

--- a/neigh_test.go
+++ b/neigh_test.go
@@ -408,7 +408,7 @@ func TestNeighSubscribeAt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer nh.Delete()
+	defer nh.Close()
 
 	// Subscribe for Neigh events on the custom netns
 	ch := make(chan NeighUpdate)
@@ -462,7 +462,7 @@ func TestNeighSubscribeListExisting(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer nh.Delete()
+	defer nh.Close()
 
 	dummy := &Dummy{LinkAttrs{Name: "neigh0"}}
 	if err := nh.LinkAdd(dummy); err != nil {

--- a/route_test.go
+++ b/route_test.go
@@ -416,7 +416,7 @@ func TestRouteSubscribeAt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer nh.Delete()
+	defer nh.Close()
 
 	// Subscribe for Route events on the custom netns
 	ch := make(chan RouteUpdate)
@@ -474,7 +474,7 @@ func TestRouteSubscribeListExisting(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer nh.Delete()
+	defer nh.Close()
 
 	// get loopback interface
 	link, err := nh.LinkByName("lo")


### PR DESCRIPTION
* issue #682
* provides a new `Close` method on netlink handles and deprecates the existing `Delete` method.
* Refactors other code including unit tests to use the new `Close` method.

Closes #689 