### PR TITLE
Fix TestLinkAddDelXfrmiNoId

### DIFF
--- a/link_test.go
+++ b/link_test.go
@@ -5,6 +5,7 @@ package netlink
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -2412,8 +2413,12 @@ func TestLinkAddDelXfrmiNoId(t *testing.T) {
 
 	lo, _ := LinkByName("lo")
 
-	testLinkAddDel(t, &Xfrmi{
+	err := LinkAdd(&Xfrmi{
 		LinkAttrs: LinkAttrs{Name: "xfrm0", ParentIndex: lo.Attrs().Index}})
+	if !errors.Is(err, unix.EINVAL) {
+		t.Errorf("Error returned expected to be EINVAL")
+	}
+
 }
 
 func TestLinkByNameWhenLinkIsNotFound(t *testing.T) {


### PR DESCRIPTION
Adding an xfrmi link with if_id 0 results in EINVAL being returned, see
[1]. Adjust TestLinkAddDelXfrmiNoId accordingly to expect an error.

[1] https://github.com/torvalds/linux/blob/8efd0d9c316af470377894a6a0f9ff63ce18c177/net/xfrm/xfrm_interface.c#L645-L648

Fixes: f7fd7af4377d ("Only set IFLA_XFRM_IF_ID if not 0")