### PR TITLE
qdisc: add statistics for qdisc

### DIFF
--- a/qdisc.go
+++ b/qdisc.go
@@ -28,6 +28,8 @@ type Qdisc interface {
 	Type() string
 }
 
+type QdiscStatistics ClassStatistics
+
 // QdiscAttrs represents a netlink qdisc. A qdisc is associated with a link,
 // has a handle, a parent and a refcnt. The root qdisc of a device should
 // have parent == HANDLE_ROOT.
@@ -37,6 +39,7 @@ type QdiscAttrs struct {
 	Parent       uint32
 	Refcnt       uint32 // read only
 	IngressBlock *uint32
+	Statistics   *QdiscStatistics
 }
 
 func (q QdiscAttrs) String() string {

--- a/qdisc_linux.go
+++ b/qdisc_linux.go
@@ -462,6 +462,18 @@ func (h *Handle) QdiscList(link Link) ([]Qdisc, error) {
 				ingressBlock := new(uint32)
 				*ingressBlock = native.Uint32(attr.Value)
 				base.IngressBlock = ingressBlock
+			case nl.TCA_STATS:
+				s, err := parseTcStats(attr.Value)
+				if err != nil {
+					return nil, err
+				}
+				base.Statistics = (*QdiscStatistics)(s)
+			case nl.TCA_STATS2:
+				s, err := parseTcStats2(attr.Value)
+				if err != nil {
+					return nil, err
+				}
+				base.Statistics = (*QdiscStatistics)(s)
 			}
 		}
 		*qdisc.Attrs() = base

--- a/qdisc_test.go
+++ b/qdisc_test.go
@@ -614,6 +614,12 @@ func TestIngressAddDel(t *testing.T) {
 	if *qdiscs[0].Attrs().IngressBlock != *ingressBlock {
 		t.Fatal("IngressBlock does not match")
 	}
+	if qdiscs[0].Attrs().Statistics == nil {
+		t.Fatal("Statistics is nil")
+	}
+	if qdiscs[0].Attrs().Statistics.Basic.Bytes != 0 || qdiscs[0].Attrs().Statistics.Basic.Packets != 0 {
+		t.Fatal("Statistics is not zero")
+	}
 	if err = QdiscDel(qdisc); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
qdisc statistics is exposed in netlink response but not parsed, here we parse it and expose it via struct QdiscStatistics.