### PR TITLE
fix: Use correct offset for unix socket diagnosis

### DIFF
--- a/socket_linux.go
+++ b/socket_linux.go
@@ -500,7 +500,7 @@ func (h *Handle) UnixSocketDiagInfo() ([]*UnixDiagInfoResp, error) {
 
 		var attrs []syscall.NetlinkRouteAttr
 		var err error
-		if attrs, err = nl.ParseRouteAttr(msg[sizeofSocket:]); err != nil {
+		if attrs, err = nl.ParseRouteAttr(msg[sizeofUnixSocket:]); err != nil {
 			return false
 		}
 


### PR DESCRIPTION
When parsing diagnosis information of Unix sockets the current code uses the wrong offset (`sizeofSocket`) for determining the start of the attached parameters.

As a result, returned attributes might be scrambled or missing. More severely, the code might **panic** if no or only a small number of attributes are available as e.g. in https://github.com/influxdata/telegraf/issues/16527

This PR uses the correct `sizeofUnixSocket` offset to fix the issue.