### PR TITLE
Support src_mac, dst_mac and vlan id in flower filters

### DIFF
--- a/filter_test.go
+++ b/filter_test.go
@@ -1635,6 +1635,14 @@ func TestFilterFlowerAddDel(t *testing.T) {
 	}
 
 	testMask := net.CIDRMask(24, 32)
+	srcMac, err := net.ParseMAC("2C:54:91:88:C9:E3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	destMac, err := net.ParseMAC("2C:54:91:88:C9:E5")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	filter := &Flower{
 		FilterAttrs: FilterAttrs{
@@ -1654,6 +1662,8 @@ func TestFilterFlowerAddDel(t *testing.T) {
 		EncSrcIPMask:  testMask,
 		EncDestPort:   8472,
 		EncKeyId:      1234,
+		SrcMac:        srcMac,
+		DestMac:       destMac,
 		Actions: []Action{
 			&MirredAction{
 				ActionAttrs: ActionAttrs{
@@ -1715,6 +1725,12 @@ func TestFilterFlowerAddDel(t *testing.T) {
 	}
 	if filter.EncDestPort != flower.EncDestPort {
 		t.Fatalf("Flower EncDestPort doesn't match")
+	}
+	if !(filter.SrcMac.String() == flower.SrcMac.String()) {
+		t.Fatalf("Flower SrcMac doesn't match")
+	}
+	if !(filter.DestMac.String() == flower.DestMac.String()) {
+		t.Fatalf("Flower DestMac doesn't match")
 	}
 
 	mia, ok := flower.Actions[0].(*MirredAction)


### PR DESCRIPTION
See title, so users are able to filter flower rules based on src/dst mac address. I ran the test on an Oracle Linux 8 virtual machine and it passed:

[] go test -run "TestFilterFlowerAddDel"
PASS
ok  	github.com/vishvananda/netlink	0.017s

I also ran the test (without cleanup) on the same machine, was able to see the flower rule was created correctly, as reported by "tc":

[] ip netns exec netns1 tc filter show dev foo ingress
filter parent ffff: protocol all pref 1 flower chain 0
filter parent ffff: protocol all pref 1 flower chain 0 handle 0x1
  dst_mac 2c:54:91:88:c9:e5
  src_mac 2c:54:91:88:c9:e3
  eth_type ipv4
  dst_ip 1.0.0.1/24
  src_ip 2.0.0.1/24
  enc_dst_ip 3.0.0.1/24
  enc_src_ip 4.0.0.1/24
  enc_key_id 1234
  enc_dst_port 8472
  not_in_hw
	action order 1: mirred (Egress Redirect to device bar) stolen
	index 1 ref 1 bind 1