### PR TITLE
Set NetNsId to -1 when attr is not specified

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -1707,6 +1707,7 @@ func LinkDeserialize(hdr *unix.NlMsghdr, m []byte) (Link, error) {
 	base.RawFlags = msg.Flags
 	base.Flags = linkFlags(msg.Flags)
 	base.EncapType = msg.EncapType()
+	base.NetNsID = -1
 	if msg.Flags&unix.IFF_PROMISC != 0 {
 		base.Promisc = 1
 	}


### PR DESCRIPTION
This attribute is not specified on interfaces not tied to a specific network namespace and so it is not present in the netlink message. When it is the case, `LinkDeserialize` does not deserialize anything in the `base.NetNsId` field and the default value of `base.NetNsId` is 0. However, 0 is also a valid value for an existing netns id. Because of this, there is no way to know if the netns was not specified or if it is currently the existing netns with the id 0.

This PR defaults the netns id to -1 so there is no more confusion (which is also the default value returned by your `netns` library when returning a non existing `NsHandle`).