### PR TITLE
fix: updates SizeofVfVlanInfo to address #1003

### DIFF
--- a/nl/link_linux.go
+++ b/nl/link_linux.go
@@ -321,7 +321,7 @@ const (
 const (
 	SizeofVfMac        = 0x24
 	SizeofVfVlan       = 0x0c
-	SizeofVfVlanInfo   = 0x0e
+	SizeofVfVlanInfo   = 0x10
 	SizeofVfTxRate     = 0x08
 	SizeofVfRate       = 0x0c
 	SizeofVfSpoofchk   = 0x08


### PR DESCRIPTION
This PR updates the `SizeOfVlanInfo` to be 16 rather than 14 to pad the attribute to be a multiple of 4 bytes, which is required by netlink when using `LinkSetVfVlanQosProto()`. This appears to have always been an issue, but was not correctly caught by netlink until [this CVE](https://lore.kernel.org/linux-cve-announce/2024053015-CVE-2024-36017-bf96@gregkh/T/) was addressed, which explains why older kernels don't have an issue with this. 

Closes #1003 