### PR TITLE
link_linux: Add deserialization of `IFF_RUNNING` flag

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -3041,7 +3041,6 @@ func parseMacvlanData(link Link, data []syscall.NetlinkRouteAttr) {
 	}
 }
 
-// copied from pkg/net_linux.go
 func linkFlags(rawFlags uint32) net.Flags {
 	var f net.Flags
 	if rawFlags&unix.IFF_UP != 0 {
@@ -3058,6 +3057,9 @@ func linkFlags(rawFlags uint32) net.Flags {
 	}
 	if rawFlags&unix.IFF_MULTICAST != 0 {
 		f |= net.FlagMulticast
+	}
+	if rawFlags&unix.IFF_RUNNING != 0 {
+		f |= net.FlagRunning
 	}
 	return f
 }


### PR DESCRIPTION
I noticed that the decoded link flags never include `net.FlagRunning`. It seems deserialization logic was never added for this particular flag. Having access to the running flag is actually useful to detect when a link is in a NO-CARRIER state, which happens when a layer 1 issue occurs such as an unplugged or broken cable.

I also removed the comment since the function now deviates from the original.