### PR TITLE
Allow netlink with no owner/group

### DIFF
--- a/link.go
+++ b/link.go
@@ -339,8 +339,8 @@ type Tuntap struct {
 	NonPersist bool
 	Queues     int
 	Fds        []*os.File
-	Owner      uint32
-	Group      uint32
+	Owner      int64 // -1 for no owner
+	Group      int64 // -1 for no group
 }
 
 func (tuntap *Tuntap) Attrs() *LinkAttrs {


### PR DESCRIPTION
Currently it is only possible to create a tuntap with owner/group specified. If not set explicitly, the default value of 0 will be used. It's therefore not possible to create a tuntap without owner/group. This PR changes this to allow this. It changes the type of owner/group from uint to int to allow setting owner/group to -1, indicating no owner/group.