### PR TITLE
Add socket diagnosis for UDP

### DIFF
--- a/inet_diag.go
+++ b/inet_diag.go
@@ -29,3 +29,8 @@ type InetDiagTCPInfoResp struct {
 	TCPInfo     *TCPInfo
 	TCPBBRInfo  *TCPBBRInfo
 }
+
+type InetDiagUDPInfoResp struct {
+	InetDiagMsg *Socket
+	Memory      *MemInfo
+}

--- a/socket_test.go
+++ b/socket_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package netlink
@@ -71,6 +72,21 @@ func TestSocketDiagTCPInfo(t *testing.T) {
 			gotFamily := i.InetDiagMsg.Family
 			if gotFamily != wantFamily {
 				t.Fatalf("Socket family = %d, want %d", gotFamily, wantFamily)
+			}
+		}
+	}
+}
+
+func TestSocketDiagUDPnfo(t *testing.T) {
+	for _, want := range []uint8{syscall.AF_INET, syscall.AF_INET6} {
+		result, err := SocketDiagUDPInfo(want)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, r := range result {
+			if got := r.InetDiagMsg.Family; got != want {
+				t.Fatalf("protocol family = %v, want %v", got, want)
 			}
 		}
 	}

--- a/tcp.go
+++ b/tcp.go
@@ -82,3 +82,11 @@ type TCPBBRInfo struct {
 	BBRPacingGain uint32
 	BBRCwndGain   uint32
 }
+
+// According to https://man7.org/linux/man-pages/man7/sock_diag.7.html
+type MemInfo struct {
+	RMem uint32
+	WMem uint32
+	FMem uint32
+	TMem uint32
+}

--- a/tcp_linux.go
+++ b/tcp_linux.go
@@ -8,6 +8,7 @@ import (
 
 const (
 	tcpBBRInfoLen = 20
+	memInfoLen    = 16
 )
 
 func checkDeserErr(err error) error {
@@ -348,6 +349,20 @@ func (t *TCPBBRInfo) deserialize(b []byte) error {
 	t.BBRMinRTT = native.Uint32(rb.Next(4))
 	t.BBRPacingGain = native.Uint32(rb.Next(4))
 	t.BBRCwndGain = native.Uint32(rb.Next(4))
+
+	return nil
+}
+
+func (m *MemInfo) deserialize(b []byte) error {
+	if len(b) != memInfoLen {
+		return errors.New("Invalid length")
+	}
+
+	rb := bytes.NewBuffer(b)
+	m.RMem = native.Uint32(rb.Next(4))
+	m.WMem = native.Uint32(rb.Next(4))
+	m.FMem = native.Uint32(rb.Next(4))
+	m.TMem = native.Uint32(rb.Next(4))
 
 	return nil
 }


### PR DESCRIPTION
This PR adds netlink socket diagnosis support for UDP and implements parsing of the `INET_DIAG_MEMINFO` extension data.