### PR TITLE
Change behavior of `Subscribe` to non-blocking. Fix test.

### DIFF
--- a/addr_linux.go
+++ b/addr_linux.go
@@ -365,6 +365,9 @@ func addrSubscribeAt(newNs, curNs netns.NsHandle, ch chan<- AddrUpdate, done <-c
 		for {
 			msgs, from, err := s.Receive()
 			if err != nil {
+				if err == syscall.EAGAIN {
+					continue
+				}
 				if cberr != nil {
 					cberr(fmt.Errorf("Receive failed: %v",
 						err))

--- a/link_linux.go
+++ b/link_linux.go
@@ -996,28 +996,28 @@ func LinkSetXdpFdWithFlags(link Link, fd, flags int) error {
 // LinkSetGSOMaxSegs sets the GSO maximum segment count of the link device.
 // Equivalent to: `ip link set $link gso_max_segs $maxSegs`
 func LinkSetGSOMaxSegs(link Link, maxSegs int) error {
-       return pkgHandle.LinkSetGSOMaxSegs(link, maxSegs)
+	return pkgHandle.LinkSetGSOMaxSegs(link, maxSegs)
 }
 
 // LinkSetGSOMaxSegs sets the GSO maximum segment count of the link device.
 // Equivalent to: `ip link set $link gso_max_segs $maxSegs`
 func (h *Handle) LinkSetGSOMaxSegs(link Link, maxSize int) error {
-       base := link.Attrs()
-       h.ensureIndex(base)
-       req := h.newNetlinkRequest(unix.RTM_SETLINK, unix.NLM_F_ACK)
+	base := link.Attrs()
+	h.ensureIndex(base)
+	req := h.newNetlinkRequest(unix.RTM_SETLINK, unix.NLM_F_ACK)
 
-       msg := nl.NewIfInfomsg(unix.AF_UNSPEC)
-       msg.Index = int32(base.Index)
-       req.AddData(msg)
+	msg := nl.NewIfInfomsg(unix.AF_UNSPEC)
+	msg.Index = int32(base.Index)
+	req.AddData(msg)
 
-       b := make([]byte, 4)
-       native.PutUint32(b, uint32(maxSize))
+	b := make([]byte, 4)
+	native.PutUint32(b, uint32(maxSize))
 
-       data := nl.NewRtAttr(unix.IFLA_GSO_MAX_SEGS, b)
-       req.AddData(data)
+	data := nl.NewRtAttr(unix.IFLA_GSO_MAX_SEGS, b)
+	req.AddData(data)
 
-       _, err := req.Execute(unix.NETLINK_ROUTE, 0)
-       return err
+	_, err := req.Execute(unix.NETLINK_ROUTE, 0)
+	return err
 }
 
 // LinkSetGSOMaxSize sets the IPv6 GSO maximum size of the link device.
@@ -2353,6 +2353,9 @@ func linkSubscribeAt(newNs, curNs netns.NsHandle, ch chan<- LinkUpdate, done <-c
 		for {
 			msgs, from, err := s.Receive()
 			if err != nil {
+				if err == syscall.EAGAIN {
+					continue
+				}
 				if cberr != nil {
 					cberr(fmt.Errorf("Receive failed: %v",
 						err))

--- a/link_test.go
+++ b/link_test.go
@@ -1605,10 +1605,8 @@ func TestLinkAddDelVxlanFlowBased(t *testing.T) {
 }
 
 func TestLinkAddDelBareUDP(t *testing.T) {
-	if os.Getenv("CI") == "true" {
-		t.Skipf("Fails in CI due to operation not supported (missing kernel module?)")
-	}
-	minKernelRequired(t, 5, 8)
+	minKernelRequired(t, 5, 1)
+	setUpNetlinkTestWithKModule(t, "bareudp")
 	tearDown := setUpNetlinkTest(t)
 	defer tearDown()
 
@@ -1635,6 +1633,7 @@ func TestBareUDPCompareToIP(t *testing.T) {
 	}
 	// requires iproute2 >= 5.10
 	minKernelRequired(t, 5, 9)
+	setUpNetlinkTestWithKModule(t, "bareudp")
 	ns, tearDown := setUpNamedNetlinkTest(t)
 	defer tearDown()
 

--- a/neigh_linux.go
+++ b/neigh_linux.go
@@ -416,6 +416,9 @@ func neighSubscribeAt(newNs, curNs netns.NsHandle, ch chan<- NeighUpdate, done <
 		for {
 			msgs, from, err := s.Receive()
 			if err != nil {
+				if err == syscall.EAGAIN {
+					continue
+				}
 				if cberr != nil {
 					cberr(err)
 				}

--- a/nl/nl_linux.go
+++ b/nl/nl_linux.go
@@ -722,6 +722,16 @@ func Subscribe(protocol int, groups ...uint) (*NetlinkSocket, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Sometimes (socket_linux.go:SocketGet), Subscribe is used to create a socket
+	// that subscirbed to no groups. So we don't need to set nonblock there.
+	if len(groups) > 0 {
+		if err := unix.SetNonblock(fd, true); err != nil {
+			unix.Close(fd)
+			return nil, err
+		}
+	}
+
 	s := &NetlinkSocket{
 		fd: int32(fd),
 	}

--- a/proc_event_linux.go
+++ b/proc_event_linux.go
@@ -148,6 +148,9 @@ func ProcEventMonitor(ch chan<- ProcEvent, done <-chan struct{}, errorChan chan<
 		for {
 			msgs, from, err := s.Receive()
 			if err != nil {
+				if err == syscall.EAGAIN {
+					continue
+				}
 				errorChan <- err
 				return
 			}

--- a/route_linux.go
+++ b/route_linux.go
@@ -1527,6 +1527,9 @@ func routeSubscribeAt(newNs, curNs netns.NsHandle, ch chan<- RouteUpdate, done <
 		for {
 			msgs, from, err := s.Receive()
 			if err != nil {
+				if err == syscall.EAGAIN {
+					continue
+				}
 				if cberr != nil {
 					cberr(fmt.Errorf("Receive failed: %v",
 						err))

--- a/socket_linux.go
+++ b/socket_linux.go
@@ -237,6 +237,9 @@ loop:
 	for {
 		msgs, from, err := s.Receive()
 		if err != nil {
+			if err == syscall.EAGAIN {
+				continue
+			}
 			return err
 		}
 		if from.Pid != nl.PidKernel {

--- a/xfrm_monitor_linux.go
+++ b/xfrm_monitor_linux.go
@@ -2,6 +2,7 @@ package netlink
 
 import (
 	"fmt"
+	"syscall"
 
 	"github.com/vishvananda/netlink/nl"
 	"github.com/vishvananda/netns"
@@ -56,6 +57,9 @@ func XfrmMonitor(ch chan<- XfrmMsg, done <-chan struct{}, errorChan chan<- error
 		for {
 			msgs, from, err := s.Receive()
 			if err != nil {
+				if err == syscall.EAGAIN {
+					continue
+				}
 				errorChan <- err
 				return
 			}


### PR DESCRIPTION
When listening for IPv6 address changes, I found that a netlink socket that is subscribed to a group is not returning from `Receive` when there is message in the socket. After some researching, I found that libnl suggest setting socket to non-blocking when subscribing to groups. [Ref](https://www.infradead.org/~tgr/libnl/doc/core.html#:~:text=best%20to%20put%20the%20socket%20in%20non-blocking%20mode) This is probably caused by a bug in kernel. 


My test machine runs in 5.10, before, `addrSubscribeAt` would only exit on timeout; after the patch, it correctly sending addr to channels on each new addr.


Also fixed test related to BareUDP, which requires "bareudp" kmod. [Ref](https://www.kernelconfig.io/config_bareudp)