### PR TITLE
Add support for TCA_HTB_DIRECT_QLEN in HTB qdisc

### DIFF
--- a/qdisc.go
+++ b/qdisc.go
@@ -123,6 +123,7 @@ type Htb struct {
 	Defcls       uint32
 	Debug        uint32
 	DirectPkts   uint32
+	DirectQlen   *uint32
 }
 
 func NewHtb(attrs QdiscAttrs) *Htb {
@@ -133,6 +134,7 @@ func NewHtb(attrs QdiscAttrs) *Htb {
 		Rate2Quantum: 10,
 		Debug:        0,
 		DirectPkts:   0,
+		DirectQlen:   nil,
 	}
 }
 

--- a/qdisc_linux.go
+++ b/qdisc_linux.go
@@ -200,7 +200,9 @@ func qdiscPayload(req *nl.NetlinkRequest, qdisc Qdisc) error {
 		opt.Debug = qdisc.Debug
 		opt.DirectPkts = qdisc.DirectPkts
 		options.AddRtAttr(nl.TCA_HTB_INIT, opt.Serialize())
-		// options.AddRtAttr(nl.TCA_HTB_DIRECT_QLEN, opt.Serialize())
+		if qdisc.DirectQlen != nil {
+			options.AddRtAttr(nl.TCA_HTB_DIRECT_QLEN, nl.Uint32Attr(*qdisc.DirectQlen))
+		}
 	case *Hfsc:
 		opt := nl.TcHfscOpt{}
 		opt.Defcls = qdisc.Defcls
@@ -525,8 +527,8 @@ func parseHtbData(qdisc Qdisc, data []syscall.NetlinkRouteAttr) error {
 			htb.Debug = opt.Debug
 			htb.DirectPkts = opt.DirectPkts
 		case nl.TCA_HTB_DIRECT_QLEN:
-			// TODO
-			//htb.DirectQlen = native.uint32(datum.Value)
+			directQlen := native.Uint32(datum.Value)
+			htb.DirectQlen = &directQlen
 		}
 	}
 	return nil

--- a/qdisc_test.go
+++ b/qdisc_test.go
@@ -87,6 +87,8 @@ func TestHtbAddDel(t *testing.T) {
 
 	qdisc := NewHtb(attrs)
 	qdisc.Rate2Quantum = 5
+	directQlen := uint32(10)
+	qdisc.DirectQlen = &directQlen
 	if err := QdiscAdd(qdisc); err != nil {
 		t.Fatal(err)
 	}
@@ -110,6 +112,9 @@ func TestHtbAddDel(t *testing.T) {
 	}
 	if htb.Debug != qdisc.Debug {
 		t.Fatal("Debug doesn't match")
+	}
+	if htb.DirectQlen == nil || *htb.DirectQlen != directQlen {
+		t.Fatalf("DirectQlen doesn't match. Expected %d, got %v", directQlen, htb.DirectQlen)
 	}
 	if err := QdiscDel(qdisc); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
- Extend Htb struct in qdisc.go to include DirectQlen field
- Implement the DirectQlen option in qdisc_linux.go
- Modify TestHtbAddDel test to validate DirectQlen changes