### PR TITLE
pedit: Fix EncodeActions to add TcGen for pedit action

### DIFF
--- a/filter_linux.go
+++ b/filter_linux.go
@@ -752,6 +752,7 @@ func EncodeActions(attr *nl.RtAttr, actions []Action) error {
 			table := attr.AddRtAttr(tabIndex, nil)
 			tabIndex++
 			pedit := nl.TcPedit{}
+			toTcGen(action.Attrs(), &pedit.Sel.TcGen)
 			if action.SrcMacAddr != nil {
 				pedit.SetEthSrc(action.SrcMacAddr)
 			}


### PR DESCRIPTION
TcGen was missing in pedit so kernel uses pass action by default.

Adding TcGen so pipe action is used, packet will be sent to other actions after pedit
