### PR TITLE
Support XFRMA_SA_EXTRA_FLAGS attribute

### DIFF
--- a/nl/xfrm_state_linux.go
+++ b/nl/xfrm_state_linux.go
@@ -28,6 +28,11 @@ const (
 	XFRM_STATE_ESN        = 128
 )
 
+const (
+	XFRM_SA_XFLAG_DONT_ENCAP_DSCP = 1
+	XFRM_SA_XFLAG_OSEQ_MAY_WRAP   = 2
+)
+
 // struct xfrm_usersa_id {
 //   xfrm_address_t      daddr;
 //   __be32        spi;
@@ -103,6 +108,7 @@ func (msg *XfrmStats) Serialize() []byte {
 // };
 //
 // #define XFRM_SA_XFLAG_DONT_ENCAP_DSCP 1
+// #define XFRM_SA_XFLAG_OSEQ_MAY_WRAP   2
 //
 
 type XfrmUsersaInfo struct {

--- a/xfrm_state.go
+++ b/xfrm_state.go
@@ -84,28 +84,30 @@ type XfrmStateStats struct {
 // XfrmState represents the state of an ipsec policy. It optionally
 // contains an XfrmStateAlgo for encryption and one for authentication.
 type XfrmState struct {
-	Dst          net.IP
-	Src          net.IP
-	Proto        Proto
-	Mode         Mode
-	Spi          int
-	Reqid        int
-	ReplayWindow int
-	Limits       XfrmStateLimits
-	Statistics   XfrmStateStats
-	Mark         *XfrmMark
-	OutputMark   *XfrmMark
-	Ifid         int
-	Auth         *XfrmStateAlgo
-	Crypt        *XfrmStateAlgo
-	Aead         *XfrmStateAlgo
-	Encap        *XfrmStateEncap
-	ESN          bool
+	Dst           net.IP
+	Src           net.IP
+	Proto         Proto
+	Mode          Mode
+	Spi           int
+	Reqid         int
+	ReplayWindow  int
+	Limits        XfrmStateLimits
+	Statistics    XfrmStateStats
+	Mark          *XfrmMark
+	OutputMark    *XfrmMark
+	Ifid          int
+	Auth          *XfrmStateAlgo
+	Crypt         *XfrmStateAlgo
+	Aead          *XfrmStateAlgo
+	Encap         *XfrmStateEncap
+	ESN           bool
+	DontEncapDSCP bool
+	OSeqMayWrap   bool
 }
 
 func (sa XfrmState) String() string {
-	return fmt.Sprintf("Dst: %v, Src: %v, Proto: %s, Mode: %s, SPI: 0x%x, ReqID: 0x%x, ReplayWindow: %d, Mark: %v, OutputMark: %v, Ifid: %d, Auth: %v, Crypt: %v, Aead: %v, Encap: %v, ESN: %t",
-		sa.Dst, sa.Src, sa.Proto, sa.Mode, sa.Spi, sa.Reqid, sa.ReplayWindow, sa.Mark, sa.OutputMark, sa.Ifid, sa.Auth, sa.Crypt, sa.Aead, sa.Encap, sa.ESN)
+	return fmt.Sprintf("Dst: %v, Src: %v, Proto: %s, Mode: %s, SPI: 0x%x, ReqID: 0x%x, ReplayWindow: %d, Mark: %v, OutputMark: %v, Ifid: %d, Auth: %v, Crypt: %v, Aead: %v, Encap: %v, ESN: %t, DontEncapDSCP: %t, OSeqMayWrap: %t",
+		sa.Dst, sa.Src, sa.Proto, sa.Mode, sa.Spi, sa.Reqid, sa.ReplayWindow, sa.Mark, sa.OutputMark, sa.Ifid, sa.Auth, sa.Crypt, sa.Aead, sa.Encap, sa.ESN, sa.DontEncapDSCP, sa.OSeqMayWrap)
 }
 func (sa XfrmState) Print(stats bool) string {
 	if !stats {


### PR DESCRIPTION
Adding support for the `XFRMA_SA_EXTRA_FLAGS` which can be used for various XFRM state-related messages. Please see the commit message for more details.

Related kernel commit: https://github.com/torvalds/linux/commit/428d2459cceb77357b81c242ca22462a6a904817