### PR TITLE
Export LinkModify function

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -1146,6 +1146,10 @@ func (h *Handle) LinkAdd(link Link) error {
 	return h.linkModify(link, unix.NLM_F_CREATE|unix.NLM_F_EXCL|unix.NLM_F_ACK)
 }
 
+func LinkModify(link Link) error {
+	return pkgHandle.LinkModify(link)
+}
+
 func (h *Handle) LinkModify(link Link) error {
 	return h.linkModify(link, unix.NLM_F_REQUEST|unix.NLM_F_ACK)
 }

--- a/link_test.go
+++ b/link_test.go
@@ -615,7 +615,7 @@ func TestLinkModify(t *testing.T) {
 	}
 
 	link.MTU = updatedMTU
-	if err := pkgHandle.LinkModify(link); err != nil {
+	if err := LinkModify(link); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
When the LinkModify was merged in [1] a function
that exports it outside of pkgHandle was never
added like is available for LinkAdd, LinkDel etc.

Update testing to use exported LinkModify that
itself calls the pkgHandle.LinkModify function.

[1] https://github.com/vishvananda/netlink/pull/541