### PR TITLE
change all ioutil calls to os

### DIFF
--- a/bridge_linux_test.go
+++ b/bridge_linux_test.go
@@ -2,7 +2,7 @@ package netlink
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 )
 
@@ -19,7 +19,7 @@ func TestBridgeVlan(t *testing.T) {
 	if err := LinkAdd(bridge); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(fmt.Sprintf("/sys/devices/virtual/net/%s/bridge/vlan_filtering", bridgeName), []byte("1"), 0644); err != nil {
+	if err := os.WriteFile(fmt.Sprintf("/sys/devices/virtual/net/%s/bridge/vlan_filtering", bridgeName), []byte("1"), 0644); err != nil {
 		t.Fatal(err)
 	}
 	if vlanMap, err := BridgeVlanList(); err != nil {

--- a/ipset_linux_test.go
+++ b/ipset_linux_test.go
@@ -2,16 +2,17 @@ package netlink
 
 import (
 	"bytes"
-	"io/ioutil"
 	"net"
+	"os"
 	"testing"
 
-	"github.com/vishvananda/netlink/nl"
 	"golang.org/x/sys/unix"
+
+	"github.com/vishvananda/netlink/nl"
 )
 
 func TestParseIpsetProtocolResult(t *testing.T) {
-	msgBytes, err := ioutil.ReadFile("testdata/ipset_protocol_result")
+	msgBytes, err := os.ReadFile("testdata/ipset_protocol_result")
 	if err != nil {
 		t.Fatalf("reading test fixture failed: %v", err)
 	}
@@ -23,7 +24,7 @@ func TestParseIpsetProtocolResult(t *testing.T) {
 }
 
 func TestParseIpsetListResult(t *testing.T) {
-	msgBytes, err := ioutil.ReadFile("testdata/ipset_list_result")
+	msgBytes, err := os.ReadFile("testdata/ipset_list_result")
 	if err != nil {
 		t.Fatalf("reading test fixture failed: %v", err)
 	}
@@ -76,14 +77,22 @@ func TestParseIpsetListResult(t *testing.T) {
 	}
 	expectedMAC := net.HardwareAddr{0xde, 0xad, 0x0, 0x0, 0xbe, 0xef}
 	if !bytes.Equal(ent.MAC, expectedMAC) {
-		t.Errorf("expected MAC for first entry to be %s, got %s", expectedMAC.String(), ent.MAC.String())
+		t.Errorf(
+			"expected MAC for first entry to be %s, got %s",
+			expectedMAC.String(),
+			ent.MAC.String(),
+		)
 	}
 
 	// second entry
 	ent = msg.Entries[1]
 	expectedMAC = net.HardwareAddr{0x1, 0x2, 0x3, 0x0, 0x1, 0x2}
 	if !bytes.Equal(ent.MAC, expectedMAC) {
-		t.Errorf("expected MAC for second entry to be %s, got %s", expectedMAC.String(), ent.MAC.String())
+		t.Errorf(
+			"expected MAC for second entry to be %s, got %s",
+			expectedMAC.String(),
+			ent.MAC.String(),
+		)
 	}
 }
 
@@ -496,58 +505,98 @@ func TestIpsetCreateListAddDelDestroyWithTestCases(t *testing.T) {
 
 			if tC.entry.IP != nil {
 				if !tC.entry.IP.Equal(result.Entries[0].IP) {
-					t.Fatalf("expected entry to be '%v', got '%v'", tC.entry.IP, result.Entries[0].IP)
+					t.Fatalf(
+						"expected entry to be '%v', got '%v'",
+						tC.entry.IP,
+						result.Entries[0].IP,
+					)
 				}
 			}
 
 			if tC.entry.CIDR > 0 {
 				if result.Entries[0].CIDR != tC.entry.CIDR {
-					t.Fatalf("expected cidr to be '%d', got '%d'", tC.entry.CIDR, result.Entries[0].CIDR)
+					t.Fatalf(
+						"expected cidr to be '%d', got '%d'",
+						tC.entry.CIDR,
+						result.Entries[0].CIDR,
+					)
 				}
 			}
 
 			if tC.entry.IP2 != nil {
 				if !tC.entry.IP2.Equal(result.Entries[0].IP2) {
-					t.Fatalf("expected entry.ip2 to be '%v', got '%v'", tC.entry.IP2, result.Entries[0].IP2)
+					t.Fatalf(
+						"expected entry.ip2 to be '%v', got '%v'",
+						tC.entry.IP2,
+						result.Entries[0].IP2,
+					)
 				}
 			}
 
 			if tC.entry.CIDR2 > 0 {
 				if result.Entries[0].CIDR2 != tC.entry.CIDR2 {
-					t.Fatalf("expected cidr2 to be '%d', got '%d'", tC.entry.CIDR2, result.Entries[0].CIDR2)
+					t.Fatalf(
+						"expected cidr2 to be '%d', got '%d'",
+						tC.entry.CIDR2,
+						result.Entries[0].CIDR2,
+					)
 				}
 			}
 
 			if tC.entry.Port != nil {
 				if *result.Entries[0].Protocol != *tC.entry.Protocol {
-					t.Fatalf("expected protocol to be '%d', got '%d'", *tC.entry.Protocol, *result.Entries[0].Protocol)
+					t.Fatalf(
+						"expected protocol to be '%d', got '%d'",
+						*tC.entry.Protocol,
+						*result.Entries[0].Protocol,
+					)
 				}
 				if *result.Entries[0].Port != *tC.entry.Port {
-					t.Fatalf("expected port to be '%d', got '%d'", *tC.entry.Port, *result.Entries[0].Port)
+					t.Fatalf(
+						"expected port to be '%d', got '%d'",
+						*tC.entry.Port,
+						*result.Entries[0].Port,
+					)
 				}
 			}
 
 			if tC.entry.MAC != nil {
 				if result.Entries[0].MAC.String() != tC.entry.MAC.String() {
-					t.Fatalf("expected mac to be '%v', got '%v'", tC.entry.MAC, result.Entries[0].MAC)
+					t.Fatalf(
+						"expected mac to be '%v', got '%v'",
+						tC.entry.MAC,
+						result.Entries[0].MAC,
+					)
 				}
 			}
 
 			if tC.entry.IFace != "" {
 				if result.Entries[0].IFace != tC.entry.IFace {
-					t.Fatalf("expected iface to be '%v', got '%v'", tC.entry.IFace, result.Entries[0].IFace)
+					t.Fatalf(
+						"expected iface to be '%v', got '%v'",
+						tC.entry.IFace,
+						result.Entries[0].IFace,
+					)
 				}
 			}
 
 			if tC.entry.Mark != nil {
 				if *result.Entries[0].Mark != *tC.entry.Mark {
-					t.Fatalf("expected mark to be '%v', got '%v'", *tC.entry.Mark, *result.Entries[0].Mark)
+					t.Fatalf(
+						"expected mark to be '%v', got '%v'",
+						*tC.entry.Mark,
+						*result.Entries[0].Mark,
+					)
 				}
 			}
 
 			if result.Entries[0].Comment != tC.entry.Comment {
 				// This is only supported in the kernel module from revision 2 or 4, so comments may be ignored.
-				t.Logf("expected comment to be '%s', got '%s'", tC.entry.Comment, result.Entries[0].Comment)
+				t.Logf(
+					"expected comment to be '%s', got '%s'",
+					tC.entry.Comment,
+					result.Entries[0].Comment,
+				)
 			}
 
 			err = IpsetDel(tC.setname, tC.entry)
@@ -630,7 +679,13 @@ func TestIpsetBitmapCreateListWithTestCases(t *testing.T) {
 
 			if tC.typename == "bitmap:port" {
 				if result.PortFrom != tC.options.PortFrom || result.PortTo != tC.options.PortTo {
-					t.Fatalf("expected port range %d-%d, got %d-%d", tC.options.PortFrom, tC.options.PortTo, result.PortFrom, result.PortTo)
+					t.Fatalf(
+						"expected port range %d-%d, got %d-%d",
+						tC.options.PortFrom,
+						tC.options.PortTo,
+						result.PortFrom,
+						result.PortTo,
+					)
 				}
 			} else if tC.typename == "bitmap:ip" {
 				if result.IPFrom == nil || result.IPTo == nil || result.IPFrom.Equal(tC.options.IPFrom) || result.IPTo.Equal(tC.options.IPTo) {

--- a/netlink_test.go
+++ b/netlink_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package netlink
@@ -7,7 +8,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -155,7 +155,7 @@ func setUpSEG6NetlinkTest(t *testing.T) tearDownNetlinkTest {
 }
 
 func setUpNetlinkTestWithKModule(t *testing.T, name string) tearDownNetlinkTest {
-	file, err := ioutil.ReadFile("/proc/modules")
+	file, err := os.ReadFile("/proc/modules")
 	if err != nil {
 		t.Fatal("Failed to open /proc/modules", err)
 	}

--- a/qdisc_linux.go
+++ b/qdisc_linux.go
@@ -2,13 +2,14 @@ package netlink
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 	"syscall"
 
-	"github.com/vishvananda/netlink/nl"
 	"golang.org/x/sys/unix"
+
+	"github.com/vishvananda/netlink/nl"
 )
 
 // NOTE function is here because it uses other linux functions
@@ -645,7 +646,7 @@ var (
 )
 
 func initClock() {
-	data, err := ioutil.ReadFile("/proc/net/psched")
+	data, err := os.ReadFile("/proc/net/psched")
 	if err != nil {
 		return
 	}

--- a/rdma_link_test.go
+++ b/rdma_link_test.go
@@ -1,9 +1,10 @@
+//go:build linux
 // +build linux
 
 package netlink
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -12,7 +13,7 @@ import (
 
 func setupRdmaKModule(t *testing.T, name string) {
 	skipUnlessRoot(t)
-	file, err := ioutil.ReadFile("/proc/modules")
+	file, err := os.ReadFile("/proc/modules")
 	if err != nil {
 		t.Fatal("Failed to open /proc/modules", err)
 	}


### PR DESCRIPTION
This pull request removes all calls and imports of ioutils which is deprecated.

Only ReadFile and WriteFile of ioutil is used and those are just imported from os instead.

_This is my first pull request on this branch, I don't know if you have some rules about how it should be done, please let me know if I need to do anything :-)_ 