### PR TITLE
Fix determination of the promiscuity counter for links

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -1975,9 +1975,6 @@ func LinkDeserialize(hdr *unix.NlMsghdr, m []byte) (Link, error) {
 	base.Flags = linkFlags(msg.Flags)
 	base.EncapType = msg.EncapType()
 	base.NetNsID = -1
-	if msg.Flags&unix.IFF_PROMISC != 0 {
-		base.Promisc = 1
-	}
 	if msg.Flags&unix.IFF_ALLMULTI != 0 {
 		base.Allmulti = 1
 	}
@@ -2164,6 +2161,8 @@ func LinkDeserialize(hdr *unix.NlMsghdr, m []byte) (Link, error) {
 			base.Name = string(attr.Value[:len(attr.Value)-1])
 		case unix.IFLA_MTU:
 			base.MTU = int(native.Uint32(attr.Value[0:4]))
+		case unix.IFLA_PROMISCUITY:
+			base.Promisc = int(native.Uint32(attr.Value[0:4]))
 		case unix.IFLA_LINK:
 			base.ParentIndex = int(native.Uint32(attr.Value[0:4]))
 		case unix.IFLA_MASTER:


### PR DESCRIPTION
Function `LinkDeserialize` checked for presence of `IFF_PROMISC` in the link's flags to determine whether it was in promiscuous mode.

This flag only tracks what is set with commands such as

	ip set <link> promisc on

but is not set when you run `tcpdump` or `wireshark` for example, which also put the device in promiscuous mode.

There is a counter that tracks the number of times promiscuous mode has been requested. It reacts to all the ways, `ip set`, and also `tcpdump` and co.

With this change this counter is used instead of checking the flag. This makes the library reflect what

	ip -d link show <link>

would show in its `promiscuity` field.

To test this change, start some processes of `tcpdump` or similar and see the counter increase in `ip -d link show <link>` as well as in the patched version of this netlink library. With the unpatched version the counter remains 0. Then enable promiscuous mode globally for the interface. This will increase the count in all variants, `ip link`, the old unpatched and the patched version of this netlink library.

Simple test program for reference:

	package main

	import "fmt"
	import "github.com/vishvananda/netlink"

	func main() {
		handle, _ := netlink.NewHandle()
		links, _ := handle.LinkList()
		for _, link := range links {
			attrs := link.Attrs()
			fmt.Printf("dev=%v promisc=%v\n",
				attrs.Name, attrs.Promisc)
		}
	}