### PR TITLE
Handle: add ConntrackDeleteFilter alias for backward compat

### DIFF
--- a/conntrack_linux.go
+++ b/conntrack_linux.go
@@ -69,6 +69,8 @@ func ConntrackUpdate(table ConntrackTableType, family InetFamily, flow *Conntrac
 
 // ConntrackDeleteFilter deletes entries on the specified table on the base of the filter
 // conntrack -D [table] parameters         Delete conntrack or expectation
+//
+// Deprecated: use [ConntrackDeleteFilter] instead.
 func ConntrackDeleteFilter(table ConntrackTableType, family InetFamily, filter CustomConntrackFilter) (uint, error) {
 	return pkgHandle.ConntrackDeleteFilters(table, family, filter)
 }
@@ -137,6 +139,14 @@ func (h *Handle) ConntrackUpdate(table ConntrackTableType, family InetFamily, fl
 
 	_, err = req.Execute(unix.NETLINK_NETFILTER, 0)
 	return err
+}
+
+// ConntrackDeleteFilter deletes entries on the specified table on the base of the filter using the netlink handle passed
+// conntrack -D [table] parameters         Delete conntrack or expectation
+//
+// Deprecated: use [Handle.ConntrackDeleteFilters] instead.
+func (h *Handle) ConntrackDeleteFilter(table ConntrackTableType, family InetFamily, filter CustomConntrackFilter) (uint, error) {
+	return h.ConntrackDeleteFilters(table, family, filter)
 }
 
 // ConntrackDeleteFilters deletes entries on the specified table matching any of the specified filters using the netlink handle passed

--- a/conntrack_unspecified.go
+++ b/conntrack_unspecified.go
@@ -11,6 +11,9 @@ type InetFamily uint8
 // ConntrackFlow placeholder
 type ConntrackFlow struct{}
 
+// CustomConntrackFilter placeholder
+type CustomConntrackFilter struct{}
+
 // ConntrackFilter placeholder
 type ConntrackFilter struct{}
 
@@ -29,7 +32,15 @@ func ConntrackTableFlush(table ConntrackTableType) error {
 
 // ConntrackDeleteFilter deletes entries on the specified table on the base of the filter
 // conntrack -D [table] parameters         Delete conntrack or expectation
+//
+// Deprecated: use [ConntrackDeleteFilter] instead.
 func ConntrackDeleteFilter(table ConntrackTableType, family InetFamily, filter *ConntrackFilter) (uint, error) {
+	return 0, ErrNotImplemented
+}
+
+// ConntrackDeleteFilters deletes entries on the specified table matching any of the specified filters
+// conntrack -D [table] parameters         Delete conntrack or expectation
+func ConntrackDeleteFilters(table ConntrackTableType, family InetFamily, filters ...CustomConntrackFilter) (uint, error) {
 	return 0, ErrNotImplemented
 }
 
@@ -48,6 +59,14 @@ func (h *Handle) ConntrackTableFlush(table ConntrackTableType) error {
 
 // ConntrackDeleteFilter deletes entries on the specified table on the base of the filter using the netlink handle passed
 // conntrack -D [table] parameters         Delete conntrack or expectation
+//
+// Deprecated: use [Handle.ConntrackDeleteFilters] instead.
 func (h *Handle) ConntrackDeleteFilter(table ConntrackTableType, family InetFamily, filter *ConntrackFilter) (uint, error) {
+	return 0, ErrNotImplemented
+}
+
+// ConntrackDeleteFilters deletes entries on the specified table matching any of the specified filters using the netlink handle passed
+// conntrack -D [table] parameters         Delete conntrack or expectation
+func (h *Handle) ConntrackDeleteFilters(table ConntrackTableType, family InetFamily, filters ...CustomConntrackFilter) (uint, error) {
 	return 0, ErrNotImplemented
 }


### PR DESCRIPTION
- relates to https://github.com/vishvananda/netlink/pull/989#discussion_r1679358097
- relates to https://github.com/moby/moby/pull/48368#issuecomment-2307059733

Commit c96b03b4befaf5cc418386ad9eaf1a5d15101b1e changed the signature of this method to accept a list of filters and renamed it to ConntrackDeleteFilters (plural).

This patch adds back ConntrackDeleteFilter as an alias, and marks it as deprecated in favor of the new version.



