### PR TITLE
Seg6local: add support for SEG6_LOCAL_ACTION_END_BPF

### DIFF
--- a/nl/seg6local_linux.go
+++ b/nl/seg6local_linux.go
@@ -12,6 +12,7 @@ const (
 	SEG6_LOCAL_NH6
 	SEG6_LOCAL_IIF
 	SEG6_LOCAL_OIF
+	SEG6_LOCAL_BPF
 	__SEG6_LOCAL_MAX
 )
 const (
@@ -34,6 +35,7 @@ const (
 	SEG6_LOCAL_ACTION_END_S                    // 12
 	SEG6_LOCAL_ACTION_END_AS                   // 13
 	SEG6_LOCAL_ACTION_END_AM                   // 14
+	SEG6_LOCAL_ACTION_END_BPF                  // 15
 	__SEG6_LOCAL_ACTION_MAX
 )
 const (
@@ -71,6 +73,8 @@ func SEG6LocalActionString(action int) string {
 		return "End.AS"
 	case SEG6_LOCAL_ACTION_END_AM:
 		return "End.AM"
+	case SEG6_LOCAL_ACTION_END_BPF:
+		return "End.BPF"
 	}
 	return "unknown"
 }

--- a/route_test.go
+++ b/route_test.go
@@ -1427,6 +1427,9 @@ func TestSEG6LocalEqual(t *testing.T) {
 	var flags_end_b6_encaps [nl.SEG6_LOCAL_MAX]bool
 	flags_end_b6_encaps[nl.SEG6_LOCAL_ACTION] = true
 	flags_end_b6_encaps[nl.SEG6_LOCAL_SRH] = true
+	var flags_end_bpf [nl.SEG6_LOCAL_MAX]bool
+	flags_end_bpf[nl.SEG6_LOCAL_ACTION] = true
+	flags_end_bpf[nl.SEG6_LOCAL_BPF] = true
 
 	cases := []SEG6LocalEncap{
 		{
@@ -1479,6 +1482,15 @@ func TestSEG6LocalEqual(t *testing.T) {
 			Segments: segs,
 		},
 	}
+
+	// SEG6_LOCAL_ACTION_END_BPF
+	endBpf := SEG6LocalEncap{
+		Flags:  flags_end_bpf,
+		Action: nl.SEG6_LOCAL_ACTION_END_BPF,
+	}
+	_ = endBpf.SetProg(1, "firewall")
+	cases = append(cases, endBpf)
+
 	for i1 := range cases {
 		for i2 := range cases {
 			got := cases[i1].Equal(&cases[i2])


### PR DESCRIPTION
This commit add the support for End.BPF. 

With this commit, the eBPF program (BPF_PROG_TYPE_LWT_SEG6LOCAL) is loaded by a third-party library, and the eBPF can be configured by setting FD and name.

For reference, the iproute2 command to set End.BPF is as follows: :
```
 ip -6 route add 2001:db8::6 encap seg6local action End.BPF endpoint object ex-obj.o section ex-prog dev eth0
```

When I try this commit in my environment, the following route is set: (eBPF section name is `lwt_seg6local/example`)
```
2001:db8:20::2  encap seg6local action End.BPF endpoint lwt_seg6local/example dev r1_h2 metric 1024 pref medium
```
