### PR TITLE
Add `OifIndex` option for `RouteGetWithOptions`

### DIFF
--- a/route_linux.go
+++ b/route_linux.go
@@ -1533,6 +1533,7 @@ type RouteGetOptions struct {
 	Iif      string
 	IifIndex int
 	Oif      string
+	OifIndex int
 	VrfName  string
 	SrcAddr  net.IP
 	UID      *uint32
@@ -1612,14 +1613,20 @@ func (h *Handle) RouteGetWithOptions(destination net.IP, options *RouteGetOption
 			req.AddData(nl.NewRtAttr(unix.RTA_IIF, b))
 		}
 
+		oifIndex := uint32(0)
 		if len(options.Oif) > 0 {
 			link, err := h.LinkByName(options.Oif)
 			if err != nil {
 				return nil, err
 			}
+			oifIndex = uint32(link.Attrs().Index)
+		} else if options.OifIndex > 0 {
+			oifIndex = uint32(options.OifIndex)
+		}
 
+		if oifIndex > 0 {
 			b := make([]byte, 4)
-			native.PutUint32(b, uint32(link.Attrs().Index))
+			native.PutUint32(b, oifIndex)
 
 			req.AddData(nl.NewRtAttr(unix.RTA_OIF, b))
 		}

--- a/route_test.go
+++ b/route_test.go
@@ -1436,6 +1436,16 @@ func TestRouteOifOption(t *testing.T) {
 		t.Fatal("Get route from unmatched interface")
 	}
 
+	// check getting route from specified Oifindex
+	routes, err = RouteGetWithOptions(dstIP, &RouteGetOptions{OifIndex: link1.Attrs().Index})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(routes) != 1 || routes[0].LinkIndex != link1.Attrs().Index ||
+		!routes[0].Gw.Equal(gw1) {
+		t.Fatal("Get route from unmatched interface")
+	}
+
 	routes, err = RouteGetWithOptions(dstIP, &RouteGetOptions{Oif: "eth1"})
 	if err != nil {
 		t.Fatal(err)
@@ -1446,6 +1456,14 @@ func TestRouteOifOption(t *testing.T) {
 		t.Fatal("Get route from unmatched interface")
 	}
 
+	routes, err = RouteGetWithOptions(dstIP, &RouteGetOptions{OifIndex: link2.Attrs().Index})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(routes) != 1 || routes[0].LinkIndex != link2.Attrs().Index ||
+		!routes[0].Gw.Equal(gw2) {
+		t.Fatal("Get route from unmatched interface")
+	}
 }
 
 func TestFilterDefaultRoute(t *testing.T) {


### PR DESCRIPTION
The `RouteGetWithOptions` function currently has a `Oif` option which gets translated from link name to link index via a `LinkByName` call. This adds unnecessary overhead when the link index is already known.

This commit adds a new `OifIndex` option to `RouteGetWithOptions` which can be specified instead of `Oif` to skip the internal link index translation.