### PR TITLE
nl_linux: Set NETLINK_GET_STRICT_CHK on sockets

### DIFF
--- a/nl/nl_linux.go
+++ b/nl/nl_linux.go
@@ -518,6 +518,10 @@ func getNetlinkSocket(protocol int) (*NetlinkSocket, error) {
 	if err != nil {
 		return nil, err
 	}
+	err = unix.SetsockoptInt(fd, unix.SOL_SOCKET, unix.NETLINK_GET_STRICT_CHK, 1)
+	if err != nil {
+		return nil, err
+	}
 	s := &NetlinkSocket{
 		fd: int32(fd),
 	}


### PR DESCRIPTION
Adds the GET_STRICT_CHK option on netlink sockets to avoid missing
routes due to a kernel bug[1]. The choice to set this option on all new
sockets copies the iproute2 behaviour fix[2]

[1]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=885b8b4dbba5ca6114db0fcd0737fe2512650745
[2]: https://git.kernel.org/pub/scm/network/iproute2/iproute2.git/commit/ip?id=aea41afcfd6d6547dd2e80ddde8df7e3b2800482