### PR TITLE
link: add LinkSetGSOIPv4MaxSize and LinkSetGROIPv4MaxSize

### DIFF
--- a/handle_unspecified.go
+++ b/handle_unspecified.go
@@ -171,6 +171,14 @@ func (h *Handle) LinkSetGROMaxSize(link Link, maxSize int) error {
 	return ErrNotImplemented
 }
 
+func (h *Handle) LinkSetGSOIPv4MaxSize(link Link, maxSize int) error {
+	return ErrNotImplemented
+}
+
+func (h *Handle) LinkSetGROIPv4MaxSize(link Link, maxSize int) error {
+	return ErrNotImplemented
+}
+
 func (h *Handle) setProtinfoAttr(link Link, mode bool, attr int) error {
 	return ErrNotImplemented
 }

--- a/link.go
+++ b/link.go
@@ -22,35 +22,37 @@ type (
 
 // LinkAttrs represents data shared by most link types
 type LinkAttrs struct {
-	Index        int
-	MTU          int
-	TxQLen       int // Transmit Queue Length
-	Name         string
-	HardwareAddr net.HardwareAddr
-	Flags        net.Flags
-	RawFlags     uint32
-	ParentIndex  int         // index of the parent link device
-	MasterIndex  int         // must be the index of a bridge
-	Namespace    interface{} // nil | NsPid | NsFd
-	Alias        string
-	Statistics   *LinkStatistics
-	Promisc      int
-	Allmulti     int
-	Multi        int
-	Xdp          *LinkXdp
-	EncapType    string
-	Protinfo     *Protinfo
-	OperState    LinkOperState
-	PhysSwitchID int
-	NetNsID      int
-	NumTxQueues  int
-	NumRxQueues  int
-	GSOMaxSize   uint32
-	GSOMaxSegs   uint32
-	GROMaxSize   uint32
-	Vfs          []VfInfo // virtual functions available on link
-	Group        uint32
-	Slave        LinkSlave
+	Index          int
+	MTU            int
+	TxQLen         int // Transmit Queue Length
+	Name           string
+	HardwareAddr   net.HardwareAddr
+	Flags          net.Flags
+	RawFlags       uint32
+	ParentIndex    int         // index of the parent link device
+	MasterIndex    int         // must be the index of a bridge
+	Namespace      interface{} // nil | NsPid | NsFd
+	Alias          string
+	Statistics     *LinkStatistics
+	Promisc        int
+	Allmulti       int
+	Multi          int
+	Xdp            *LinkXdp
+	EncapType      string
+	Protinfo       *Protinfo
+	OperState      LinkOperState
+	PhysSwitchID   int
+	NetNsID        int
+	NumTxQueues    int
+	NumRxQueues    int
+	GSOMaxSegs     uint32
+	GSOMaxSize     uint32
+	GROMaxSize     uint32
+	GSOIPv4MaxSize uint32
+	GROIPv4MaxSize uint32
+	Vfs            []VfInfo // virtual functions available on link
+	Group          uint32
+	Slave          LinkSlave
 }
 
 // LinkSlave represents a slave device.

--- a/link_linux.go
+++ b/link_linux.go
@@ -956,13 +956,13 @@ func LinkSetXdpFdWithFlags(link Link, fd, flags int) error {
 	return err
 }
 
-// LinkSetGSOMaxSize sets the GSO maximum size of the link device.
+// LinkSetGSOMaxSize sets the IPv6 GSO maximum size of the link device.
 // Equivalent to: `ip link set $link gso_max_size $maxSize`
 func LinkSetGSOMaxSize(link Link, maxSize int) error {
 	return pkgHandle.LinkSetGSOMaxSize(link, maxSize)
 }
 
-// LinkSetGSOMaxSize sets the GSO maximum size of the link device.
+// LinkSetGSOMaxSize sets the IPv6 GSO maximum size of the link device.
 // Equivalent to: `ip link set $link gso_max_size $maxSize`
 func (h *Handle) LinkSetGSOMaxSize(link Link, maxSize int) error {
 	base := link.Attrs()
@@ -983,13 +983,13 @@ func (h *Handle) LinkSetGSOMaxSize(link Link, maxSize int) error {
 	return err
 }
 
-// LinkSetGROMaxSize sets the GRO maximum size of the link device.
+// LinkSetGROMaxSize sets the IPv6 GRO maximum size of the link device.
 // Equivalent to: `ip link set $link gro_max_size $maxSize`
 func LinkSetGROMaxSize(link Link, maxSize int) error {
 	return pkgHandle.LinkSetGROMaxSize(link, maxSize)
 }
 
-// LinkSetGROMaxSize sets the GRO maximum size of the link device.
+// LinkSetGROMaxSize sets the IPv6 GRO maximum size of the link device.
 // Equivalent to: `ip link set $link gro_max_size $maxSize`
 func (h *Handle) LinkSetGROMaxSize(link Link, maxSize int) error {
 	base := link.Attrs()
@@ -1004,6 +1004,60 @@ func (h *Handle) LinkSetGROMaxSize(link Link, maxSize int) error {
 	native.PutUint32(b, uint32(maxSize))
 
 	data := nl.NewRtAttr(unix.IFLA_GRO_MAX_SIZE, b)
+	req.AddData(data)
+
+	_, err := req.Execute(unix.NETLINK_ROUTE, 0)
+	return err
+}
+
+// LinkSetGSOIPv4MaxSize sets the IPv4 GSO maximum size of the link device.
+// Equivalent to: `ip link set $link gso_ipv4_max_size $maxSize`
+func LinkSetGSOIPv4MaxSize(link Link, maxSize int) error {
+	return pkgHandle.LinkSetGSOIPv4MaxSize(link, maxSize)
+}
+
+// LinkSetGSOIPv4MaxSize sets the IPv4 GSO maximum size of the link device.
+// Equivalent to: `ip link set $link gso_ipv4_max_size $maxSize`
+func (h *Handle) LinkSetGSOIPv4MaxSize(link Link, maxSize int) error {
+	base := link.Attrs()
+	h.ensureIndex(base)
+	req := h.newNetlinkRequest(unix.RTM_SETLINK, unix.NLM_F_ACK)
+
+	msg := nl.NewIfInfomsg(unix.AF_UNSPEC)
+	msg.Index = int32(base.Index)
+	req.AddData(msg)
+
+	b := make([]byte, 4)
+	native.PutUint32(b, uint32(maxSize))
+
+	data := nl.NewRtAttr(nl.IFLA_GSO_IPV4_MAX_SIZE, b)
+	req.AddData(data)
+
+	_, err := req.Execute(unix.NETLINK_ROUTE, 0)
+	return err
+}
+
+// LinkSetGROIPv4MaxSize sets the IPv4 GRO maximum size of the link device.
+// Equivalent to: `ip link set $link gro_ipv4_max_size $maxSize`
+func LinkSetGROIPv4MaxSize(link Link, maxSize int) error {
+	return pkgHandle.LinkSetGROIPv4MaxSize(link, maxSize)
+}
+
+// LinkSetGROIPv4MaxSize sets the IPv4 GRO maximum size of the link device.
+// Equivalent to: `ip link set $link gro_ipv4_max_size $maxSize`
+func (h *Handle) LinkSetGROIPv4MaxSize(link Link, maxSize int) error {
+	base := link.Attrs()
+	h.ensureIndex(base)
+	req := h.newNetlinkRequest(unix.RTM_SETLINK, unix.NLM_F_ACK)
+
+	msg := nl.NewIfInfomsg(unix.AF_UNSPEC)
+	msg.Index = int32(base.Index)
+	req.AddData(msg)
+
+	b := make([]byte, 4)
+	native.PutUint32(b, uint32(maxSize))
+
+	data := nl.NewRtAttr(nl.IFLA_GRO_IPV4_MAX_SIZE, b)
 	req.AddData(data)
 
 	_, err := req.Execute(unix.NETLINK_ROUTE, 0)
@@ -1467,6 +1521,16 @@ func (h *Handle) linkModify(link Link, flags int) error {
 
 	if base.GROMaxSize > 0 {
 		groAttr := nl.NewRtAttr(unix.IFLA_GRO_MAX_SIZE, nl.Uint32Attr(base.GROMaxSize))
+		req.AddData(groAttr)
+	}
+
+	if base.GSOIPv4MaxSize > 0 {
+		gsoAttr := nl.NewRtAttr(nl.IFLA_GSO_IPV4_MAX_SIZE, nl.Uint32Attr(base.GSOIPv4MaxSize))
+		req.AddData(gsoAttr)
+	}
+
+	if base.GROIPv4MaxSize > 0 {
+		groAttr := nl.NewRtAttr(nl.IFLA_GRO_IPV4_MAX_SIZE, nl.Uint32Attr(base.GROIPv4MaxSize))
 		req.AddData(groAttr)
 	}
 
@@ -2006,12 +2070,16 @@ func LinkDeserialize(hdr *unix.NlMsghdr, m []byte) (Link, error) {
 			base.PhysSwitchID = int(native.Uint32(attr.Value[0:4]))
 		case unix.IFLA_LINK_NETNSID:
 			base.NetNsID = int(native.Uint32(attr.Value[0:4]))
-		case unix.IFLA_GSO_MAX_SIZE:
-			base.GSOMaxSize = native.Uint32(attr.Value[0:4])
 		case unix.IFLA_GSO_MAX_SEGS:
 			base.GSOMaxSegs = native.Uint32(attr.Value[0:4])
+		case unix.IFLA_GSO_MAX_SIZE:
+			base.GSOMaxSize = native.Uint32(attr.Value[0:4])
 		case unix.IFLA_GRO_MAX_SIZE:
 			base.GROMaxSize = native.Uint32(attr.Value[0:4])
+		case nl.IFLA_GSO_IPV4_MAX_SIZE:
+			base.GSOIPv4MaxSize = native.Uint32(attr.Value[0:4])
+		case nl.IFLA_GRO_IPV4_MAX_SIZE:
+			base.GROIPv4MaxSize = native.Uint32(attr.Value[0:4])
 		case unix.IFLA_VFINFO_LIST:
 			data, err := nl.ParseRouteAttr(attr.Value)
 			if err != nil {

--- a/link_test.go
+++ b/link_test.go
@@ -2148,6 +2148,66 @@ func TestLinkSetGROMaxSize(t *testing.T) {
 	}
 }
 
+func TestLinkSetGSOIPv4MaxSize(t *testing.T) {
+	minKernelRequired(t, 6, 3)
+	tearDown := setUpNetlinkTest(t)
+	defer tearDown()
+
+	iface := &Veth{LinkAttrs: LinkAttrs{Name: "foo", TxQLen: testTxQLen, MTU: 1500}, PeerName: "bar"}
+	if err := LinkAdd(iface); err != nil {
+		t.Fatal(err)
+	}
+
+	link, err := LinkByName("foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = LinkSetGSOIPv4MaxSize(link, 32768)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	link, err = LinkByName("foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if link.Attrs().GSOIPv4MaxSize != 32768 {
+		t.Fatalf("GSO max size was not modified")
+	}
+}
+
+func TestLinkSetGROIPv4MaxSize(t *testing.T) {
+	minKernelRequired(t, 6, 3)
+	tearDown := setUpNetlinkTest(t)
+	defer tearDown()
+
+	iface := &Veth{LinkAttrs: LinkAttrs{Name: "foo", TxQLen: testTxQLen, MTU: 1500}, PeerName: "bar"}
+	if err := LinkAdd(iface); err != nil {
+		t.Fatal(err)
+	}
+
+	link, err := LinkByName("foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = LinkSetGROIPv4MaxSize(link, 32768)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	link, err = LinkByName("foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if link.Attrs().GROIPv4MaxSize != 32768 {
+		t.Fatalf("GRO max size was not modified")
+	}
+}
+
 func TestBridgeCreationWithMulticastSnooping(t *testing.T) {
 	minKernelRequired(t, 4, 4)
 

--- a/netlink_unspecified.go
+++ b/netlink_unspecified.go
@@ -132,6 +132,14 @@ func LinkSetGROMaxSize(link Link, maxSize int) error {
 	return ErrNotImplemented
 }
 
+func LinkSetGSOIPv4MaxSize(link Link, maxSize int) error {
+	return ErrNotImplemented
+}
+
+func LinkSetGROIPv4MaxSize(link Link, maxSize int) error {
+	return ErrNotImplemented
+}
+
 func LinkAdd(link Link) error {
 	return ErrNotImplemented
 }

--- a/nl/link_linux.go
+++ b/nl/link_linux.go
@@ -21,6 +21,11 @@ const (
 )
 
 const (
+	IFLA_GSO_IPV4_MAX_SIZE = 63
+	IFLA_GRO_IPV4_MAX_SIZE = 64
+)
+
+const (
 	IFLA_VLAN_UNSPEC = iota
 	IFLA_VLAN_ID
 	IFLA_VLAN_FLAGS


### PR DESCRIPTION
Add two new methods to allow setting GSO and GRO max size attributes only. They make it much easier to enable IPv4 BIG TCP [0].

The equivalent iproute2 commands are:

$ ip link set $link gso_ipv4_max_size $maxSize
$ ip link set $link gro_ipv4_max_size $maxSize

Also add tests for them. We already do support the IPv6 counterpart via 543bb1cadec5 ("link: add LinkSetGSOMaxSize and LinkSetGROMaxSize").

  [0] https://lore.kernel.org/netdev/cover.1674921359.git.lucien.xin@gmail.com/