### PR TITLE
socket: add functions for unspecified platforms

### DIFF
--- a/netlink_unspecified.go
+++ b/netlink_unspecified.go
@@ -284,11 +284,3 @@ func NeighList(linkIndex, family int) ([]Neigh, error) {
 func NeighDeserialize(m []byte) (*Neigh, error) {
 	return nil, ErrNotImplemented
 }
-
-func SocketGet(local, remote net.Addr) (*Socket, error) {
-	return nil, ErrNotImplemented
-}
-
-func SocketDestroy(local, remote net.Addr) (*Socket, error) {
-	return nil, ErrNotImplemented
-}

--- a/socket_unspecified.go
+++ b/socket_unspecified.go
@@ -1,0 +1,40 @@
+//go:build !linux
+// +build !linux
+
+package netlink
+
+import (
+	"net"
+)
+
+func SocketGet(local, remote net.Addr) (*Socket, error) {
+	return nil, ErrNotImplemented
+}
+
+func SocketDestroy(local, remote net.Addr) error {
+	return ErrNotImplemented
+}
+
+func SocketDiagTCPInfo(family uint8) ([]*InetDiagTCPInfoResp, error) {
+	return nil, ErrNotImplemented
+}
+
+func SocketDiagTCP(family uint8) ([]*Socket, error) {
+	return nil, ErrNotImplemented
+}
+
+func SocketDiagUDPInfo(family uint8) ([]*InetDiagUDPInfoResp, error) {
+	return nil, ErrNotImplemented
+}
+
+func SocketDiagUDP(family uint8) ([]*Socket, error) {
+	return nil, ErrNotImplemented
+}
+
+func UnixSocketDiagInfo() ([]*UnixDiagInfoResp, error) {
+	return nil, ErrNotImplemented
+}
+
+func UnixSocketDiag() ([]*UnixSocket, error) {
+	return nil, ErrNotImplemented
+}

--- a/socket_xdp_unspecified.go
+++ b/socket_xdp_unspecified.go
@@ -1,0 +1,12 @@
+//go:build !linux
+// +build !linux
+
+package netlink
+
+func SocketXDPGetInfo(ino uint32, cookie uint64) (*XDPDiagInfoResp, error) {
+	return nil, ErrNotImplemented
+}
+
+func SocketDiagXDP() ([]*XDPDiagInfoResp, error) {
+	return nil, ErrNotImplemented
+}


### PR DESCRIPTION
This PR adds socket functions for unspecified (non-Linux) platforms and fixes https://github.com/vishvananda/netlink/issues/1069.