### PR TITLE
Ci bump

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,9 @@ jobs:
       run: ./.github/scripts/modprobe.sh
       shell: bash
 
+    - name: Build
+      run: go build ./...
+
     - name: Test
       run: sudo -E env PATH=$PATH go test -v ./ ./nl
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,11 @@ on:
 jobs:
 
   build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04, ubuntu-24.04]
+        go-version: [1.17.x, 1.22.x, 1.23.x]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -16,7 +21,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.17
+        go-version: ${{ matrix.go-version }}
 
     - name: Kernel Modules
       run: ./.github/scripts/modprobe.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,10 +11,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: 1.17
 
@@ -30,13 +30,13 @@ jobs:
     # on macOS, which helps catch missing build tags.
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: 1.17
-          
+
     - name: Build
       run: go build ./...
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       run: go build ./...
 
     - name: Test
-      run: sudo -E env PATH=$PATH go test -v ./ ./nl
+      run: go test -exec 'sudo --preserve-env=CI,PATH -n' -v ./ ./nl
 
   build-macos:
     # netlink is Linux-only, but this ensures that netlink builds without error


### PR DESCRIPTION
Please see individual commit messages for details. High level overview:
 - bump github actions to latest versions
 - add build step to ensure everything is buildable
 - use `go test -exec sudo` to speed up test running
 - ci/gha: test on different Go and Ubuntu versions