### PR TITLE
link: Add `FlowBased` support to Gretun

### DIFF
--- a/link.go
+++ b/link.go
@@ -1166,6 +1166,7 @@ type Gretun struct {
 	EncapFlags uint16
 	EncapSport uint16
 	EncapDport uint16
+	FlowBased  bool
 }
 
 func (gretun *Gretun) Attrs() *LinkAttrs {

--- a/link_linux.go
+++ b/link_linux.go
@@ -2797,6 +2797,12 @@ func parseGretapData(link Link, data []syscall.NetlinkRouteAttr) {
 func addGretunAttrs(gre *Gretun, linkInfo *nl.RtAttr) {
 	data := linkInfo.AddRtAttr(nl.IFLA_INFO_DATA, nil)
 
+	if gre.FlowBased {
+		// In flow based mode, no other attributes need to be configured
+		data.AddRtAttr(nl.IFLA_GRE_COLLECT_METADATA, []byte{})
+		return
+	}
+
 	if ip := gre.Local; ip != nil {
 		if ip.To4() != nil {
 			ip = ip.To4()
@@ -2867,6 +2873,8 @@ func parseGretunData(link Link, data []syscall.NetlinkRouteAttr) {
 			gre.EncapSport = ntohs(datum.Value[0:2])
 		case nl.IFLA_GRE_ENCAP_DPORT:
 			gre.EncapDport = ntohs(datum.Value[0:2])
+		case nl.IFLA_GRE_COLLECT_METADATA:
+			gre.FlowBased = true
 		}
 	}
 }

--- a/link_test.go
+++ b/link_test.go
@@ -460,6 +460,9 @@ func compareGretun(t *testing.T, expected, actual *Gretun) {
 	if actual.EncapDport != expected.EncapDport {
 		t.Fatal("Gretun.EncapDport doesn't match")
 	}
+	if actual.FlowBased != expected.FlowBased {
+		t.Fatal("Gretun.FlowBased doesn't match")
+	}
 }
 
 func compareVxlan(t *testing.T, expected, actual *Vxlan) {
@@ -745,6 +748,17 @@ func TestLinkAddDelGretunPointToMultiPoint(t *testing.T) {
 		Local:     net.ParseIP("2001:db8:1234::4"),
 		IKey:      5678,
 		OKey:      7890})
+}
+
+func TestLinkAddDelGretunFlowBased(t *testing.T) {
+	minKernelRequired(t, 4, 3)
+
+	tearDown := setUpNetlinkTest(t)
+	defer tearDown()
+
+	testLinkAddDel(t, &Gretun{
+		LinkAttrs: LinkAttrs{Name: "foo"},
+		FlowBased: true})
 }
 
 func TestLinkAddDelGretapFlowBased(t *testing.T) {


### PR DESCRIPTION
GRE L3 devices support "FlowBased" ("collect_md"/"external") mode.
Add support for this configuration and relevant test.

Signed-off-by: Eyal Birger <eyal.birger@gmail.com>