### PR TITLE
fix RouteList can't list routes properly when don't specify link

### DIFF
--- a/route_linux.go
+++ b/route_linux.go
@@ -1004,8 +1004,10 @@ func (h *Handle) RouteList(link Link, family int) ([]Route, error) {
 	routeFilter := &Route{}
 	if link != nil {
 		routeFilter.LinkIndex = link.Attrs().Index
+
+		return h.RouteListFiltered(family, routeFilter, RT_FILTER_OIF)
 	}
-	return h.RouteListFiltered(family, routeFilter, RT_FILTER_OIF)
+	return h.RouteListFiltered(family, routeFilter, 0)
 }
 
 // RouteListFiltered gets a list of routes in the system filtered with specified rules.

--- a/route_test.go
+++ b/route_test.go
@@ -49,6 +49,14 @@ func TestRouteAddDel(t *testing.T) {
 		t.Fatal("Route not added properly")
 	}
 
+	routes, err = RouteList(nil, FAMILY_V4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(routes) != 1 {
+		t.Fatal("Route not listed properly")
+	}
+
 	dstIP := net.IPv4(192, 168, 0, 42)
 	routeToDstIP, err := RouteGet(dstIP)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: chengzhycn <chengzhycn@gmail.com>

pr #782 introduced a problem that `RouteList` couldn't show routes properly when we didn't specify a link. 

It changed `routeFilter` from a nil pointer to an empty `Route{}` by default, so in `RouteListFiltered` it couldn't skip the filter logic when we didn't specify a link and we could only get an empty route list returned by it.

cc @cjmakes 