### PR TITLE
vxlan: Fix parseVxlanData for source port range

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -2821,7 +2821,7 @@ func parseVxlanData(link Link, data []syscall.NetlinkRouteAttr) {
 		case nl.IFLA_VXLAN_PORT_RANGE:
 			buf := bytes.NewBuffer(datum.Value[0:4])
 			var pr vxlanPortRange
-			if binary.Read(buf, binary.BigEndian, &pr) != nil {
+			if binary.Read(buf, binary.BigEndian, &pr) == nil {
 				vxlan.PortLow = int(pr.Lo)
 				vxlan.PortHigh = int(pr.Hi)
 			}


### PR DESCRIPTION
binary.Read() != nil check means error case, so the vxlan.Port{Low,High} are never populated. Fix the check.