### PR TITLE
Add support for VCAN

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -1853,6 +1853,8 @@ func LinkDeserialize(hdr *unix.NlMsghdr, m []byte) (Link, error) {
 						link = &Tuntap{}
 					case "ipoib":
 						link = &IPoIB{}
+					case "vcan":
+						fallthrough
 					case "can":
 						link = &Can{}
 					case "bareudp":


### PR DESCRIPTION
Dummy strategy in order to make `vcan` interpreted as `can`.

Does it sounds acceptable ? Or would you rather use a dedicated struct for handling `vcan` interfaces ?

Cheers.