### PR TITLE
add build on macOS test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,3 +24,21 @@ jobs:
 
     - name: Test
       run: sudo -E env PATH=$PATH go test -v ./ ./nl
+
+  build-macos:
+    # netlink is Linux-only, but this ensures that netlink builds without error
+    # on macOS, which helps catch missing build tags.
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+          
+    - name: Build
+      run: go build ./...
+
+    - name: Test
+      run: go test ./...


### PR DESCRIPTION
netlink is Linux-only, but adding this test ensures that netlink builds
without error on macOS, which helps catch missing build tags.

cc @aditighag who found the problem and is submitting a PR to fix the missing build tags.