### PR TITLE
Clean up logging

### DIFF
--- a/fou_linux.go
+++ b/fou_linux.go
@@ -6,7 +6,6 @@ package netlink
 import (
 	"encoding/binary"
 	"errors"
-	"log"
 	"net"
 
 	"github.com/vishvananda/netlink/nl"
@@ -202,8 +201,6 @@ func deserializeFouMsg(msg []byte) (Fou, error) {
 			fou.PeerPort = int(networkOrder.Uint16(attr.Value))
 		case FOU_ATTR_IFINDEX:
 			fou.IfIndex = int(native.Uint16(attr.Value))
-		default:
-			log.Printf("unknown fou attribute from kernel: %+v %v", attr, attr.Type&nl.NLA_TYPE_MASK)
 		}
 	}
 

--- a/fou_linux.go
+++ b/fou_linux.go
@@ -169,18 +169,13 @@ func (h *Handle) FouList(fam int) ([]Fou, error) {
 
 	fous := make([]Fou, 0, len(msgs))
 	for _, m := range msgs {
-		f, err := deserializeFouMsg(m)
-		if err != nil {
-			return fous, err
-		}
-
-		fous = append(fous, f)
+		fous = append(fous, deserializeFouMsg(m))
 	}
 
 	return fous, executeErr
 }
 
-func deserializeFouMsg(msg []byte) (Fou, error) {
+func deserializeFouMsg(msg []byte) Fou {
 	fou := Fou{}
 
 	for attr := range nl.ParseAttributes(msg[4:]) {
@@ -204,5 +199,5 @@ func deserializeFouMsg(msg []byte) (Fou, error) {
 		}
 	}
 
-	return fou, nil
+	return fou
 }

--- a/fou_test.go
+++ b/fou_test.go
@@ -13,71 +13,63 @@ func TestFouDeserializeMsg(t *testing.T) {
 
 	// deserialize a valid message
 	msg = []byte{3, 1, 0, 0, 5, 0, 2, 0, 2, 0, 0, 0, 6, 0, 1, 0, 21, 179, 0, 0, 5, 0, 3, 0, 4, 0, 0, 0, 5, 0, 4, 0, 1, 0, 0, 0}
-	if fou, err := deserializeFouMsg(msg); err != nil {
-		t.Error(err.Error())
-	} else {
+	fou := deserializeFouMsg(msg)
+	// check if message was deserialized correctly
+	if fou.Family != FAMILY_V4 {
+		t.Errorf("expected family %d, got %d", FAMILY_V4, fou.Family)
+	}
 
-		// check if message was deserialized correctly
-		if fou.Family != FAMILY_V4 {
-			t.Errorf("expected family %d, got %d", FAMILY_V4, fou.Family)
-		}
+	if fou.Port != 5555 {
+		t.Errorf("expected port 5555, got %d", fou.Port)
+	}
 
-		if fou.Port != 5555 {
-			t.Errorf("expected port 5555, got %d", fou.Port)
-		}
+	if fou.Protocol != 4 { // ipip
+		t.Errorf("expected protocol 4, got %d", fou.Protocol)
+	}
 
-		if fou.Protocol != 4 { // ipip
-			t.Errorf("expected protocol 4, got %d", fou.Protocol)
-		}
-
-		if fou.EncapType != FOU_ENCAP_DIRECT {
-			t.Errorf("expected encap type %d, got %d", FOU_ENCAP_DIRECT, fou.EncapType)
-		}
+	if fou.EncapType != FOU_ENCAP_DIRECT {
+		t.Errorf("expected encap type %d, got %d", FOU_ENCAP_DIRECT, fou.EncapType)
 	}
 
 	// deserialize a valid message(kernel >= 5.2)
 	msg = []byte{3, 1, 0, 0, 5, 0, 2, 0, 2, 0, 0, 0, 6, 0, 1, 0, 43, 103, 0, 0, 6, 0, 10, 0, 86, 206, 0, 0, 5, 0, 3, 0, 0, 0, 0, 0, 5, 0, 4, 0, 2, 0, 0, 0, 8, 0, 11, 0, 0, 0, 0, 0, 8, 0, 6, 0, 1, 2, 3, 4, 8, 0, 8, 0, 5, 6, 7, 8}
-	if fou, err := deserializeFouMsg(msg); err != nil {
-		t.Error(err.Error())
-	} else {
-		if fou.Family != FAMILY_V4 {
-			t.Errorf("expected family %d, got %d", FAMILY_V4, fou.Family)
-		}
+	fou = deserializeFouMsg(msg)
+	if fou.Family != FAMILY_V4 {
+		t.Errorf("expected family %d, got %d", FAMILY_V4, fou.Family)
+	}
 
-		if fou.Port != 11111 {
-			t.Errorf("expected port 5555, got %d", fou.Port)
-		}
+	if fou.Port != 11111 {
+		t.Errorf("expected port 5555, got %d", fou.Port)
+	}
 
-		if fou.Protocol != 0 { // gue
-			t.Errorf("expected protocol 0, got %d", fou.Protocol)
-		}
+	if fou.Protocol != 0 { // gue
+		t.Errorf("expected protocol 0, got %d", fou.Protocol)
+	}
 
-		if fou.IfIndex != 0 {
-			t.Errorf("expected ifindex 0, got %d", fou.Protocol)
-		}
+	if fou.IfIndex != 0 {
+		t.Errorf("expected ifindex 0, got %d", fou.Protocol)
+	}
 
-		if fou.EncapType != FOU_ENCAP_GUE {
-			t.Errorf("expected encap type %d, got %d", FOU_ENCAP_GUE, fou.EncapType)
-		}
+	if fou.EncapType != FOU_ENCAP_GUE {
+		t.Errorf("expected encap type %d, got %d", FOU_ENCAP_GUE, fou.EncapType)
+	}
 
-		if expected := net.IPv4(1, 2, 3, 4); !fou.Local.Equal(expected) {
-			t.Errorf("expected local %v, got %v", expected, fou.Local)
-		}
+	if expected := net.IPv4(1, 2, 3, 4); !fou.Local.Equal(expected) {
+		t.Errorf("expected local %v, got %v", expected, fou.Local)
+	}
 
-		if expected := net.IPv4(5, 6, 7, 8); !fou.Peer.Equal(expected) {
-			t.Errorf("expected peer %v, got %v", expected, fou.Peer)
-		}
+	if expected := net.IPv4(5, 6, 7, 8); !fou.Peer.Equal(expected) {
+		t.Errorf("expected peer %v, got %v", expected, fou.Peer)
+	}
 
-		if fou.PeerPort != 22222 {
-			t.Errorf("expected peer port 0, got %d", fou.PeerPort)
-		}
+	if fou.PeerPort != 22222 {
+		t.Errorf("expected peer port 0, got %d", fou.PeerPort)
 	}
 
 	// unknown attribute should be skipped
 	msg = []byte{3, 1, 0, 0, 5, 0, 112, 0, 2, 0, 0, 0, 5, 0, 2, 0, 2, 0, 0}
-	if fou, err := deserializeFouMsg(msg); err != nil {
-		t.Errorf("unexpected error: %s", err.Error())
-	} else if fou.Family != 2 {
+	fou = deserializeFouMsg(msg)
+	if fou.Family != 2 {
 		t.Errorf("expected family 2, got %d", fou.Family)
 	}
 }

--- a/ipset_linux.go
+++ b/ipset_linux.go
@@ -2,7 +2,6 @@ package netlink
 
 import (
 	"encoding/binary"
-	"log"
 	"net"
 	"syscall"
 
@@ -516,8 +515,6 @@ func (result *IPSetResult) unserialize(msg []byte) {
 			result.ProtocolMinVersion = attr.Value[0]
 		case nl.IPSET_ATTR_MARKMASK:
 			result.MarkMask = attr.Uint32()
-		default:
-			log.Printf("unknown ipset attribute from kernel: %+v %v", attr, attr.Type&nl.NLA_TYPE_MASK)
 		}
 	}
 }
@@ -547,8 +544,6 @@ func (result *IPSetResult) parseAttrData(data []byte) {
 					result.Entries = append(result.Entries, IPSetEntry{IP: nested.Value})
 				case nl.IPSET_ATTR_IP:
 					result.IPFrom = nested.Value
-				default:
-					log.Printf("unknown nested ipset data attribute from kernel: %+v %v", nested, nested.Type&nl.NLA_TYPE_MASK)
 				}
 			}
 		case nl.IPSET_ATTR_IP_TO | nl.NLA_F_NESTED:
@@ -556,8 +551,6 @@ func (result *IPSetResult) parseAttrData(data []byte) {
 				switch nested.Type {
 				case nl.IPSET_ATTR_IP:
 					result.IPTo = nested.Value
-				default:
-					log.Printf("unknown nested ipset data attribute from kernel: %+v %v", nested, nested.Type&nl.NLA_TYPE_MASK)
 				}
 			}
 		case nl.IPSET_ATTR_PORT_FROM | nl.NLA_F_NET_BYTEORDER:
@@ -570,8 +563,6 @@ func (result *IPSetResult) parseAttrData(data []byte) {
 			result.Comment = nl.BytesToString(attr.Value)
 		case nl.IPSET_ATTR_MARKMASK:
 			result.MarkMask = attr.Uint32()
-		default:
-			log.Printf("unknown ipset data attribute from kernel: %+v %v", attr, attr.Type&nl.NLA_TYPE_MASK)
 		}
 	}
 }
@@ -581,8 +572,6 @@ func (result *IPSetResult) parseAttrADT(data []byte) {
 		switch attr.Type {
 		case nl.IPSET_ATTR_DATA | nl.NLA_F_NESTED:
 			result.Entries = append(result.Entries, parseIPSetEntry(attr.Value))
-		default:
-			log.Printf("unknown ADT attribute from kernel: %+v %v", attr, attr.Type&nl.NLA_TYPE_MASK)
 		}
 	}
 }
@@ -610,8 +599,6 @@ func parseIPSetEntry(data []byte) (entry IPSetEntry) {
 				switch attr.Type {
 				case nl.IPSET_ATTR_IPADDR_IPV4, nl.IPSET_ATTR_IPADDR_IPV6:
 					entry.IP = net.IP(attr.Value)
-				default:
-					log.Printf("unknown nested ADT attribute from kernel: %+v", attr)
 				}
 			}
 		case nl.IPSET_ATTR_IP2 | nl.NLA_F_NESTED:
@@ -619,8 +606,6 @@ func parseIPSetEntry(data []byte) (entry IPSetEntry) {
 				switch attr.Type {
 				case nl.IPSET_ATTR_IPADDR_IPV4, nl.IPSET_ATTR_IPADDR_IPV6:
 					entry.IP2 = net.IP(attr.Value)
-				default:
-					log.Printf("unknown nested ADT attribute from kernel: %+v", attr)
 				}
 			}
 		case nl.IPSET_ATTR_CIDR:
@@ -638,8 +623,6 @@ func parseIPSetEntry(data []byte) (entry IPSetEntry) {
 		case nl.IPSET_ATTR_MARK | nl.NLA_F_NET_BYTEORDER:
 			val := attr.Uint32()
 			entry.Mark = &val
-		default:
-			log.Printf("unknown ADT attribute from kernel: %+v", attr)
 		}
 	}
 	return

--- a/socket_test.go
+++ b/socket_test.go
@@ -4,8 +4,6 @@
 package netlink
 
 import (
-	"fmt"
-	"log"
 	"net"
 	"os/user"
 	"strconv"
@@ -66,11 +64,11 @@ func TestSocketGet(t *testing.T) {
 	for _, v := range [...]string{"tcp4", "tcp6"} {
 		addr, err := net.ResolveTCPAddr(v, "localhost:0")
 		if err != nil {
-			log.Fatal(err)
+			t.Fatal(err)
 		}
 		l, err := net.ListenTCP(v, addr)
 		if err != nil {
-			log.Fatal(err)
+			t.Fatal(err)
 		}
 		defer l.Close()
 
@@ -86,11 +84,11 @@ func TestSocketGet(t *testing.T) {
 	for _, v := range [...]string{"udp4", "udp6"} {
 		addr, err := net.ResolveUDPAddr(v, "localhost:0")
 		if err != nil {
-			log.Fatal(err)
+			t.Fatal(err)
 		}
 		l, err := net.ListenUDP(v, addr)
 		if err != nil {
-			log.Fatal(err)
+			t.Fatal(err)
 		}
 		defer l.Close()
 		conn, err := net.Dial(l.LocalAddr().Network(), l.LocalAddr().String())
@@ -108,11 +106,11 @@ func TestSocketDestroy(t *testing.T) {
 
 	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 	l, err := net.ListenTCP("tcp", addr)
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 	defer l.Close()
 
@@ -171,7 +169,6 @@ func TestUnixSocketDiagInfo(t *testing.T) {
 	}
 
 	for i, r := range result {
-		fmt.Println(r.DiagMsg)
 		if got := r.DiagMsg.Family; got != uint8(want) {
 			t.Fatalf("%d: protocol family = %v, want %v", i, got, want)
 		}


### PR DESCRIPTION
Don't log from the library on (yet) unknown fou or ipset attributes.These may appear any time a new kernel is used which adds new attributes.

Also clean up some stray logging in tests.

See commits for details.