### PR TITLE
Add missing bond hash policy VLAN_SRCMAC

### DIFF
--- a/link.go
+++ b/link.go
@@ -709,6 +709,7 @@ const (
 	BOND_XMIT_HASH_POLICY_LAYER2_3
 	BOND_XMIT_HASH_POLICY_ENCAP2_3
 	BOND_XMIT_HASH_POLICY_ENCAP3_4
+	BOND_XMIT_HASH_POLICY_VLAN_SRCMAC
 	BOND_XMIT_HASH_POLICY_UNKNOWN
 )
 
@@ -718,6 +719,7 @@ var bondXmitHashPolicyToString = map[BondXmitHashPolicy]string{
 	BOND_XMIT_HASH_POLICY_LAYER2_3: "layer2+3",
 	BOND_XMIT_HASH_POLICY_ENCAP2_3: "encap2+3",
 	BOND_XMIT_HASH_POLICY_ENCAP3_4: "encap3+4",
+	BOND_XMIT_HASH_POLICY_VLAN_SRCMAC: "vlan+srcmac",
 }
 var StringToBondXmitHashPolicyMap = map[string]BondXmitHashPolicy{
 	"layer2":   BOND_XMIT_HASH_POLICY_LAYER2,
@@ -725,6 +727,7 @@ var StringToBondXmitHashPolicyMap = map[string]BondXmitHashPolicy{
 	"layer2+3": BOND_XMIT_HASH_POLICY_LAYER2_3,
 	"encap2+3": BOND_XMIT_HASH_POLICY_ENCAP2_3,
 	"encap3+4": BOND_XMIT_HASH_POLICY_ENCAP3_4,
+	"vlan+srcmac": BOND_XMIT_HASH_POLICY_VLAN_SRCMAC,
 }
 
 // BondLacpRate type


### PR DESCRIPTION
Linux added a new bond transmit hashing policy, VLAN_SRCMAC in [1], available since Linux 5.12. Add this hashing policy into the respective data structures.

[1] https://github.com/torvalds/linux/commit/7b8fc0103bb51d1d3e1fb5fd67958612e709f883