### PR TITLE
Add support for IFLA_MIN_MTU and IFLA_MAX_MTU in LinkAttrs

### DIFF
--- a/link.go
+++ b/link.go
@@ -24,6 +24,8 @@ type (
 type LinkAttrs struct {
 	Index          int
 	MTU            int
+	MinMTU         int
+	MaxMTU         int
 	TxQLen         int // Transmit Queue Length
 	Name           string
 	HardwareAddr   net.HardwareAddr

--- a/link_linux.go
+++ b/link_linux.go
@@ -2248,6 +2248,10 @@ func LinkDeserialize(hdr *unix.NlMsghdr, m []byte) (Link, error) {
 			base.Name = string(attr.Value[:len(attr.Value)-1])
 		case unix.IFLA_MTU:
 			base.MTU = int(native.Uint32(attr.Value[0:4]))
+		case unix.IFLA_MIN_MTU:
+			base.MinMTU = int(native.Uint32(attr.Value[0:4]))
+		case unix.IFLA_MAX_MTU:
+			base.MaxMTU = int(native.Uint32(attr.Value[0:4]))
 		case unix.IFLA_PROMISCUITY:
 			base.Promisc = int(native.Uint32(attr.Value[0:4]))
 		case unix.IFLA_LINK:

--- a/link_test.go
+++ b/link_test.go
@@ -707,6 +707,57 @@ func compareBareUDP(t *testing.T, expected, actual *BareUDP) {
 	}
 }
 
+func TestLinkDeserializeMTULimits(t *testing.T) {
+	const (
+		mtu    uint32 = 1500
+		minMTU uint32 = 68
+		maxMTU uint32 = 9000
+	)
+
+	msg := nl.NewIfInfomsg(unix.AF_UNSPEC)
+	msg.Index = 42
+
+	raw := append([]byte{}, msg.Serialize()...)
+	raw = append(raw,
+		nl.NewRtAttr(unix.IFLA_IFNAME,
+			nl.ZeroTerminated("foo")).Serialize()...)
+	raw = append(raw,
+		nl.NewRtAttr(unix.IFLA_MTU,
+			nl.Uint32Attr(mtu)).Serialize()...)
+	raw = append(raw,
+		nl.NewRtAttr(unix.IFLA_MIN_MTU,
+			nl.Uint32Attr(minMTU)).Serialize()...)
+	raw = append(raw,
+		nl.NewRtAttr(unix.IFLA_MAX_MTU,
+			nl.Uint32Attr(maxMTU)).Serialize()...)
+
+	link, err := LinkDeserialize(nil, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if link == nil {
+		t.Fatal("link is nil")
+	}
+
+	attrs := link.Attrs()
+
+	if attrs.MTU != int(mtu) {
+		t.Fatalf("unexpected MTU: got=%d want=%d",
+			attrs.MTU, mtu)
+	}
+
+	if attrs.MinMTU != int(minMTU) {
+		t.Fatalf("unexpected MinMTU: got=%d want=%d",
+			attrs.MinMTU, minMTU)
+	}
+
+	if attrs.MaxMTU != int(maxMTU) {
+		t.Fatalf("unexpected MaxMTU: got=%d want=%d",
+			attrs.MaxMTU, maxMTU)
+	}
+}
+
 func TestLinkAddDelWithIndex(t *testing.T) {
 	tearDown := setUpNetlinkTest(t)
 	defer tearDown()


### PR DESCRIPTION
Added attributes 	MinMTU, MaxMTU to LinkAttrs struct
Added cases for IFLA_MIN_MTU, IFLA_MAX_MTU
Signed-off-by: Aleksey Mamedov <alekseymamedoff@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Network links now expose minimum and maximum transmission unit (MTU) bounds, enabling applications to query supported MTU ranges for network interfaces.

* **Tests**
  * Added comprehensive test coverage for MTU limit parsing and deserialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vishvananda/netlink/pull/1102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->