### PR TITLE
go.mod: bump to Go 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vishvananda/netlink
 
-go 1.12
+go 1.20
 
 require (
 	github.com/vishvananda/netns v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,4 @@
 github.com/vishvananda/netns v0.0.4 h1:Oeaw1EM2JMxD51g9uhtC0D7erkIjgmj8+JZc26m1YX8=
 github.com/vishvananda/netns v0.0.4/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
-golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
 golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
PR https://github.com/vishvananda/netlink/pull/1038 started using `net.FlagRunning` which was introduced in Go 1.20, see https://go.dev/doc/go1.20#netpkgnet. Bump the minimum required Go version in `go.mod` accordingly and run `go mod tidy`.