### PR TITLE
bridge: add/del vlan range

### DIFF
--- a/bridge_linux_test.go
+++ b/bridge_linux_test.go
@@ -53,6 +53,9 @@ func TestBridgeVlan(t *testing.T) {
 	if err := BridgeVlanAdd(dummy, 3, true, true, false, false); err != nil {
 		t.Fatal(err)
 	}
+	if err := BridgeVlanAddRange(dummy, 4, 6, false, false, false, false); err != nil {
+		t.Fatal(err)
+	}
 	if vlanMap, err := BridgeVlanList(); err != nil {
 		t.Fatal(err)
 	} else {
@@ -69,7 +72,7 @@ func TestBridgeVlan(t *testing.T) {
 		if vInfo, ok := vlanMap[int32(dummy.Index)]; !ok {
 			t.Fatal("vlanMap should include dum1 port vlan info")
 		} else {
-			if fmt.Sprintf("%v", vInfo) != "[{Flags:4 Vid:1} {Flags:0 Vid:2} {Flags:6 Vid:3}]" {
+			if fmt.Sprintf("%v", vInfo) != "[{Flags:4 Vid:1} {Flags:0 Vid:2} {Flags:6 Vid:3} {Flags:0 Vid:4} {Flags:0 Vid:5} {Flags:0 Vid:6}]" {
 				t.Fatalf("unexpected result %v", vInfo)
 			}
 		}


### PR DESCRIPTION
Allow user to add vlan range in one rtnetlink call.
Usually, users will want to allow all vlans (2~4094) for some ports via iproute2 command (as below)
```
bridge vlan add vid 2-4094 dev dum0
```
Avoid to call rtnetlink 4000 times.
We should invlove vlan range to the modify function.

NOTE: original function didn't check if the vlan value is valid, so I didn't add validation.