### PR TITLE
Add a test to check if we can cleanly close subscribe goroutine

### DIFF
--- a/nl/nl_linux.go
+++ b/nl/nl_linux.go
@@ -734,6 +734,7 @@ func SubscribeAt(newNs, curNs netns.NsHandle, protocol int, groups ...uint) (*Ne
 
 func (s *NetlinkSocket) Close() {
 	fd := int(atomic.SwapInt32(&s.fd, -1))
+	unix.Shutdown(fd, unix.SHUT_RDWR)
 	unix.Close(fd)
 }
 

--- a/route_test.go
+++ b/route_test.go
@@ -355,6 +355,24 @@ func TestRouteSubscribe(t *testing.T) {
 	}
 }
 
+func TestRouteSubscribeClose(t *testing.T) {
+	tearDown := setUpNetlinkTest(t)
+	defer tearDown()
+
+	ch := make(chan RouteUpdate)
+	done := make(chan struct{})
+	if err := RouteSubscribe(ch, done); err != nil {
+		t.Fatal(err)
+	}
+	close(done)
+	select {
+	case <-ch:
+		// OK
+	case <-time.After(5 * time.Second):
+		t.Fatal("Unable to close subscription channel")
+	}
+}
+
 func TestRouteSubscribeWithOptions(t *testing.T) {
 	tearDown := setUpNetlinkTest(t)
 	defer tearDown()


### PR DESCRIPTION
This is for #542. It seems to work just fine this way. If not, this
should always work with the following patch:

```diff
diff --git a/nl/nl_linux.go b/nl/nl_linux.go
index 600b942b1785..72104b93ef2b 100644
--- a/nl/nl_linux.go
+++ b/nl/nl_linux.go
@@ -734,6 +734,7 @@ func SubscribeAt(newNs, curNs netns.NsHandle, protocol int, groups ...uint) (*Ne

 func (s *NetlinkSocket) Close() {
        fd := int(atomic.SwapInt32(&s.fd, -1))
+       unix.Shutdown(fd, unix.SHUT_RDWR)
        unix.Close(fd)
 }
```

Let's see the result of the tests.