### PR TITLE
Support vlan action, including pop and push

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -190,6 +190,35 @@ func NewCsumAction() *CsumAction {
 	}
 }
 
+type VlanAct int8
+
+type VlanAction struct {
+	ActionAttrs
+	Action   VlanAct
+	VlanID   uint16
+}
+
+const (
+	TCA_VLAN_ACT_POP      VlanAct = 1
+	TCA_VLAN_ACT_PUSH     VlanAct = 2
+)
+
+func (action *VlanAction) Type() string {
+	return "vlan"
+}
+
+func (action *VlanAction) Attrs() *ActionAttrs {
+	return &action.ActionAttrs
+}
+
+func NewVlanAction() *VlanAction {
+	return &VlanAction{
+		ActionAttrs: ActionAttrs{
+			Action: TC_ACT_PIPE,
+		},
+	}
+}
+
 type MirredAct uint8
 
 func (a MirredAct) String() string {

--- a/filter_test.go
+++ b/filter_test.go
@@ -1655,6 +1655,19 @@ func TestFilterFlowerAddDel(t *testing.T) {
 		EncDestPort:   8472,
 		EncKeyId:      1234,
 		Actions: []Action{
+			&VlanAction{
+				ActionAttrs: ActionAttrs{
+					Action: TC_ACT_PIPE,
+				},
+				Action: TCA_VLAN_ACT_POP,
+			},
+			&VlanAction{
+				ActionAttrs: ActionAttrs{
+					Action: TC_ACT_PIPE,
+				},
+				Action: TCA_VLAN_ACT_PUSH,
+				VlanID: 1234,
+			},
 			&MirredAction{
 				ActionAttrs: ActionAttrs{
 					Action: TC_ACT_STOLEN,
@@ -1717,7 +1730,33 @@ func TestFilterFlowerAddDel(t *testing.T) {
 		t.Fatalf("Flower EncDestPort doesn't match")
 	}
 
-	mia, ok := flower.Actions[0].(*MirredAction)
+	va1, ok := flower.Actions[0].(*VlanAction)
+	if !ok {
+		t.Fatal("Unable to find vlan action")
+	}
+
+	if va1.Attrs().Action != TC_ACT_PIPE {
+		t.Fatal("Vlan action isn't TC_ACT_PIPE")
+	}
+
+	if va1.Action != TCA_VLAN_ACT_POP {
+		t.Fatal("First Vlan action isn't pop")
+	}
+
+	va2, ok := flower.Actions[1].(*VlanAction)
+	if !ok {
+		t.Fatal("Unable to find vlan action")
+	}
+
+	if va2.Attrs().Action != TC_ACT_PIPE {
+		t.Fatal("Vlan action isn't TC_ACT_PIPE")
+	}
+
+	if va2.Action != TCA_VLAN_ACT_PUSH {
+		t.Fatal("Second Vlan action isn't push")
+	}
+
+	mia, ok := flower.Actions[2].(*MirredAction)
 	if !ok {
 		t.Fatal("Unable to find mirred action")
 	}

--- a/nl/tc_linux.go
+++ b/nl/tc_linux.go
@@ -91,6 +91,7 @@ const (
 	SizeofTcGen          = 0x14
 	SizeofTcConnmark     = SizeofTcGen + 0x04
 	SizeofTcCsum         = SizeofTcGen + 0x04
+	SizeofTcVlan         = SizeofTcGen + 0x04
 	SizeofTcMirred       = SizeofTcGen + 0x08
 	SizeofTcTunnelKey    = SizeofTcGen + 0x04
 	SizeofTcSkbEdit      = SizeofTcGen
@@ -723,6 +724,41 @@ func DeserializeTcCsum(b []byte) *TcCsum {
 
 func (x *TcCsum) Serialize() []byte {
 	return (*(*[SizeofTcCsum]byte)(unsafe.Pointer(x)))[:]
+}
+
+const (
+	TCA_VLAN_UNSPEC = iota
+	TCA_VLAN_TM
+	TCA_VLAN_PARMS
+	TCA_VLAN_PUSH_VLAN_ID
+	TCA_VLAN_PUSH_VLAN_PROTOCOL
+	TCA_VLAN_PAD
+	TCA_VLAN_PUSH_VLAN_PRIORITY
+	TCA_VLAN_PUSH_ETH_DST
+	TCA_VLAN_PUSH_ETH_SRC
+	TCA_VLAN_MAX
+)
+
+//struct tc_vlan {
+//	tc_gen;
+//	int v_action;
+//};
+
+type TcVlan struct {
+	TcGen
+	Action int32
+}
+
+func (msg *TcVlan) Len() int {
+	return SizeofTcVlan
+}
+
+func DeserializeTcVlan(b []byte) *TcVlan {
+	return (*TcVlan)(unsafe.Pointer(&b[0:SizeofTcVlan][0]))
+}
+
+func (x *TcVlan) Serialize() []byte {
+	return (*(*[SizeofTcVlan]byte)(unsafe.Pointer(x)))[:]
 }
 
 const (


### PR DESCRIPTION
This would allow users to strip/add vlan tags as a packet goes through an interface. Tested on an Oracle Linux 8 VM. I ran the test without clean up, and verified that vlan push rule was added correctly:

filter parent ffff: protocol all pref 1 flower chain 0
filter parent ffff: protocol all pref 1 flower chain 0 handle 0x1
  eth_type ipv4
  dst_ip 1.0.0.1/24
  src_ip 2.0.0.1/24
  enc_dst_ip 3.0.0.1/24
  enc_src_ip 4.0.0.1/24
  enc_key_id 1234
  enc_dst_port 8472
  not_in_hw
	action order 1: vlan  pop pipe
	 index 1 ref 1 bind 1

	action order 2: vlan  push id 1234 protocol 802.1Q priority 0 pipe
	 index 2 ref 1 bind 1

	action order 3: mirred (Egress Redirect to device bar) stolen
	index 1 ref 1 bind 1