### PR TITLE
fix: Allow TCA_OPTIONS with NLA_F_NESTED and NLA_F_NET_BYTEORDER flag

### DIFF
--- a/filter_linux.go
+++ b/filter_linux.go
@@ -505,7 +505,8 @@ func (h *Handle) FilterList(link Link, parent uint32) ([]Filter, error) {
 		filterType := ""
 		detailed := false
 		for _, attr := range attrs {
-			switch attr.Attr.Type {
+			attrType := attr.Attr.Type & nl.NLA_TYPE_MASK
+			switch attrType {
 			case nl.TCA_KIND:
 				filterType = string(attr.Value[:len(attr.Value)-1])
 				switch filterType {


### PR DESCRIPTION
Fixes #1104

# What ?
- And TC Filter's Attribute type with NLA_MASK to remove topmost bits that are not for actual type value

See https://github.com/iproute2/iproute2/blob/ede5e0b67c13d6d8fb51891d7d4be330733862cd/include/uapi/linux/netlink.h#L242

```c
/*
 * nla_type (16 bits)
 * +---+---+-------------------------------+
 * | N | O | Attribute Type                |
 * +---+---+-------------------------------+
 * N := Carries nested attributes
 * O := Payload stored in network byte order
 *
 * Note: The N and O flag are mutually exclusive.
 */
#define NLA_F_NESTED		(1 << 15)
#define NLA_F_NET_BYTEORDER	(1 << 14)
#define NLA_TYPE_MASK		~(NLA_F_NESTED | NLA_F_NET_BYTEORDER)
``` 

# Why ?
- https://github.com/vishvananda/netlink/issues/1104#issuecomment-3089858371



# How do you know it works ?

Example code
```
func listTCFilters(ifaceName string, verbose bool) error {
	// fmt.Println("listTCFilters() ifaceName : ", ifaceName)
	link, err := netlink.LinkByName(ifaceName)
	if err != nil {
		fmt.Printf("Failed to get link by name: %v\n", err)
		return err
	}
	if verbose {
		fmt.Printf("Got link : %v\n", link)
	}
	handle := netlink.MakeHandle(1, 0)
	filters, err := netlink.FilterList(link, handle)
	if err != nil {
		fmt.Printf("Failed to list filters: %v\n", err)
		return err
	}

	fmt.Printf("Filters : %v\n", filters)
	return nil
}
```

<details><summary>Before</summary>
<p>

```bash
[root@flamingo-preprod-load-balancer-02461 kuknitin]# ./nu2 --interface tap1001600eth1
Filters : []
[root@flamingo-preprod-load-balancer-02461 kuknitin]# tc filter show dev tap1001600eth1
filter parent 1: protocol all pref 10 vcn chain 0
filter parent 1: protocol all pref 10 vcn chain 0 fh 00000001 [Unknown filter, optlen=180]
[root@flamingo-preprod-load-balancer-02461 kuknitin]#
```

</p>
</details> 

<details><summary>After</summary>
<p>

Update go.mod

```
replace (
	github.com/vishvananda/netlink => /Users/kuknitin/Workspace/kuknitin/netlink
)
```

```bash
[root@flamingo-preprod-load-balancer-02461 kuknitin]# ./nu2 --interface tap1001600eth1
Filters : [{LinkIndex: 62, Handle: 0:1, Parent: 1:0, Priority: 10, Protocol: 3}]
[root@flamingo-preprod-load-balancer-02461 kuknitin]# tc filter show dev tap1001600eth1
filter parent 1: protocol all pref 10 vcn chain 0
filter parent 1: protocol all pref 10 vcn chain 0 fh 00000001 [Unknown filter, optlen=180]
[root@flamingo-preprod-load-balancer-02461 kuknitin]#
```

</p>
</details> 