### PR TITLE
link: fix `FlowBased` support in Gretap

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -2714,7 +2714,7 @@ func addGretapAttrs(gretap *Gretap, linkInfo *nl.RtAttr) {
 
 	if gretap.FlowBased {
 		// In flow based mode, no other attributes need to be configured
-		data.AddRtAttr(nl.IFLA_GRE_COLLECT_METADATA, boolAttr(gretap.FlowBased))
+		data.AddRtAttr(nl.IFLA_GRE_COLLECT_METADATA, []byte{})
 		return
 	}
 

--- a/link_test.go
+++ b/link_test.go
@@ -394,14 +394,9 @@ func compareGretap(t *testing.T, expected, actual *Gretap) {
 		t.Fatal("Gretap.Link doesn't match")
 	}
 
-	/*
-		 * NOTE: setting the FlowBased flag doesn't seem to work, but by lack of
-		 * a proper way to debug this, this test is disabled for now
-
-		 if actual.FlowBased != expected.FlowBased {
-			t.Fatal("Gretap.FlowBased doesn't match")
-		 }
-	*/
+	if actual.FlowBased != expected.FlowBased {
+		t.Fatal("Gretap.FlowBased doesn't match")
+	 }
 }
 
 func compareGretun(t *testing.T, expected, actual *Gretun) {
@@ -748,9 +743,6 @@ func TestLinkAddDelGretunPointToMultiPoint(t *testing.T) {
 }
 
 func TestLinkAddDelGretapFlowBased(t *testing.T) {
-	if os.Getenv("CI") == "true" {
-		t.Skipf("Fails in CI with: link_test.go:34: numerical result out of range")
-	}
 	minKernelRequired(t, 4, 3)
 
 	tearDown := setUpNetlinkTest(t)


### PR DESCRIPTION
IFLA_GRE_COLLECT_METADATA is a "flag" netlink attribute. As such it should
not be sent with a data payload.

Fix gretap link to send this flag correctly and re-enable tests.

Signed-off-by: Eyal Birger <eyal.birger@gmail.com>