### PR TITLE
Support tc flower action statistic

### DIFF
--- a/class.go
+++ b/class.go
@@ -47,6 +47,7 @@ type ClassStatistics struct {
 	Basic   *GnetStatsBasic
 	Queue   *GnetStatsQueue
 	RateEst *GnetStatsRateEst
+	BasicHw *GnetStatsBasic // Hardward statistics added in kernel 4.20
 }
 
 // NewClassStatistics Construct a ClassStatistics struct which fields are all initialized by 0.
@@ -55,6 +56,7 @@ func NewClassStatistics() *ClassStatistics {
 		Basic:   &GnetStatsBasic{},
 		Queue:   &GnetStatsQueue{},
 		RateEst: &GnetStatsRateEst{},
+		BasicHw: &GnetStatsBasic{},
 	}
 }
 

--- a/class_linux.go
+++ b/class_linux.go
@@ -388,7 +388,13 @@ func parseTcStats2(data []byte) (*ClassStatistics, error) {
 				return nil, fmt.Errorf("Failed to parse ClassStatistics.RateEst with: %v\n%s",
 					err, hex.Dump(datum.Value))
 			}
+		case nl.TCA_STATS_BASIC_HW:
+			if err := parseGnetStats(datum.Value, stats.BasicHw); err != nil {
+				return nil, fmt.Errorf("Failed to parse ClassStatistics.BasicHw with: %v\n%s",
+					err, hex.Dump(datum.Value))
+			}
 		}
+
 	}
 
 	return stats, nil

--- a/filter.go
+++ b/filter.go
@@ -118,16 +118,31 @@ func (a TcPolAct) String() string {
 }
 
 type ActionAttrs struct {
-	Index   int
-	Capab   int
-	Action  TcAct
-	Refcnt  int
-	Bindcnt int
+	Index      int
+	Capab      int
+	Action     TcAct
+	Refcnt     int
+	Bindcnt    int
+	Statistics *ActionStatistic
+	Timestamp  *ActionTimestamp
 }
 
 func (q ActionAttrs) String() string {
 	return fmt.Sprintf("{Index: %d, Capab: %x, Action: %s, Refcnt: %d, Bindcnt: %d}", q.Index, q.Capab, q.Action.String(), q.Refcnt, q.Bindcnt)
 }
+
+type ActionTimestamp struct {
+	Installed uint64
+	LastUsed  uint64
+	Expires   uint64
+	FirstUsed uint64
+}
+
+func (t ActionTimestamp) String() string {
+	return fmt.Sprintf("Installed %d LastUsed %d Expires %d FirstUsed %d", t.Installed, t.LastUsed, t.Expires, t.FirstUsed)
+}
+
+type ActionStatistic ClassStatistics
 
 // Action represents an action in any supported filter.
 type Action interface {

--- a/nl/tc_linux.go
+++ b/nl/tc_linux.go
@@ -87,7 +87,11 @@ const (
 	TCA_STATS_RATE_EST
 	TCA_STATS_QUEUE
 	TCA_STATS_APP
-	TCA_STATS_MAX = TCA_STATS_APP
+	TCA_STATS_RATE_EST64
+	TCA_STATS_PAD
+	TCA_STATS_BASIC_HW
+	TCA_STATS_PKT64
+	TCA_STATS_MAX = TCA_STATS_PKT64
 )
 
 const (
@@ -146,6 +150,18 @@ func DeserializeTcMsg(b []byte) *TcMsg {
 
 func (x *TcMsg) Serialize() []byte {
 	return (*(*[SizeofTcMsg]byte)(unsafe.Pointer(x)))[:]
+}
+
+type Tcf struct {
+	Install  uint64
+	LastUse  uint64
+	Expires  uint64
+	FirstUse uint64
+}
+
+func DeserializeTcf(b []byte) *Tcf {
+	const size = int(unsafe.Sizeof(Tcf{}))
+	return (*Tcf)(unsafe.Pointer(&b[0:size][0]))
 }
 
 // struct tcamsg {
@@ -1071,14 +1087,14 @@ func (x *TcSfqQopt) Serialize() []byte {
 	return (*(*[SizeofTcSfqQopt]byte)(unsafe.Pointer(x)))[:]
 }
 
-// struct tc_sfqred_stats {
-// 	__u32           prob_drop;      /* Early drops, below max threshold */
-// 	__u32           forced_drop;	/* Early drops, after max threshold */
-// 	__u32           prob_mark;      /* Marked packets, below max threshold */
-// 	__u32           forced_mark;    /* Marked packets, after max threshold */
-// 	__u32           prob_mark_head; /* Marked packets, below max threshold */
-// 	__u32           forced_mark_head;/* Marked packets, after max threshold */
-// };
+//	struct tc_sfqred_stats {
+//		__u32           prob_drop;      /* Early drops, below max threshold */
+//		__u32           forced_drop;	/* Early drops, after max threshold */
+//		__u32           prob_mark;      /* Marked packets, below max threshold */
+//		__u32           forced_mark;    /* Marked packets, after max threshold */
+//		__u32           prob_mark_head; /* Marked packets, below max threshold */
+//		__u32           forced_mark_head;/* Marked packets, after max threshold */
+//	};
 type TcSfqRedStats struct {
 	ProbDrop       uint32
 	ForcedDrop     uint32
@@ -1100,22 +1116,26 @@ func (x *TcSfqRedStats) Serialize() []byte {
 	return (*(*[SizeofTcSfqRedStats]byte)(unsafe.Pointer(x)))[:]
 }
 
-// struct tc_sfq_qopt_v1 {
-// 	struct tc_sfq_qopt v0;
-// 	unsigned int	depth;		/* max number of packets per flow */
-// 	unsigned int	headdrop;
+//	struct tc_sfq_qopt_v1 {
+//		struct tc_sfq_qopt v0;
+//		unsigned int	depth;		/* max number of packets per flow */
+//		unsigned int	headdrop;
+//
 // /* SFQRED parameters */
-// 	__u32		limit;		/* HARD maximal flow queue length (bytes) */
-// 	__u32		qth_min;	/* Min average length threshold (bytes) */
-// 	__u32		qth_max;	/* Max average length threshold (bytes) */
-// 	unsigned char   Wlog;		/* log(W)		*/
-// 	unsigned char   Plog;		/* log(P_max/(qth_max-qth_min))	*/
-// 	unsigned char   Scell_log;	/* cell size for idle damping */
-// 	unsigned char	flags;
-// 	__u32		max_P;		/* probability, high resolution */
+//
+//	__u32		limit;		/* HARD maximal flow queue length (bytes) */
+//	__u32		qth_min;	/* Min average length threshold (bytes) */
+//	__u32		qth_max;	/* Max average length threshold (bytes) */
+//	unsigned char   Wlog;		/* log(W)		*/
+//	unsigned char   Plog;		/* log(P_max/(qth_max-qth_min))	*/
+//	unsigned char   Scell_log;	/* cell size for idle damping */
+//	unsigned char	flags;
+//	__u32		max_P;		/* probability, high resolution */
+//
 // /* SFQRED stats */
-// 	struct tc_sfqred_stats stats;
-// };
+//
+//		struct tc_sfqred_stats stats;
+//	};
 type TcSfqQoptV1 struct {
 	TcSfqQopt
 	Depth    uint32


### PR DESCRIPTION
Enable tc filter statistics for flower action, equivalent to: `tc -s filter show`, including:
1. Classic statistics like `Sent 1024 bytes 1 pkt (dropped 0, overlimits 0 requeues 0)`
2. Hardward statistics like `Sent hardware 1024 bytes 1 pkt`
3. Time statistics like `ref 1 bind 1 installed 10 sec used 10 sec`
