### PR TITLE
Fix bug in modify U32 filter, correct the number of Keys in Sel

### DIFF
--- a/filter_linux.go
+++ b/filter_linux.go
@@ -349,7 +349,7 @@ func (h *Handle) filterModify(filter Filter, proto, flags int) error {
 		if native != networkOrder {
 			// Copy TcU32Sel.
 			cSel := *sel
-			keys := make([]nl.TcU32Key, cap(sel.Keys))
+			keys := make([]nl.TcU32Key, len(sel.Keys))
 			copy(keys, sel.Keys)
 			cSel.Keys = keys
 			sel = &cSel


### PR DESCRIPTION
When `func (h *Handle) filterModify(...)` handles an `U32` filter, it also corrects the endiannes for the `Mask` and `Val` in the filter's `Sel.Keys`. For this it creates a new Keys slice and copies the values from the old one. This new slice is created with an incorrect size, likely the intention was to specify its capacity, but instead the size is specified.

This is reported in and fixes https://github.com/vishvananda/netlink/issues/1089

The old code happens to work correctly in practice when the number of keys is a power of 2. Otherwise empty (match all) keys are added to the end to make the number a power of 2.

This commit fixes the issue. It was well tested, here's an excerpt:

- Create a U32 filter with 5 Keys. The content of keys is irrelevant, only the number matters.
- Print the filter back with `tc filter show ...`.

The old behaviour:

```
filter parent ffff: protocol all pref 49150 u32 chain 0 fh 800::601 order 1537 key ht 800 bkt 0 *flowid :1 not_in_hw 
  match 40000000/60000000 at 0
  match 07010723/ffffffff at 24
  match 07450767/ffffffff at 28
  match 07890733/ffffffff at 32
  match 07420801/ffe00000 at 36
  match 00000000/00000000 at 0 
  match 00000000/00000000 at 0
  match 00000000/00000000 at 0
```
The last 3 entries were added by netlink.

New behaviour:
```
filter parent ffff: protocol all pref 49150 u32 chain 0 fh 800::801 order 2049 key ht 800 bkt 0 flowid :1 not_in_hw 
  match 60000000/f0000000 at 0
  match 07010723/ffffffff at 24
  match 07450767/ffffffff at 28
  match 07890733/ffffffff at 32
  match 07400000/ffe00000 at 36
```

There're 2 ways to copy a slice in go and the error landed exactly in between.