### PR TITLE
fix: add missing CLOEXEC flag

### DIFF
--- a/ioctl_linux.go
+++ b/ioctl_linux.go
@@ -86,5 +86,5 @@ func newIocltStringSetReq(linkName string) (*Ifreq, *ethtoolSset) {
 // getSocketUDP returns file descriptor to new UDP socket
 // It is used for communication with ioctl interface.
 func getSocketUDP() (int, error) {
-	return syscall.Socket(unix.AF_INET, unix.SOCK_DGRAM, 0)
+	return syscall.Socket(unix.AF_INET, unix.SOCK_DGRAM|unix.SOCK_CLOEXEC, 0)
 }

--- a/nl/nl_linux.go
+++ b/nl/nl_linux.go
@@ -789,7 +789,7 @@ func executeInNetns(newNs, curNs netns.NsHandle) (func(), error) {
 // Returns the netlink socket on which Receive() method can be called
 // to retrieve the messages from the kernel.
 func Subscribe(protocol int, groups ...uint) (*NetlinkSocket, error) {
-	fd, err := unix.Socket(unix.AF_NETLINK, unix.SOCK_RAW, protocol)
+	fd, err := unix.Socket(unix.AF_NETLINK, unix.SOCK_RAW|unix.SOCK_CLOEXEC, protocol)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Some calls were already using it, some were not, but fix the remaining ones.

Without this flag, the file descriptor would to the child process after fork/exec.