### PR TITLE
Fix: Do not crash when enumerating tc filters with unknown actionType

### DIFF
--- a/filter_linux.go
+++ b/filter_linux.go
@@ -920,9 +920,11 @@ func parseActions(tables []syscall.NetlinkRouteAttr) ([]Action, error) {
 				actionnStatistic = (*ActionStatistic)(s)
 			}
 		}
-		action.Attrs().Statistics = actionnStatistic
-		action.Attrs().Timestamp = actionTimestamp
-		actions = append(actions, action)
+		if action != nil {
+			action.Attrs().Statistics = actionnStatistic
+			action.Attrs().Timestamp = actionTimestamp
+			actions = append(actions, action)
+		}
 	}
 	return actions, nil
 }


### PR DESCRIPTION
for example actionType "vlan"

#987