### PR TITLE
Implement the Temporary() method on errDumpInterrupted

### DIFF
--- a/nl/nl_linux.go
+++ b/nl/nl_linux.go
@@ -58,6 +58,8 @@ func (errDumpInterrupted) Error() string {
 	return "results may be incomplete or inconsistent"
 }
 
+func (errDumpInterrupted) Temporary() bool { return true }
+
 // Before errDumpInterrupted was introduced, EINTR was returned when a netlink
 // response had NLM_F_DUMP_INTR. Retain backward compatibility with code that
 // may be checking for EINTR using Is.


### PR DESCRIPTION
Implement the Temporary() method on errDumpInterrupted as per this issue

https://github.com/vishvananda/netlink/issues/1086

This is minimal, non-breaking, and preserves compatibility with older retry detection patterns.