### PR TITLE
Add support for ARP/ND Timestamps when retriving neighbors

### DIFF
--- a/neigh.go
+++ b/neigh.go
@@ -19,6 +19,14 @@ type Neigh struct {
 	Vlan         int
 	VNI          int
 	MasterIndex  int
+
+	// These values are expressed as "clock ticks ago".  To
+	// convert these clock ticks to seconds divide by sysconf(_SC_CLK_TCK).
+	// When _SC_CLK_TCK is 100, for example, the ndm_* times are expressed
+	// in centiseconds.
+	Confirmed uint32 // The last time ARP/ND succeeded OR higher layer confirmation was received
+	Used      uint32 // The last time ARP/ND took place for this neighbor
+	Updated   uint32 // The time when the current NUD state was entered
 }
 
 // String returns $ip/$hwaddr $label

--- a/neigh_linux.go
+++ b/neigh_linux.go
@@ -349,6 +349,10 @@ func NeighDeserialize(m []byte) (*Neigh, error) {
 			neigh.VNI = int(native.Uint32(attr.Value[0:4]))
 		case NDA_MASTER:
 			neigh.MasterIndex = int(native.Uint32(attr.Value[0:4]))
+		case NDA_CACHEINFO:
+			neigh.Confirmed = native.Uint32(attr.Value[0:4])
+			neigh.Used = native.Uint32(attr.Value[4:8])
+			neigh.Updated = native.Uint32(attr.Value[8:12])
 		}
 	}
 


### PR DESCRIPTION
On Linux, Netlink provides NDA_CACHEINFO which carries timestamps about when ARP/ND was updated, used, and confirmed.

``` 
struct nda_cacheinfo {
    __u32         ndm_confirmed;
    __u32         ndm_used;
    __u32         ndm_updated;
    __u32         ndm_refcnt;
};
```

Expose these fields in the Neigh type