### PR TITLE
Support setting GSO Max Segment count

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -956,6 +956,33 @@ func LinkSetXdpFdWithFlags(link Link, fd, flags int) error {
 	return err
 }
 
+// LinkSetGSOMaxSegs sets the GSO maximum segment count of the link device.
+// Equivalent to: `ip link set $link gso_max_segs $maxSegs`
+func LinkSetGSOMaxSegs(link Link, maxSegs int) error {
+       return pkgHandle.LinkSetGSOMaxSegs(link, maxSegs)
+}
+
+// LinkSetGSOMaxSegs sets the GSO maximum segment count of the link device.
+// Equivalent to: `ip link set $link gso_max_segs $maxSegs`
+func (h *Handle) LinkSetGSOMaxSegs(link Link, maxSize int) error {
+       base := link.Attrs()
+       h.ensureIndex(base)
+       req := h.newNetlinkRequest(unix.RTM_SETLINK, unix.NLM_F_ACK)
+
+       msg := nl.NewIfInfomsg(unix.AF_UNSPEC)
+       msg.Index = int32(base.Index)
+       req.AddData(msg)
+
+       b := make([]byte, 4)
+       native.PutUint32(b, uint32(maxSize))
+
+       data := nl.NewRtAttr(unix.IFLA_GSO_MAX_SEGS, b)
+       req.AddData(data)
+
+       _, err := req.Execute(unix.NETLINK_ROUTE, 0)
+       return err
+}
+
 // LinkSetGSOMaxSize sets the IPv6 GSO maximum size of the link device.
 // Equivalent to: `ip link set $link gso_max_size $maxSize`
 func LinkSetGSOMaxSize(link Link, maxSize int) error {

--- a/link_test.go
+++ b/link_test.go
@@ -2146,6 +2146,36 @@ func TestLinkSetGSOMaxSize(t *testing.T) {
 	}
 }
 
+func TestLinkSetGSOMaxSegs(t *testing.T) {
+       minKernelRequired(t, 5, 19)
+       tearDown := setUpNetlinkTest(t)
+       defer tearDown()
+
+       iface := &Veth{LinkAttrs: LinkAttrs{Name: "foo", TxQLen: testTxQLen, MTU: 1500}, PeerName: "bar"}
+       if err := LinkAdd(iface); err != nil {
+               t.Fatal(err)
+       }
+
+       link, err := LinkByName("foo")
+       if err != nil {
+               t.Fatal(err)
+       }
+
+       err = LinkSetGSOMaxSegs(link, 16)
+       if err != nil {
+               t.Fatal(err)
+       }
+
+       link, err = LinkByName("foo")
+       if err != nil {
+               t.Fatal(err)
+       }
+
+       if link.Attrs().GSOMaxSegs != 16 {
+               t.Fatalf("GSO max segments was not modified")
+       }
+}
+
 func TestLinkSetGROMaxSize(t *testing.T) {
 	minKernelRequired(t, 5, 19)
 	tearDown := setUpNetlinkTest(t)


### PR DESCRIPTION
This allows for `ip link set $link gso_max_segs $maxSegs` type operations.

Validated by running unit tests on Arch Linux running kernel 6.1.15-1-ec2, and running a program which calls `LinkSetGSOMaxSegs(link, 0)` and running `ip -d link show`:

```
151: veth_data@if152: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8697 qdisc noqueue state UP mode DEFAULT group default qlen 1000
    link/ether 12:54:1d:99:d1:0b brd ff:ff:ff:ff:ff:ff link-netnsid 0 promiscuity 0 minmtu 68 maxmtu 65535
    veth addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 0
```