### PR TITLE
Fix FlowBased support for Iptun

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -2997,13 +2997,13 @@ func parseLinkXdp(data []byte) (*LinkXdp, error) {
 }
 
 func addIptunAttrs(iptun *Iptun, linkInfo *nl.RtAttr) {
+	data := linkInfo.AddRtAttr(nl.IFLA_INFO_DATA, nil)
+
 	if iptun.FlowBased {
 		// In flow based mode, no other attributes need to be configured
-		linkInfo.AddRtAttr(nl.IFLA_IPTUN_COLLECT_METADATA, boolAttr(iptun.FlowBased))
+		data.AddRtAttr(nl.IFLA_IPTUN_COLLECT_METADATA, []byte{})
 		return
 	}
-
-	data := linkInfo.AddRtAttr(nl.IFLA_INFO_DATA, nil)
 
 	ip := iptun.Local.To4()
 	if ip != nil {
@@ -3031,10 +3031,6 @@ func addIptunAttrs(iptun *Iptun, linkInfo *nl.RtAttr) {
 func parseIptunData(link Link, data []syscall.NetlinkRouteAttr) {
 	iptun := link.(*Iptun)
 	for _, datum := range data {
-		// NOTE: same with vxlan, ip tunnel may also has null datum.Value
-		if len(datum.Value) == 0 {
-			continue
-		}
 		switch datum.Attr.Type {
 		case nl.IFLA_IPTUN_LOCAL:
 			iptun.Local = net.IP(datum.Value[0:4])

--- a/link_test.go
+++ b/link_test.go
@@ -223,10 +223,13 @@ func testLinkAddDel(t *testing.T, link Link) {
 		}
 	}
 
-	if _, ok := link.(*Iptun); ok {
-		_, ok := result.(*Iptun)
+	if iptun, ok := link.(*Iptun); ok {
+		other, ok := result.(*Iptun)
 		if !ok {
 			t.Fatal("Result of create is not a iptun")
+		}
+		if iptun.FlowBased != other.FlowBased {
+			t.Fatal("Iptun.FlowBased doesn't match")
 		}
 	}
 
@@ -2045,6 +2048,17 @@ func TestLinkAddDelIptun(t *testing.T) {
 		PMtuDisc:  1,
 		Local:     net.IPv4(127, 0, 0, 1),
 		Remote:    net.IPv4(127, 0, 0, 1)})
+}
+
+func TestLinkAddDelIptunFlowBased(t *testing.T) {
+	minKernelRequired(t, 4, 9)
+	tearDown := setUpNetlinkTest(t)
+	defer tearDown()
+
+	testLinkAddDel(t, &Iptun{
+		LinkAttrs: LinkAttrs{Name: "iptunflowfoo"},
+		FlowBased: true,
+	})
 }
 
 func TestLinkAddDelIp6tnl(t *testing.T) {


### PR DESCRIPTION
IFLA_IPTUN_COLLECT_METADATA is a "flag" netlink attribute, and shouldn't have any payload. This also needs to be considered when parsing netlink messages for Iptun.

This fixes Iptun link, by crafting and parsing messages accordingly and adds a test.