### PR TITLE
.github/workflows: Bump CI Go version to v1.22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.22
 
     - name: Kernel Modules
       run: ./.github/scripts/modprobe.sh
@@ -35,7 +35,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.22
           
     - name: Build
       run: go build ./...


### PR DESCRIPTION
Update the Go version we test against to Go v1.22 which is currently the oldest version still receiving security updates. This PR is in preparation for #1038