### PR TITLE
Add support for qdisc MQPRIO

### DIFF
--- a/nl/tc_linux.go
+++ b/nl/tc_linux.go
@@ -98,6 +98,7 @@ const (
 	SizeofTcSfqQopt      = 0x0b
 	SizeofTcSfqRedStats  = 0x18
 	SizeofTcSfqQoptV1    = SizeofTcSfqQopt + SizeofTcSfqRedStats + 0x1c
+	SizeofTcMqPrioQopt   = 0x54
 )
 
 // struct tcmsg {
@@ -1121,4 +1122,40 @@ func DeserializeTcSfqQoptV1(b []byte) *TcSfqQoptV1 {
 
 func (x *TcSfqQoptV1) Serialize() []byte {
 	return (*(*[SizeofTcSfqQoptV1]byte)(unsafe.Pointer(x)))[:]
+}
+
+const (
+	TCA_MQPRIO_UNSPEC = iota
+	TCA_MQPRIO_MODE
+	TCA_MQPRIO_SHAPER
+	TCA_MQPRIO_MIN_RATE64
+	TCA_MQPRIO_MAX_RATE64
+	__TCA_MQPRIO_MAX
+)
+
+// struct tc_mqprio_qopt {
+// 	__u8	num_tc;
+// 	__u8	prio_tc_map[TC_QOPT_BITMASK + 1];
+// 	__u8	hw;
+// 	__u16	count[TC_QOPT_MAX_QUEUE];
+// 	__u16	offset[TC_QOPT_MAX_QUEUE];
+// };
+type TcMqPrioQopt struct {
+	NumTc     uint8
+	PrioTcMap [16]uint8
+	Hw        uint8
+	Count     [16]uint16
+	Offset    [16]uint16
+}
+
+func (x *TcMqPrioQopt) Len() int {
+	return SizeofTcMqPrioQopt
+}
+
+func DeserializeTcMqPrioQopt(b []byte) *TcMqPrioQopt {
+	return (*TcMqPrioQopt)(unsafe.Pointer(&b[0:SizeofTcMqPrioQopt][0]))
+}
+
+func (x *TcMqPrioQopt) Serialize() []byte {
+	return (*(*[SizeofTcMqPrioQopt]byte)(unsafe.Pointer(x)))[:]
 }

--- a/qdisc.go
+++ b/qdisc.go
@@ -3,6 +3,8 @@ package netlink
 import (
 	"fmt"
 	"math"
+
+	"github.com/vishvananda/netlink/nl"
 )
 
 const (
@@ -372,4 +374,28 @@ func (qdisc *Sfq) Attrs() *QdiscAttrs {
 
 func (qdisc *Sfq) Type() string {
 	return "sfq"
+}
+
+type MqPrio struct {
+	QdiscAttrs
+	Opt       nl.TcMqPrioQopt
+	Mode      uint16
+	Shaper    uint16
+	MinRate64 uint64
+	MaxRate64 uint64
+}
+
+func (qdisc *MqPrio) Attrs() *QdiscAttrs {
+	return &qdisc.QdiscAttrs
+}
+
+func (qdisc *MqPrio) Type() string {
+	return "mqprio"
+}
+
+func (qdisc *MqPrio) String() string {
+	return fmt.Sprintf(
+		"{%v -- Opt %+v, Mode: %v Shaper %v MinRate64 %v MaxRate64 %v}",
+		qdisc.Attrs(), qdisc.Opt, qdisc.Mode, qdisc.Shaper, qdisc.MinRate64, qdisc.MaxRate64,
+	)
 }

--- a/qdisc_linux.go
+++ b/qdisc_linux.go
@@ -300,6 +300,20 @@ func qdiscPayload(req *nl.NetlinkRequest, qdisc Qdisc) error {
 		opt.TcSfqQopt.Divisor = qdisc.Divisor
 
 		options = nl.NewRtAttr(nl.TCA_OPTIONS, opt.Serialize())
+	case *MqPrio:
+		options = nl.NewRtAttr(nl.TCA_OPTIONS, qdisc.Opt.Serialize())
+		if qdisc.Mode != 0 {
+			options.AddRtAttr(nl.TCA_MQPRIO_MODE, nl.Uint16Attr(qdisc.Mode))
+		}
+		if qdisc.Shaper != 0 {
+			options.AddRtAttr(nl.TCA_MQPRIO_SHAPER, nl.Uint16Attr(qdisc.Shaper))
+		}
+		if qdisc.MaxRate64 != 0 {
+			options.AddRtAttr(nl.TCA_MQPRIO_MAX_RATE64, nl.Uint64Attr(qdisc.MaxRate64))
+		}
+		if qdisc.MinRate64 != 0 {
+			options.AddRtAttr(nl.TCA_MQPRIO_MIN_RATE64, nl.Uint64Attr(qdisc.MinRate64))
+		}
 	default:
 		options = nil
 	}
@@ -386,6 +400,8 @@ func (h *Handle) QdiscList(link Link) ([]Qdisc, error) {
 					qdisc = &Netem{}
 				case "sfq":
 					qdisc = &Sfq{}
+				case "mqprio":
+					qdisc = &MqPrio{}
 				default:
 					qdisc = &GenericQdisc{QdiscType: qdiscType}
 				}
@@ -443,6 +459,10 @@ func (h *Handle) QdiscList(link Link) ([]Qdisc, error) {
 					}
 				case "sfq":
 					if err := parseSfqData(qdisc, attr.Value); err != nil {
+						return nil, err
+					}
+				case "mqprio":
+					if err := parseMqprioData(qdisc, attr.Value); err != nil {
 						return nil, err
 					}
 
@@ -624,6 +644,29 @@ func parseSfqData(qdisc Qdisc, value []byte) error {
 	sfq.Limit = opt.TcSfqQopt.Limit
 	sfq.Divisor = opt.TcSfqQopt.Divisor
 
+	return nil
+}
+
+func parseMqprioData(qdisc Qdisc, value []byte) error {
+	mqprio := qdisc.(*MqPrio)
+	opt := nl.DeserializeTcMqPrioQopt(value)
+	data, err := nl.ParseRouteAttr(value[nl.SizeofTcMqPrioQopt:])
+	if err != nil {
+		return err
+	}
+	for _, datum := range data {
+		switch datum.Attr.Type {
+		case nl.TCA_MQPRIO_MODE:
+			mqprio.Mode = native.Uint16(datum.Value)
+		case nl.TCA_MQPRIO_SHAPER:
+			mqprio.Shaper = native.Uint16(datum.Value)
+		case nl.TCA_MQPRIO_MAX_RATE64:
+			mqprio.MaxRate64 = native.Uint64(datum.Value)
+		case nl.TCA_MQPRIO_MIN_RATE64:
+			mqprio.MinRate64 = native.Uint64(datum.Value)
+		}
+	}
+	mqprio.Opt = *opt
 	return nil
 }
 


### PR DESCRIPTION
This patch adds support for qdisc mqprio. It is a simple queuing discipline that allows mapping traffic flows to hardware queue ranges using priorities and a configurable priority to traffic class mapping.