### PR TITLE
Only set IFLA_XFRM_IF_ID if not 0

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -3226,8 +3226,9 @@ func parseVfInfo(data []syscall.NetlinkRouteAttr, id int) VfInfo {
 func addXfrmiAttrs(xfrmi *Xfrmi, linkInfo *nl.RtAttr) {
 	data := linkInfo.AddRtAttr(nl.IFLA_INFO_DATA, nil)
 	data.AddRtAttr(nl.IFLA_XFRM_LINK, nl.Uint32Attr(uint32(xfrmi.ParentIndex)))
-	data.AddRtAttr(nl.IFLA_XFRM_IF_ID, nl.Uint32Attr(xfrmi.Ifid))
-
+	if xfrmi.Ifid != 0 {
+		data.AddRtAttr(nl.IFLA_XFRM_IF_ID, nl.Uint32Attr(xfrmi.Ifid))
+	}
 }
 
 func parseXfrmiData(link Link, data []syscall.NetlinkRouteAttr) {


### PR DESCRIPTION
A value of 0 for IFLA_XFRM_IF_ID is not valid and will be rejected by
the kernel by returning EINVAL, see [1]. Thus, only set the
IFLA_XFRM_IF_ID attribute in case Xfrmi.Ifid != 0.

[1] https://github.com/torvalds/linux/blob/8efd0d9c316af470377894a6a0f9ff63ce18c177/net/xfrm/xfrm_interface.c#L645-L648