### PR TITLE
feat(sock_diag): add state filter option to SocketDiag

### DIFF
--- a/socket_test.go
+++ b/socket_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package netlink
@@ -71,6 +72,31 @@ func TestSocketDiagTCPInfo(t *testing.T) {
 			gotFamily := i.InetDiagMsg.Family
 			if gotFamily != wantFamily {
 				t.Fatalf("Socket family = %d, want %d", gotFamily, wantFamily)
+			}
+		}
+	}
+}
+
+func TestSocketDiagTCPInfoFilterState(t *testing.T) {
+	Family4 := uint8(syscall.AF_INET)
+	Family6 := uint8(syscall.AF_INET6)
+	families := []uint8{Family4, Family6}
+
+	wantState := uint8(TCP_LISTEN)
+	for _, wantFamily := range families {
+		res, err := SocketDiagTCPInfo(wantFamily, wantState)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, i := range res {
+			gotFamily := i.InetDiagMsg.Family
+			if gotFamily != wantFamily {
+				t.Fatalf("Socket family = %d, want %d", gotFamily, wantFamily)
+			}
+
+			gotState := i.InetDiagMsg.State
+			if gotState != wantState {
+				t.Fatalf("Socket state = %d, want %d", gotState, wantState)
 			}
 		}
 	}


### PR DESCRIPTION
I want to retrieve all listening sockets, but I've noticed that SocketDiagTCP consumes a lot of memory and works slowly due to the large number of ESTABLISHED sockets on my server. Therefore, I've added a state filter(backward compatibility) to the SocketDiag function to pre-filter the sockets in the OS.