### PR TITLE
Add field for permanent hardware address

### DIFF
--- a/link.go
+++ b/link.go
@@ -54,6 +54,7 @@ type LinkAttrs struct {
 	GROIPv4MaxSize uint32
 	Vfs            []VfInfo // virtual functions available on link
 	Group          uint32
+	PermHWAddr     net.HardwareAddr
 	Slave          LinkSlave
 }
 

--- a/link_linux.go
+++ b/link_linux.go
@@ -2100,6 +2100,13 @@ func LinkDeserialize(hdr *unix.NlMsghdr, m []byte) (Link, error) {
 			base.NumRxQueues = int(native.Uint32(attr.Value[0:4]))
 		case unix.IFLA_GROUP:
 			base.Group = native.Uint32(attr.Value[0:4])
+		case unix.IFLA_PERM_ADDRESS:
+			for _, b := range attr.Value {
+				if b != 0 {
+					base.PermHWAddr = attr.Value[:]
+					break
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Linux 5.6 and higher support IFLA_PERM_ADDRESS, which contains the permanent hardware address of the interface if an interface has such an address. This can be used to identify interfaces even when the normal hardware address has been changed.