### PR TITLE
Eliminate busy loop when receiving messages from non-blocking socket

### DIFF
--- a/nl/nl_linux_test.go
+++ b/nl/nl_linux_test.go
@@ -75,7 +75,7 @@ func TestIfSocketCloses(t *testing.T) {
 		for {
 			_, _, err := sk.Receive()
 			// Receive returned because of a timeout and the FD == -1 means that the socket got closed
-			if err == unix.EAGAIN && nlSock.GetFd() == -1 {
+			if nlSock.GetFd() == -1 {
 				endCh <- err
 				return
 			}


### PR DESCRIPTION
For a non-blocking socket, it should wait for events first before receiving messages from the socket, otherwise it would receive empty message and run into a busy loop.

This is an alternative of https://github.com/vishvananda/netlink/pull/976.

Fixes #975

