### PR TITLE
disable broadcast if broadcast is set to net.IPv4zero

### DIFF
--- a/addr_linux.go
+++ b/addr_linux.go
@@ -18,6 +18,7 @@ import (
 //
 // If `addr` is an IPv4 address and the broadcast address is not given, it
 // will be automatically computed based on the IP mask if /30 or larger.
+// If `net.IPv4zero` is given as the broadcast address, broadcast is disabled.
 func AddrAdd(link Link, addr *Addr) error {
 	return pkgHandle.AddrAdd(link, addr)
 }
@@ -28,6 +29,7 @@ func AddrAdd(link Link, addr *Addr) error {
 //
 // If `addr` is an IPv4 address and the broadcast address is not given, it
 // will be automatically computed based on the IP mask if /30 or larger.
+// If `net.IPv4zero` is given as the broadcast address, broadcast is disabled.
 func (h *Handle) AddrAdd(link Link, addr *Addr) error {
 	req := h.newNetlinkRequest(unix.RTM_NEWADDR, unix.NLM_F_CREATE|unix.NLM_F_EXCL|unix.NLM_F_ACK)
 	return h.addrHandle(link, addr, req)
@@ -39,6 +41,7 @@ func (h *Handle) AddrAdd(link Link, addr *Addr) error {
 //
 // If `addr` is an IPv4 address and the broadcast address is not given, it
 // will be automatically computed based on the IP mask if /30 or larger.
+// If `net.IPv4zero` is given as the broadcast address, broadcast is disabled.
 func AddrReplace(link Link, addr *Addr) error {
 	return pkgHandle.AddrReplace(link, addr)
 }
@@ -49,6 +52,7 @@ func AddrReplace(link Link, addr *Addr) error {
 //
 // If `addr` is an IPv4 address and the broadcast address is not given, it
 // will be automatically computed based on the IP mask if /30 or larger.
+// If `net.IPv4zero` is given as the broadcast address, broadcast is disabled.
 func (h *Handle) AddrReplace(link Link, addr *Addr) error {
 	req := h.newNetlinkRequest(unix.RTM_NEWADDR, unix.NLM_F_CREATE|unix.NLM_F_REPLACE|unix.NLM_F_ACK)
 	return h.addrHandle(link, addr, req)
@@ -57,18 +61,13 @@ func (h *Handle) AddrReplace(link Link, addr *Addr) error {
 // AddrDel will delete an IP address from a link device.
 //
 // Equivalent to: `ip addr del $addr dev $link`
-//
-// If `addr` is an IPv4 address and the broadcast address is not given, it
-// will be automatically computed based on the IP mask if /30 or larger.
 func AddrDel(link Link, addr *Addr) error {
 	return pkgHandle.AddrDel(link, addr)
 }
 
 // AddrDel will delete an IP address from a link device.
-// Equivalent to: `ip addr del $addr dev $link`
 //
-// If `addr` is an IPv4 address and the broadcast address is not given, it
-// will be automatically computed based on the IP mask if /30 or larger.
+// Equivalent to: `ip addr del $addr dev $link`
 func (h *Handle) AddrDel(link Link, addr *Addr) error {
 	req := h.newNetlinkRequest(unix.RTM_DELADDR, unix.NLM_F_ACK)
 	return h.addrHandle(link, addr, req)
@@ -140,6 +139,10 @@ func (h *Handle) addrHandle(link Link, addr *Addr, req *nl.NetlinkRequest) error
 				calcBroadcast[i] = localAddrData[i] | ^mask[i]
 			}
 			addr.Broadcast = calcBroadcast
+		}
+
+		if net.IPv4zero.Equal(addr.Broadcast) {
+			addr.Broadcast = nil
 		}
 
 		if addr.Broadcast != nil {


### PR DESCRIPTION
Another go at fixing [329](https://github.com/vishvananda/netlink/issues/329).

According to [comment](https://github.com/vishvananda/netlink/issues/329#issuecomment-373133170), broadcast address auto-calculation is now a feature, and there is no intention to revert that. However, sometimes users do not want broadcast to be enabled.

Currently this can be done by setting `Broadcast` to `net.IPv4zero`. But that's not a public api of the netlink. And in my test, it will cause an error to be generated in the kernel log like `attribute type 4 has an invalid length.`.

I think we can use this as a special value to disable broadcast since it already works. But now we explicitly set it to nil when interacting with netlink.

This is an alternative to introducing a new function or extending the `Addr` struct.