### PR TITLE
Add IFLA_PARENT_DEV_NAME / IFLA_PARENT_DEV_BUS_NAME to links

### DIFF
--- a/link.go
+++ b/link.go
@@ -56,6 +56,8 @@ type LinkAttrs struct {
 	Vfs            []VfInfo // virtual functions available on link
 	Group          uint32
 	PermHWAddr     net.HardwareAddr
+	ParentDev      string
+	ParentDevBus   string
 	Slave          LinkSlave
 }
 

--- a/link_linux.go
+++ b/link_linux.go
@@ -2263,6 +2263,10 @@ func LinkDeserialize(hdr *unix.NlMsghdr, m []byte) (Link, error) {
 					break
 				}
 			}
+		case unix.IFLA_PARENT_DEV_NAME:
+			base.ParentDev = string(attr.Value[:len(attr.Value)-1])
+		case unix.IFLA_PARENT_DEV_BUS_NAME:
+			base.ParentDevBus = string(attr.Value[:len(attr.Value)-1])
 		}
 	}
 


### PR DESCRIPTION
These attributes are supported since kernel v5.14 (see [1]). Here's what iproute2 shows:

```
$ ip -d link show eth0
4: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 65535 qdisc pfifo_fast state UP mode DEFAULT group default qlen 1000
    ... parentbus virtio parentdev virtio0
```

[1]: https://github.com/torvalds/linux/commit/00e77ed8e64d5f271c1f015c7153545980d48a76