### PR TITLE
Fix panic in DeserializeRtNexthop.

### DIFF
--- a/nl/route_linux.go
+++ b/nl/route_linux.go
@@ -48,7 +48,10 @@ type RtNexthop struct {
 }
 
 func DeserializeRtNexthop(b []byte) *RtNexthop {
-	return (*RtNexthop)(unsafe.Pointer(&b[0:unix.SizeofRtNexthop][0]))
+	// Can't just cast to our RtNextHop struct because our struct is longer than the kernel data.
+	var nh RtNexthop
+	copy((*[unsafe.Sizeof(nh.RtNexthop)]byte)(unsafe.Pointer(&nh.RtNexthop))[:], b[:unix.SizeofRtNexthop])
+	return &nh
 }
 
 func (msg *RtNexthop) Len() int {


### PR DESCRIPTION
Fixes #780 by copying the data into the wrapper struct.  I couldn't see a way to fix without copying given `RtNexthop` is part of the public API.

I checked for other instances of the same problem but it was the only place where I found a message struct that wasn't a direct mirror of the kernel struct.