### PR TITLE
nl_linux: Set NETLINK_GET_STRICT_CHK on sockets

### DIFF
--- a/addr_linux.go
+++ b/addr_linux.go
@@ -176,7 +176,7 @@ func AddrList(link Link, family int) ([]Addr, error) {
 // The list can be filtered by link and ip family.
 func (h *Handle) AddrList(link Link, family int) ([]Addr, error) {
 	req := h.newNetlinkRequest(unix.RTM_GETADDR, unix.NLM_F_DUMP)
-	msg := nl.NewIfInfomsg(family)
+	msg := nl.NewIfAddrmsg(family)
 	req.AddData(msg)
 
 	msgs, err := req.Execute(unix.NETLINK_ROUTE, unix.RTM_NEWADDR)

--- a/handle_linux.go
+++ b/handle_linux.go
@@ -107,6 +107,21 @@ func (h *Handle) GetSocketReceiveBufferSize() ([]int, error) {
 	return results, nil
 }
 
+// SetStrictCheck sets the strict check socket option for each socket in the netlink handle. Returns early if any set operation fails
+func (h *Handle) SetStrictCheck(state bool) error {
+	for _, sh := range h.sockets {
+		var stateInt int = 0
+		if state {
+			stateInt = 1
+		}
+		err := unix.SetsockoptInt(sh.Socket.GetFd(), unix.SOL_NETLINK, unix.NETLINK_GET_STRICT_CHK, stateInt)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // NewHandleAt returns a netlink handle on the network namespace
 // specified by ns. If ns=netns.None(), current network namespace
 // will be assumed

--- a/route_linux.go
+++ b/route_linux.go
@@ -1030,8 +1030,9 @@ func RouteListFiltered(family int, filter *Route, filterMask uint64) ([]Route, e
 // All rules must be defined in RouteFilter struct
 func (h *Handle) RouteListFiltered(family int, filter *Route, filterMask uint64) ([]Route, error) {
 	req := h.newNetlinkRequest(unix.RTM_GETROUTE, unix.NLM_F_DUMP)
-	infmsg := nl.NewIfInfomsg(family)
-	req.AddData(infmsg)
+	rtmsg := nl.NewRtMsg()
+	rtmsg.Family = uint8(family)
+	req.AddData(rtmsg)
 
 	msgs, err := req.Execute(unix.NETLINK_ROUTE, unix.RTM_NEWROUTE)
 	if err != nil {


### PR DESCRIPTION
Adds the GET_STRICT_CHK option on netlink sockets to avoid missing
routes due to a kernel bug[1]. The choice to set this option on all new
sockets copies the iproute2 behaviour fix[2]

[1]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=885b8b4dbba5ca6114db0fcd0737fe2512650745
[2]: https://git.kernel.org/pub/scm/network/iproute2/iproute2.git/commit/ip?id=aea41afcfd6d6547dd2e80ddde8df7e3b2800482