### PR TITLE
Add support for NDA_FLAGS_EXT neighboring attribute

### DIFF
--- a/neigh.go
+++ b/neigh.go
@@ -12,6 +12,7 @@ type Neigh struct {
 	State        int
 	Type         int
 	Flags        int
+	FlagsExt     int
 	IP           net.IP
 	HardwareAddr net.HardwareAddr
 	LLIPAddr     net.IP //Used in the case of NHRP

--- a/neigh_linux.go
+++ b/neigh_linux.go
@@ -24,7 +24,11 @@ const (
 	NDA_MASTER
 	NDA_LINK_NETNSID
 	NDA_SRC_VNI
-	NDA_MAX = NDA_SRC_VNI
+	NDA_PROTOCOL
+	NDA_NH_ID
+	NDA_FDB_EXT_ATTRS
+	NDA_FLAGS_EXT
+	NDA_MAX = NDA_FLAGS_EXT
 )
 
 // Neighbor Cache Entry States.
@@ -47,7 +51,14 @@ const (
 	NTF_MASTER      = 0x04
 	NTF_PROXY       = 0x08
 	NTF_EXT_LEARNED = 0x10
+	NTF_OFFLOADED   = 0x20
+	NTF_STICKY      = 0x40
 	NTF_ROUTER      = 0x80
+)
+
+// Extended Neighbor Flags
+const (
+	NTF_EXT_MANAGED = 0x00000001
 )
 
 // Ndmsg is for adding, removing or receiving information about a neighbor table entry
@@ -166,6 +177,11 @@ func neighHandle(neigh *Neigh, req *nl.NetlinkRequest) error {
 	} else if neigh.Flags != NTF_PROXY || neigh.HardwareAddr != nil {
 		hwData := nl.NewRtAttr(NDA_LLADDR, []byte(neigh.HardwareAddr))
 		req.AddData(hwData)
+	}
+
+	if neigh.FlagsExt != 0 {
+		flagsExtData := nl.NewRtAttr(NDA_FLAGS_EXT, nl.Uint32Attr(uint32(neigh.FlagsExt)))
+		req.AddData(flagsExtData)
 	}
 
 	if neigh.Vlan != 0 {
@@ -306,6 +322,8 @@ func NeighDeserialize(m []byte) (*Neigh, error) {
 			} else {
 				neigh.HardwareAddr = net.HardwareAddr(attr.Value)
 			}
+		case NDA_FLAGS_EXT:
+			neigh.FlagsExt = int(native.Uint32(attr.Value[0:4]))
 		case NDA_VLAN:
 			neigh.Vlan = int(native.Uint16(attr.Value[0:2]))
 		case NDA_VNI:

--- a/neigh_linux.go
+++ b/neigh_linux.go
@@ -174,7 +174,7 @@ func neighHandle(neigh *Neigh, req *nl.NetlinkRequest) error {
 	if neigh.LLIPAddr != nil {
 		llIPData := nl.NewRtAttr(NDA_LLADDR, neigh.LLIPAddr.To4())
 		req.AddData(llIPData)
-	} else if neigh.Flags != NTF_PROXY || neigh.HardwareAddr != nil {
+	} else if neigh.HardwareAddr != nil {
 		hwData := nl.NewRtAttr(NDA_LLADDR, []byte(neigh.HardwareAddr))
 		req.AddData(hwData)
 	}


### PR DESCRIPTION
This allows to set NTF_EXT_MANAGED neighbor flag for managed neighbor
entries as per kernel commit 7482e3841d52 ("net, neigh: Add NTF_MANAGED
flag for managed neighbor entries"). The flag then indicates to the
kernel that the neighbor entry should be periodically probed for keeping
the entry in NUD_REACHABLE state iff possible.

Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>