### PR TITLE
Fix parsing 4-bytes attribute

### DIFF
--- a/nl/parse_attr_linux.go
+++ b/nl/parse_attr_linux.go
@@ -17,7 +17,7 @@ func ParseAttributes(data []byte) <-chan Attribute {
 
 	go func() {
 		i := 0
-		for i+4 < len(data) {
+		for i+4 <= len(data) {
 			length := int(native.Uint16(data[i : i+2]))
 			attrType := native.Uint16(data[i+2 : i+4])
 


### PR DESCRIPTION
What if the data length of attribute is 4? The attribute will be ignored, because `i+4 < len(data)`.