### PR TITLE
rule: add support for ipproto - fix review comments

### DIFF
--- a/rule.go
+++ b/rule.go
@@ -25,6 +25,7 @@ type Rule struct {
 	Invert            bool
 	Dport             *RulePortRange
 	Sport             *RulePortRange
+	IPProto           int
 }
 
 func (r Rule) String() string {

--- a/rule_linux.go
+++ b/rule_linux.go
@@ -162,6 +162,12 @@ func ruleHandle(rule *Rule, req *nl.NetlinkRequest) error {
 		req.AddData(nl.NewRtAttr(nl.FRA_SPORT_RANGE, b))
 	}
 
+	if rule.IPProto > 0 {
+		b := make([]byte, 4)
+		native.PutUint32(b, uint32(rule.IPProto))
+		req.AddData(nl.NewRtAttr(nl.FRA_IP_PROTO, b))
+	}
+
 	_, err := req.Execute(unix.NETLINK_ROUTE, 0)
 	return err
 }

--- a/rule_linux.go
+++ b/rule_linux.go
@@ -152,6 +152,12 @@ func ruleHandle(rule *Rule, req *nl.NetlinkRequest) error {
 		req.AddData(nl.NewRtAttr(nl.FRA_GOTO, b))
 	}
 
+	if rule.IPProto > 0 {
+		b := make([]byte, 4)
+		native.PutUint32(b, uint32(rule.IPProto))
+		req.AddData(nl.NewRtAttr(nl.FRA_IP_PROTO, b))
+	}
+
 	if rule.Dport != nil {
 		b := rule.Dport.toRtAttrData()
 		req.AddData(nl.NewRtAttr(nl.FRA_DPORT_RANGE, b))
@@ -160,12 +166,6 @@ func ruleHandle(rule *Rule, req *nl.NetlinkRequest) error {
 	if rule.Sport != nil {
 		b := rule.Sport.toRtAttrData()
 		req.AddData(nl.NewRtAttr(nl.FRA_SPORT_RANGE, b))
-	}
-
-	if rule.IPProto > 0 {
-		b := make([]byte, 4)
-		native.PutUint32(b, uint32(rule.IPProto))
-		req.AddData(nl.NewRtAttr(nl.FRA_IP_PROTO, b))
 	}
 
 	_, err := req.Execute(unix.NETLINK_ROUTE, 0)
@@ -256,6 +256,8 @@ func (h *Handle) RuleListFiltered(family int, filter *Rule, filterMask uint64) (
 				rule.Goto = int(native.Uint32(attrs[j].Value[0:4]))
 			case nl.FRA_PRIORITY:
 				rule.Priority = int(native.Uint32(attrs[j].Value[0:4]))
+			case nl.FRA_IP_PROTO:
+				rule.IPProto = int(native.Uint32(attrs[j].Value[0:4]))
 			case nl.FRA_DPORT_RANGE:
 				rule.Dport = NewRulePortRange(native.Uint16(attrs[j].Value[0:2]), native.Uint16(attrs[j].Value[2:4]))
 			case nl.FRA_SPORT_RANGE:

--- a/rule_test.go
+++ b/rule_test.go
@@ -418,5 +418,6 @@ func ruleEquals(a, b Rule) bool {
 		a.Priority == b.Priority &&
 		a.IifName == b.IifName &&
 		a.Invert == b.Invert &&
-		a.Tos == b.Tos
+		a.Tos == b.Tos &&
+		a.IPProto == b.IPProto
 }

--- a/rule_test.go
+++ b/rule_test.go
@@ -33,6 +33,7 @@ func TestRuleAddDel(t *testing.T) {
 	rule.Tos = 0x10
 	rule.Dport = NewRulePortRange(80, 80)
 	rule.Sport = NewRulePortRange(1000, 1024)
+	rule.IPProto = unix.IPPROTO_UDP
 	if err := RuleAdd(rule); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR is a continuation of this one - https://github.com/vishvananda/netlink/pull/686
Closes: https://github.com/vishvananda/netlink/pull/686

We are very interested in this functionality, and we would like it to be merged in as soon as possible.
In this PR I fixed a comment from the previous one.

## Description
This is similar to #511, but this time for the `ipproto` option:
`ip rule add ipproto xxx table main`