### PR TITLE
qdisc: Add Clsact

### DIFF
--- a/qdisc.go
+++ b/qdisc.go
@@ -217,6 +217,19 @@ func (qdisc *Tbf) Type() string {
 	return "tbf"
 }
 
+// Clsact is a qdisc for adding filters
+type Clsact struct {
+	QdiscAttrs
+}
+
+func (qdisc *Clsact) Attrs() *QdiscAttrs {
+	return &qdisc.QdiscAttrs
+}
+
+func (qdisc *Clsact) Type() string {
+	return "clsact"
+}
+
 // Ingress is a qdisc for adding ingress filters
 type Ingress struct {
 	QdiscAttrs

--- a/qdisc_linux.go
+++ b/qdisc_linux.go
@@ -234,6 +234,8 @@ func qdiscPayload(req *nl.NetlinkRequest, qdisc Qdisc) error {
 		if reorder.Probability > 0 {
 			options.AddRtAttr(nl.TCA_NETEM_REORDER, reorder.Serialize())
 		}
+	case *Clsact:
+		options = nil
 	case *Ingress:
 		// ingress filters must use the proper handle
 		if qdisc.Attrs().Parent != HANDLE_INGRESS {
@@ -392,6 +394,8 @@ func (h *Handle) QdiscList(link Link) ([]Qdisc, error) {
 					qdisc = &Netem{}
 				case "sfq":
 					qdisc = &Sfq{}
+				case "clsact":
+					qdisc = &Clsact{}
 				default:
 					qdisc = &GenericQdisc{QdiscType: qdiscType}
 				}


### PR DESCRIPTION
Qdisc implementation was missing the clsact qdisc which would allow adding filters to both ingress and egress. See https://lwn.net/Articles/671458/

We have been running a fork with this patch for approx 1 year. Seems stable enough to propose to upstream.