### PR TITLE
Support ipset test entry existence

### DIFF
--- a/cmd/ipset-test/main.go
+++ b/cmd/ipset-test/main.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package main
@@ -28,6 +29,7 @@ var (
 		"listall":  {cmdListAll, "list all ipsets", 0},
 		"add":      {cmdAddDel(netlink.IpsetAdd), "add entry", 2},
 		"del":      {cmdAddDel(netlink.IpsetDel), "delete entry", 2},
+		"test":     {cmdTest, "test whether an entry is in a set or not", 2},
 	}
 
 	timeoutVal   *uint32
@@ -138,6 +140,21 @@ func cmdAddDel(f func(string, *netlink.IPSetEntry) error) func([]string) {
 
 		check(f(setName, &entry))
 	}
+}
+
+func cmdTest(args []string) {
+	setName := args[0]
+	element := args[1]
+	ip := net.ParseIP(element)
+	entry := &netlink.IPSetEntry{
+		Timeout: timeoutVal,
+		IP:      ip,
+		Comment: *comment,
+		Replace: *replace,
+	}
+	exist, err := netlink.IpsetTest(setName, entry)
+	check(err)
+	log.Printf("existence: %t\n", exist)
 }
 
 // panic on error

--- a/ipset_linux_test.go
+++ b/ipset_linux_test.go
@@ -143,14 +143,35 @@ func TestIpsetCreateListAddDelDestroy(t *testing.T) {
 		t.Errorf("expected timeout to be 3, but got '%d'", *results[0].Timeout)
 	}
 
+	ip := net.ParseIP("10.99.99.99")
+	exist, err := IpsetTest("my-test-ipset-1", &IPSetEntry{
+		IP: ip,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exist {
+		t.Errorf("entry should not exist before being added: %s", ip.String())
+	}
+
 	err = IpsetAdd("my-test-ipset-1", &IPSetEntry{
 		Comment: "test comment",
-		IP:      net.ParseIP("10.99.99.99"),
+		IP:      ip,
 		Replace: false,
 	})
 
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	exist, err = IpsetTest("my-test-ipset-1", &IPSetEntry{
+		IP: ip,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exist {
+		t.Errorf("entry should exist after being added: %s", ip.String())
 	}
 
 	result, err := IpsetList("my-test-ipset-1")
@@ -455,6 +476,14 @@ func TestIpsetCreateListAddDelDestroyWithTestCases(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			exist, err := IpsetTest(tC.setname, tC.entry)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !exist {
+				t.Errorf("entry should exist, but 'test' got false, case: %s", tC.desc)
+			}
+
 			result, err = IpsetList(tC.setname)
 
 			if err != nil {
@@ -524,6 +553,14 @@ func TestIpsetCreateListAddDelDestroyWithTestCases(t *testing.T) {
 			err = IpsetDel(tC.setname, tC.entry)
 			if err != nil {
 				t.Fatal(err)
+			}
+
+			exist, err = IpsetTest(tC.setname, tC.entry)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if exist {
+				t.Errorf("entry should be deleted, but 'test' got true, case: %s", tC.desc)
 			}
 
 			result, err = IpsetList(tC.setname)


### PR DESCRIPTION
This PR supports ipset test whether an entry is in a set or not.

Func added:

- IpsetTest(setname string, entry *IPSetEntry) (bool, error)