### PR TITLE
Fix FouList attribute body truncated error with kernel 5.2+

### DIFF
--- a/fou.go
+++ b/fou.go
@@ -1,16 +1,7 @@
 package netlink
 
 import (
-	"errors"
-)
-
-var (
-	// ErrAttrHeaderTruncated is returned when a netlink attribute's header is
-	// truncated.
-	ErrAttrHeaderTruncated = errors.New("attribute header truncated")
-	// ErrAttrBodyTruncated is returned when a netlink attribute's body is
-	// truncated.
-	ErrAttrBodyTruncated = errors.New("attribute body truncated")
+	"net"
 )
 
 type Fou struct {
@@ -18,4 +9,8 @@ type Fou struct {
 	Port      int
 	Protocol  int
 	EncapType int
+	Local     net.IP
+	Peer      net.IP
+	PeerPort  int
+	IfIndex   int
 }

--- a/fou_unspecified.go
+++ b/fou_unspecified.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package netlink


### PR DESCRIPTION
fou module added a bunch of new attributes in commit https://github.com/torvalds/linux/commit/1713cb37bf671e5d98919536941a8b56337874fd

which caused the old parsing logic failed, fix and add support for these attrributes.