### PR TITLE
link: add TSOMaxSize and TSOMaxSegs to link attributes

### DIFF
--- a/link.go
+++ b/link.go
@@ -45,6 +45,8 @@ type LinkAttrs struct {
 	NetNsID        int
 	NumTxQueues    int
 	NumRxQueues    int
+	TSOMaxSegs     uint32
+	TSOMaxSize     uint32
 	GSOMaxSegs     uint32
 	GSOMaxSize     uint32
 	GROMaxSize     uint32

--- a/link_linux.go
+++ b/link_linux.go
@@ -2070,6 +2070,10 @@ func LinkDeserialize(hdr *unix.NlMsghdr, m []byte) (Link, error) {
 			base.PhysSwitchID = int(native.Uint32(attr.Value[0:4]))
 		case unix.IFLA_LINK_NETNSID:
 			base.NetNsID = int(native.Uint32(attr.Value[0:4]))
+		case unix.IFLA_TSO_MAX_SEGS:
+			base.TSOMaxSegs = native.Uint32(attr.Value[0:4])
+		case unix.IFLA_TSO_MAX_SIZE:
+			base.TSOMaxSize = native.Uint32(attr.Value[0:4])
 		case unix.IFLA_GSO_MAX_SEGS:
 			base.GSOMaxSegs = native.Uint32(attr.Value[0:4])
 		case unix.IFLA_GSO_MAX_SIZE:

--- a/link_test.go
+++ b/link_test.go
@@ -2148,6 +2148,26 @@ func TestLinkSetGROMaxSize(t *testing.T) {
 	}
 }
 
+func TestLinkGetTSOMax(t *testing.T) {
+	minKernelRequired(t, 5, 19)
+	tearDown := setUpNetlinkTest(t)
+	defer tearDown()
+
+	iface := &Veth{LinkAttrs: LinkAttrs{Name: "foo", TxQLen: testTxQLen, MTU: 1500}, PeerName: "bar"}
+	if err := LinkAdd(iface); err != nil {
+		t.Fatal(err)
+	}
+
+	link, err := LinkByName("foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if link.Attrs().TSOMaxSize != 524280 || link.Attrs().TSOMaxSegs != 65535 {
+		t.Fatalf("TSO max size and segments could not be retrieved")
+	}
+}
+
 func TestLinkSetGSOIPv4MaxSize(t *testing.T) {
 	minKernelRequired(t, 6, 3)
 	tearDown := setUpNetlinkTest(t)


### PR DESCRIPTION
This is a read-only netlink attribute which has been added in 5.19 kernel. This is useful to query in order to probe if a given driver supports IPv6 BIG TCP.

  [0] https://lore.kernel.org/netdev/20220513183408.686447-2-eric.dumazet@gmail.com/