### PR TITLE
veth: allow configuring peer attributes beyond namespace and address

### DIFF
--- a/link.go
+++ b/link.go
@@ -426,6 +426,17 @@ type Veth struct {
 	PeerName         string // veth on create only
 	PeerHardwareAddr net.HardwareAddr
 	PeerNamespace    interface{}
+	PeerTxQLen       int
+	PeerNumTxQueues  uint32
+	PeerNumRxQueues  uint32
+	PeerMTU          uint32
+}
+
+func NewVeth(attr LinkAttrs) *Veth {
+	return &Veth{
+		LinkAttrs:  attr,
+		PeerTxQLen: -1,
+	}
 }
 
 func (veth *Veth) Attrs() *LinkAttrs {

--- a/link_linux.go
+++ b/link_linux.go
@@ -1696,16 +1696,25 @@ func (h *Handle) linkModify(link Link, flags int) error {
 		peer := data.AddRtAttr(nl.VETH_INFO_PEER, nil)
 		nl.NewIfInfomsgChild(peer, unix.AF_UNSPEC)
 		peer.AddRtAttr(unix.IFLA_IFNAME, nl.ZeroTerminated(link.PeerName))
-		if base.TxQLen >= 0 {
+
+		if link.PeerTxQLen >= 0 {
+			peer.AddRtAttr(unix.IFLA_TXQLEN, nl.Uint32Attr(uint32(link.PeerTxQLen)))
+		} else if base.TxQLen >= 0 {
 			peer.AddRtAttr(unix.IFLA_TXQLEN, nl.Uint32Attr(uint32(base.TxQLen)))
 		}
-		if base.NumTxQueues > 0 {
+		if link.PeerNumTxQueues > 0 {
+			peer.AddRtAttr(unix.IFLA_NUM_TX_QUEUES, nl.Uint32Attr(link.PeerNumTxQueues))
+		} else if base.NumTxQueues > 0 {
 			peer.AddRtAttr(unix.IFLA_NUM_TX_QUEUES, nl.Uint32Attr(uint32(base.NumTxQueues)))
 		}
-		if base.NumRxQueues > 0 {
+		if link.PeerNumRxQueues > 0 {
+			peer.AddRtAttr(unix.IFLA_NUM_RX_QUEUES, nl.Uint32Attr(link.PeerNumRxQueues))
+		} else if base.NumRxQueues > 0 {
 			peer.AddRtAttr(unix.IFLA_NUM_RX_QUEUES, nl.Uint32Attr(uint32(base.NumRxQueues)))
 		}
-		if base.MTU > 0 {
+		if link.PeerMTU > 0 {
+			peer.AddRtAttr(unix.IFLA_MTU, nl.Uint32Attr(link.PeerMTU))
+		} else if base.MTU > 0 {
 			peer.AddRtAttr(unix.IFLA_MTU, nl.Uint32Attr(uint32(base.MTU)))
 		}
 		if link.PeerHardwareAddr != nil {


### PR DESCRIPTION
I added a `NewVeth` function as well to initialize the `PeerTxQLen` to `-1`.