### PR TITLE
Allow NLMSG_DONE with no data

### DIFF
--- a/nl/nl_linux.go
+++ b/nl/nl_linux.go
@@ -565,6 +565,11 @@ done:
 			}
 
 			if m.Header.Type == unix.NLMSG_DONE || m.Header.Type == unix.NLMSG_ERROR {
+				// NLMSG_DONE might have no payload, if so assume no error.
+				if m.Header.Type == unix.NLMSG_DONE && len(m.Data) == 0 {
+					break done
+				}
+
 				native := NativeEndian()
 				errno := int32(native.Uint32(m.Data[0:4]))
 				if errno == 0 {


### PR DESCRIPTION
certain implementations in kernel return NLMSG_DONE with no data. If that is the case, assume no error occured.

currently we panic.


Note:
This behaviour exists in devlink subsystem, and possibly others.
clarification has been added to kernel docs[1]


[1] https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git/commit/?id=8ad55b1e73c4e77656e2bea68fa2b484f33a6425