### PR TITLE
Add support for XFRMA_SA_DIR and XFRMA_SA_PCPU attributes for XFRM

### DIFF
--- a/nl/xfrm_linux.go
+++ b/nl/xfrm_linux.go
@@ -78,10 +78,14 @@ const (
 	XFRMA_PROTO          /* __u8 */
 	XFRMA_ADDRESS_FILTER /* struct xfrm_address_filter */
 	XFRMA_PAD
-	XFRMA_OFFLOAD_DEV   /* struct xfrm_state_offload */
-	XFRMA_SET_MARK      /* __u32 */
-	XFRMA_SET_MARK_MASK /* __u32 */
-	XFRMA_IF_ID         /* __u32 */
+	XFRMA_OFFLOAD_DEV            /* struct xfrm_state_offload */
+	XFRMA_SET_MARK               /* __u32 */
+	XFRMA_SET_MARK_MASK          /* __u32 */
+	XFRMA_IF_ID                  /* __u32 */
+	XFRMA_MTIMER_THRESH          /* __u32 in seconds for input SA */
+	XFRMA_SA_DIR                 /* __u8 */
+	XFRMA_NAT_KEEPALIVE_INTERVAL /* __u32 in seconds for NAT keepalive */
+	XFRMA_SA_PCPU                /* __u32 */
 
 	XFRMA_MAX = iota - 1
 )

--- a/xfrm_linux.go
+++ b/xfrm_linux.go
@@ -48,6 +48,14 @@ const (
 	XFRM_MODE_MAX
 )
 
+// SADir is an enum representing an ipsec template direction.
+type SADir uint8
+
+const (
+	XFRM_SA_DIR_IN SADir = iota + 1
+	XFRM_SA_DIR_OUT
+)
+
 func (m Mode) String() string {
 	switch m {
 	case XFRM_MODE_TRANSPORT:

--- a/xfrm_state_linux_test.go
+++ b/xfrm_state_linux_test.go
@@ -225,6 +225,72 @@ func TestXfrmStateWithIfid(t *testing.T) {
 	}
 }
 
+func TestXfrmStateWithSADir(t *testing.T) {
+	minKernelRequired(t, 4, 19)
+	defer setUpNetlinkTest(t)()
+
+	state := getBaseState()
+	state.SADir = XFRM_SA_DIR_IN
+	if err := XfrmStateAdd(state); err != nil {
+		t.Fatal(err)
+	}
+	s, err := XfrmStateGet(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !compareStates(state, s) {
+		t.Fatalf("unexpected state returned.\nExpected: %v.\nGot %v", state, s)
+	}
+	if err = XfrmStateDel(s); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestXfrmStateWithPcpunumWithoutSADir(t *testing.T) {
+	minKernelRequired(t, 4, 19)
+	defer setUpNetlinkTest(t)()
+
+	state := getBaseState()
+	pcpuNum := uint32(1)
+	state.Pcpunum = &pcpuNum
+	if err := XfrmStateAdd(state); err != nil {
+		t.Fatal(err)
+	}
+	s, err := XfrmStateGet(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !compareStates(state, s) {
+		t.Fatalf("unexpected state returned.\nExpected: %v.\nGot %v", state, s)
+	}
+	if err = XfrmStateDel(s); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestXfrmStateWithPcpunumWithSADir(t *testing.T) {
+	minKernelRequired(t, 4, 19)
+	defer setUpNetlinkTest(t)()
+
+	state := getBaseState()
+	state.SADir = XFRM_SA_DIR_IN
+	pcpuNum := uint32(1)
+	state.Pcpunum = &pcpuNum
+	if err := XfrmStateAdd(state); err != nil {
+		t.Fatal(err)
+	}
+	s, err := XfrmStateGet(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !compareStates(state, s) {
+		t.Fatalf("unexpected state returned.\nExpected: %v.\nGot %v", state, s)
+	}
+	if err = XfrmStateDel(s); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestXfrmStateWithOutputMark(t *testing.T) {
 	minKernelRequired(t, 4, 14)
 	defer setUpNetlinkTest(t)()


### PR DESCRIPTION
Adding support for two new XFRM attributes: Security Association (SA) direction and per-CPU selector for XFRM state. These features are based on recent kernel patches that introduce the ability to specify SA direction explicitly and allow XFRM states to be pinned to a specific CPU, enhancing performance and traffic handling for IPsec policies.

Kernel Patch References:
- [Patchwork: fa1ec47b31ab6e969b5f92cd6f1ef71a3da78710](https://patchwork.kernel.org/project/netdevbpf/patch/fa1ec47b31ab6e969b5f92cd6f1ef71a3da78710/)
- [Kernel.org: 1ddf9916ac09313128e40d6581cef889c0b4ce84](https://git.kernel.org/pub/scm/linux/kernel/git/klassert/ipsec-next.git/commit/?id=1ddf9916ac09313128e40d6581cef889c0b4ce84)

