### PR TITLE
fq: Fix to set missing TCA_FQ_PLIMIT attribute

### DIFF
--- a/qdisc_linux.go
+++ b/qdisc_linux.go
@@ -265,6 +265,9 @@ func qdiscPayload(req *nl.NetlinkRequest, qdisc Qdisc) error {
 		if qdisc.Buckets > 0 {
 			options.AddRtAttr(nl.TCA_FQ_BUCKETS_LOG, nl.Uint32Attr((uint32(qdisc.Buckets))))
 		}
+		if qdisc.PacketLimit > 0 {
+			options.AddRtAttr(nl.TCA_FQ_PLIMIT, nl.Uint32Attr((uint32(qdisc.PacketLimit))))
+		}
 		if qdisc.LowRateThreshold > 0 {
 			options.AddRtAttr(nl.TCA_FQ_LOW_RATE_THRESHOLD, nl.Uint32Attr((uint32(qdisc.LowRateThreshold))))
 		}


### PR DESCRIPTION
The qdiscPayload() function was missing the TCA_FQ_PLIMIT attribute for the Fq Qdisc. Therefore, it could not be changed via the library. Fix this up, so that QdiscReplace() with different qdisc.PacketLimit works now.