### PR TITLE
Fix test on 32bit arch

### DIFF
--- a/xfrm_policy_test.go
+++ b/xfrm_policy_test.go
@@ -280,7 +280,7 @@ func getPolicy() *XfrmPolicy {
 		Dst:   net.ParseIP("127.0.0.2"),
 		Proto: XFRM_PROTO_ESP,
 		Mode:  XFRM_MODE_TUNNEL,
-		Spi:   0xabcdef99,
+		Spi:   0x1bcdef99,
 	}
 	policy.Tmpls = append(policy.Tmpls, tmpl)
 	return policy


### PR DESCRIPTION
When I run tests on 32bit arch, I got

```
$ GOARCH=386 go test ./... -v
# github.com/vishvananda/netlink [github.com/vishvananda/netlink.test]
./xfrm_policy_test.go:283:3: constant 2882400153 overflows int
FAIL    github.com/vishvananda/netlink [build failed]
```