### PR TITLE
Fix FlowBased support for Geneve

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -2778,9 +2778,8 @@ func addGeneveAttrs(geneve *Geneve, linkInfo *nl.RtAttr) {
 	data := linkInfo.AddRtAttr(nl.IFLA_INFO_DATA, nil)
 
 	if geneve.FlowBased {
-		// In flow based mode, no other attributes need to be configured
-		linkInfo.AddRtAttr(nl.IFLA_GENEVE_COLLECT_METADATA, boolAttr(geneve.FlowBased))
-		return
+		geneve.ID = 0
+		data.AddRtAttr(nl.IFLA_GENEVE_COLLECT_METADATA, []byte{})
 	}
 
 	if ip := geneve.Remote; ip != nil {
@@ -2822,6 +2821,8 @@ func parseGeneveData(link Link, data []syscall.NetlinkRouteAttr) {
 			geneve.Ttl = uint8(datum.Value[0])
 		case nl.IFLA_GENEVE_TOS:
 			geneve.Tos = uint8(datum.Value[0])
+		case nl.IFLA_GENEVE_COLLECT_METADATA:
+			geneve.FlowBased = true
 		}
 	}
 }

--- a/link_test.go
+++ b/link_test.go
@@ -341,6 +341,10 @@ func compareGeneve(t *testing.T, expected, actual *Geneve) {
 		t.Fatalf("Geneve.Remote is not equal: %s!=%s", actual.Remote, expected.Remote)
 	}
 
+	if actual.FlowBased != expected.FlowBased {
+		t.Fatal("Geneve.FlowBased doesn't match")
+	}
+
 	// TODO: we should implement the rest of the geneve methods
 }
 
@@ -659,6 +663,16 @@ func TestLinkAddDelGeneve(t *testing.T) {
 		LinkAttrs: LinkAttrs{Name: "foo6", EncapType: "geneve"},
 		ID:        0x1000,
 		Remote:    net.ParseIP("2001:db8:ef33::2")})
+}
+
+func TestLinkAddDelGeneveFlowBased(t *testing.T) {
+	tearDown := setUpNetlinkTest(t)
+	defer tearDown()
+
+	testLinkAddDel(t, &Geneve{
+		LinkAttrs: LinkAttrs{Name: "foo"},
+		Dport:     1234,
+		FlowBased: true})
 }
 
 func TestGeneveCompareToIP(t *testing.T) {


### PR DESCRIPTION
The IFLA_GENEVE_COLLECT_METADATA netlink attribute shouldn't have any a payload. For Geneve devices also other attributes can be set next to FlowBased, however the VNI needs to be 0.

This commit also adds a test for creating a Geneve device in FlowBased mode.