### PR TITLE
ipset: support creation of inet6 sets

### DIFF
--- a/nl/ipset_linux.go
+++ b/nl/ipset_linux.go
@@ -54,6 +54,8 @@ const (
 
 /* CADT specific attributes */
 const (
+	IPSET_ATTR_IPV4        = 1
+	IPSET_ATTR_IPV6        = 2
 	IPSET_ATTR_IP          = 1
 	IPSET_ATTR_IP_FROM     = 1
 	IPSET_ATTR_IP_TO       = 2


### PR DESCRIPTION
This PR adds support for AF_INET6 address and network management in the ipset code.