### PR TITLE
go.mod: bump golang.org/x/sys to v0.10.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.12
 
 require (
 	github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae
-	golang.org/x/sys v0.9.1-0.20230616193735-e0c3b6e6ae3b
+	golang.org/x/sys v0.10.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae h1:4hwBBUfQCFe3Cym0ZtKyq7L16eZUtYKs+BaHDN6mAns=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.9.1-0.20230616193735-e0c3b6e6ae3b h1:5elkVbSN5WHw2BspeECIoFRcbpHNAZJEU8jlgEQl3p0=
-golang.org/x/sys v0.9.1-0.20230616193735-e0c3b6e6ae3b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
+golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
Use a tagged relase rather than an intermediate version.