### PR TITLE
add group_fwd_mask support for bridge and bridge port

### DIFF
--- a/link.go
+++ b/link.go
@@ -272,6 +272,7 @@ type Bridge struct {
 	HelloTime         *uint32
 	VlanFiltering     *bool
 	VlanDefaultPVID   *uint16
+	GroupFwdMask      *uint16
 }
 
 func (bridge *Bridge) Attrs() *LinkAttrs {


### PR DESCRIPTION
group_fwd_mask is useful to make certain Ethernet link local traffic like LLDP to pass-through bridge;
this PR provides capability equivalent to command `ip link add <name> type bridge group_fwd_mask <mask` and `ip link set <name> type bridge_slave group_fwd_mask <mask>`
