### PR TITLE
bugfix: parse ipv4 src/dst error

### DIFF
--- a/nl/tc_linux.go
+++ b/nl/tc_linux.go
@@ -1533,7 +1533,7 @@ func (p *TcPedit) SetIPv6Dst(ip6 net.IP) {
 }
 
 func (p *TcPedit) SetIPv4Src(ip net.IP) {
-	u32 := NativeEndian().Uint32(ip[:4])
+	u32 := NativeEndian().Uint32(ip.To4())
 
 	tKey := TcPeditKey{}
 	tKeyEx := TcPeditKeyEx{}
@@ -1549,7 +1549,7 @@ func (p *TcPedit) SetIPv4Src(ip net.IP) {
 }
 
 func (p *TcPedit) SetIPv4Dst(ip net.IP) {
-	u32 := NativeEndian().Uint32(ip[:4])
+	u32 := NativeEndian().Uint32(ip.To4())
 
 	tKey := TcPeditKey{}
 	tKeyEx := TcPeditKeyEx{}


### PR DESCRIPTION
### Introduction

When I use tc-pedit module to modify the src_ipv4/dst_ipv4, I check the result but the src_ipv4/dst_ipv4 is always "0".

For example, I want to set the dst_ipv4 to “172.17.0.2”, and I check the result with `tc filter show dev eth0`:

```
# actual
action order 1: pedit action ...
   key #1 at ipv4+16 val 00000000 mask 00000000
```

but the result is expeted to this:
```
# expect, the val is "172.17.0.2" not "0"
action order 1: pedit action ...
   key #1 at ipv4+16 val ac110002 mask 00000000
```