### PR TITLE
Mark skipUnlessRoot and minKernelRequired as test helpers

### DIFF
--- a/netlink_test.go
+++ b/netlink_test.go
@@ -24,6 +24,8 @@ import (
 type tearDownNetlinkTest func()
 
 func skipUnlessRoot(t *testing.T) {
+	t.Helper()
+
 	if os.Getuid() != 0 {
 		t.Skip("Test requires root privileges.")
 	}
@@ -187,6 +189,8 @@ func remountSysfs() error {
 }
 
 func minKernelRequired(t *testing.T, kernel, major int) {
+	t.Helper()
+
 	k, m, err := KernelVersion()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
With this, the skip message will display the position of the helper invocation (i.e. the test that caused the skip) instead of the position of the t.Skip call in minKernelRequired the helper.