### PR TITLE
Fix go race detector races

### DIFF
--- a/qdisc_linux.go
+++ b/qdisc_linux.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 
 	"github.com/vishvananda/netlink/nl"
@@ -688,6 +689,9 @@ var (
 	tickInUsec  float64
 	clockFactor float64
 	hz          float64
+
+	// Without this, the go race detector may report races.
+	initClockMutex sync.Mutex
 )
 
 func initClock() {
@@ -722,6 +726,8 @@ func initClock() {
 }
 
 func TickInUsec() float64 {
+	initClockMutex.Lock()
+	defer initClockMutex.Unlock()
 	if tickInUsec == 0.0 {
 		initClock()
 	}
@@ -729,6 +735,8 @@ func TickInUsec() float64 {
 }
 
 func ClockFactor() float64 {
+	initClockMutex.Lock()
+	defer initClockMutex.Unlock()
 	if clockFactor == 0.0 {
 		initClock()
 	}
@@ -736,6 +744,8 @@ func ClockFactor() float64 {
 }
 
 func Hz() float64 {
+	initClockMutex.Lock()
+	defer initClockMutex.Unlock()
 	if hz == 0.0 {
 		initClock()
 	}


### PR DESCRIPTION
This fixes an issue I had where the Go race detector reported races.

Even though there technically is a race, the existing code probably works fine. However, it is nice to be able to use the Go race detector without having races reported.

I considered using sync.Once instead. However, I wanted to preserve the existing behavior, that in case of problems reading "/proc/net/psched", we try to read it again next time.