### PR TITLE
Revert "Change behavior of `Subscribe` to non-blocking. Fix test."

### DIFF
--- a/addr_linux.go
+++ b/addr_linux.go
@@ -367,9 +367,6 @@ func addrSubscribeAt(newNs, curNs netns.NsHandle, ch chan<- AddrUpdate, done <-c
 		for {
 			msgs, from, err := s.Receive()
 			if err != nil {
-				if err == syscall.EAGAIN {
-					continue
-				}
 				if cberr != nil {
 					cberr(fmt.Errorf("Receive failed: %v",
 						err))

--- a/link_linux.go
+++ b/link_linux.go
@@ -2434,9 +2434,6 @@ func linkSubscribeAt(newNs, curNs netns.NsHandle, ch chan<- LinkUpdate, done <-c
 		for {
 			msgs, from, err := s.Receive()
 			if err != nil {
-				if err == syscall.EAGAIN {
-					continue
-				}
 				if cberr != nil {
 					cberr(fmt.Errorf("Receive failed: %v",
 						err))

--- a/neigh_linux.go
+++ b/neigh_linux.go
@@ -416,9 +416,6 @@ func neighSubscribeAt(newNs, curNs netns.NsHandle, ch chan<- NeighUpdate, done <
 		for {
 			msgs, from, err := s.Receive()
 			if err != nil {
-				if err == syscall.EAGAIN {
-					continue
-				}
 				if cberr != nil {
 					cberr(err)
 				}

--- a/nl/nl_linux.go
+++ b/nl/nl_linux.go
@@ -727,16 +727,6 @@ func Subscribe(protocol int, groups ...uint) (*NetlinkSocket, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	// Sometimes (socket_linux.go:SocketGet), Subscribe is used to create a socket
-	// that subscirbed to no groups. So we don't need to set nonblock there.
-	if len(groups) > 0 {
-		if err := unix.SetNonblock(fd, true); err != nil {
-			unix.Close(fd)
-			return nil, err
-		}
-	}
-
 	s := &NetlinkSocket{
 		fd: int32(fd),
 	}

--- a/proc_event_linux.go
+++ b/proc_event_linux.go
@@ -148,9 +148,6 @@ func ProcEventMonitor(ch chan<- ProcEvent, done <-chan struct{}, errorChan chan<
 		for {
 			msgs, from, err := s.Receive()
 			if err != nil {
-				if err == syscall.EAGAIN {
-					continue
-				}
 				errorChan <- err
 				return
 			}

--- a/route_linux.go
+++ b/route_linux.go
@@ -1657,9 +1657,6 @@ func routeSubscribeAt(newNs, curNs netns.NsHandle, ch chan<- RouteUpdate, done <
 		for {
 			msgs, from, err := s.Receive()
 			if err != nil {
-				if err == syscall.EAGAIN {
-					continue
-				}
 				if cberr != nil {
 					cberr(fmt.Errorf("Receive failed: %v",
 						err))

--- a/socket_linux.go
+++ b/socket_linux.go
@@ -499,9 +499,6 @@ loop:
 	for {
 		msgs, from, err := s.Receive()
 		if err != nil {
-			if err == syscall.EAGAIN {
-				continue
-			}
 			return err
 		}
 		if from.Pid != nl.PidKernel {

--- a/xfrm_monitor_linux.go
+++ b/xfrm_monitor_linux.go
@@ -2,7 +2,6 @@ package netlink
 
 import (
 	"fmt"
-	"syscall"
 
 	"github.com/vishvananda/netlink/nl"
 	"github.com/vishvananda/netns"
@@ -57,9 +56,6 @@ func XfrmMonitor(ch chan<- XfrmMsg, done <-chan struct{}, errorChan chan<- error
 		for {
 			msgs, from, err := s.Receive()
 			if err != nil {
-				if err == syscall.EAGAIN {
-					continue
-				}
 				errorChan <- err
 				return
 			}


### PR DESCRIPTION
This reverts commit 916f9685fa42fc711f76a7f48d058e2656f7edf6.

It doesn't revert the BareUDP test fix.

For #975 