### PR TITLE
Read rule type and l3mdev flag

### DIFF
--- a/rule.go
+++ b/rule.go
@@ -29,6 +29,7 @@ type Rule struct {
 	UIDRange          *RuleUIDRange
 	Protocol          uint8
 	Type              uint8
+	L3mdev            uint8
 }
 
 func (r Rule) Equal(x Rule) bool {
@@ -43,7 +44,8 @@ func (r Rule) Equal(x Rule) bool {
 		r.IifName == x.IifName &&
 		r.Invert == x.Invert &&
 		r.Tos == x.Tos &&
-		r.Type == x.Type &&
+		(r.Type == x.Type ||
+			(r.Type == 0 && x.Type == 1 || r.Type == 1 && x.Type == 0)) && // 1 is unix.RTN_UNICAST
 		r.IPProto == x.IPProto &&
 		r.Protocol == x.Protocol &&
 		r.Mark == x.Mark &&
@@ -59,7 +61,8 @@ func (r Rule) Equal(x Rule) bool {
 		r.SuppressPrefixlen == x.SuppressPrefixlen &&
 		(r.Dport == x.Dport || (r.Dport != nil && x.Dport != nil && r.Dport.Equal(*x.Dport))) &&
 		(r.Sport == x.Sport || (r.Sport != nil && x.Sport != nil && r.Sport.Equal(*x.Sport))) &&
-		(r.UIDRange == x.UIDRange || (r.UIDRange != nil && x.UIDRange != nil && r.UIDRange.Equal(*x.UIDRange)))
+		(r.UIDRange == x.UIDRange || (r.UIDRange != nil && x.UIDRange != nil && r.UIDRange.Equal(*x.UIDRange))) &&
+		r.L3mdev == x.L3mdev
 }
 
 func ptrEqual(a, b *uint32) bool {

--- a/rule_linux.go
+++ b/rule_linux.go
@@ -178,6 +178,10 @@ func ruleHandle(rule *Rule, req *nl.NetlinkRequest) error {
 		req.AddData(nl.NewRtAttr(nl.FRA_PROTOCOL, nl.Uint8Attr(rule.Protocol)))
 	}
 
+	if rule.L3mdev > 0 {
+		req.AddData(nl.NewRtAttr(nl.FRA_L3MDEV, nl.Uint8Attr(rule.L3mdev)))
+	}
+
 	_, err := req.Execute(unix.NETLINK_ROUTE, 0)
 	return err
 }
@@ -239,6 +243,7 @@ func (h *Handle) RuleListFiltered(family int, filter *Rule, filterMask uint64) (
 		rule.Invert = msg.Flags&FibRuleInvert > 0
 		rule.Family = int(msg.Family)
 		rule.Tos = uint(msg.Tos)
+		rule.Type = msg.Type
 
 		for j := range attrs {
 			switch attrs[j].Attr.Type {
@@ -291,6 +296,8 @@ func (h *Handle) RuleListFiltered(family int, filter *Rule, filterMask uint64) (
 				rule.UIDRange = NewRuleUIDRange(native.Uint32(attrs[j].Value[0:4]), native.Uint32(attrs[j].Value[4:8]))
 			case nl.FRA_PROTOCOL:
 				rule.Protocol = uint8(attrs[j].Value[0])
+			case nl.FRA_L3MDEV:
+				rule.L3mdev = uint8(attrs[j].Value[0])
 			}
 		}
 

--- a/rule_test.go
+++ b/rule_test.go
@@ -55,7 +55,7 @@ func TestRuleAddDel(t *testing.T) {
 	// find this rule
 	found := ruleExists(rules, *rule)
 	if !found {
-		t.Fatal("Rule has diffrent options than one added")
+		t.Fatal("Rule has different options than one added")
 	}
 
 	if err := RuleDel(rule); err != nil {
@@ -699,6 +699,7 @@ func TestRuleEqual(t *testing.T) {
 		{UIDRange: &RuleUIDRange{Start: 3, End: 5}},
 		{Protocol: FAMILY_V6},
 		{Type: unix.RTN_UNREACHABLE},
+		{L3mdev: 1},
 	}
 	for i1 := range cases {
 		for i2 := range cases {
@@ -711,6 +712,14 @@ func TestRuleEqual(t *testing.T) {
 					strconv.FormatBool(expected))
 			}
 		}
+	}
+}
+
+func TestRuleEqualTypeUnspecifiedEqualsUnicast(t *testing.T) {
+	a := Rule{Type: unix.RTN_UNSPEC}
+	b := Rule{Type: unix.RTN_UNICAST}
+	if !a.Equal(b) || !b.Equal(a) {
+		t.Errorf("Rules are expected to be equal")
 	}
 }
 


### PR DESCRIPTION
When reading rules, makes sure to populate the type field of `Rule`.
Also adds a l3mdev flag to `Rule`, reads it and makes sure it is taken into account when comparing rules using `Equal` as introduced in https://github.com/vishvananda/netlink/pull/1095.

This fixes https://github.com/vishvananda/netlink/issues/1055