### PR TITLE
Ignore ENOPROTOOPT error when setting NETLINK_EXT_ACK to 0

### DIFF
--- a/nl/nl_linux.go
+++ b/nl/nl_linux.go
@@ -798,7 +798,13 @@ func (s *NetlinkSocket) SetExtAck(enable bool) error {
 		enableN = 1
 	}
 
-	return unix.SetsockoptInt(int(s.fd), unix.SOL_NETLINK, unix.NETLINK_EXT_ACK, enableN)
+	var err error
+	if err = unix.SetsockoptInt(int(s.fd), unix.SOL_NETLINK, unix.NETLINK_EXT_ACK, enableN); err == unix.ENOPROTOOPT && !enable {
+		// older kernels may not support NETLINK_EXT_ACK
+		return nil
+	}
+
+	return err
 }
 
 func (s *NetlinkSocket) GetPid() (uint32, error) {


### PR DESCRIPTION
Fix for https://github.com/vishvananda/netlink/issues/751