### PR TITLE
Skip TestSocketXDPGetInfo on EPERM

### DIFF
--- a/socket_xdp_linux_test.go
+++ b/socket_xdp_linux_test.go
@@ -4,6 +4,7 @@
 package netlink
 
 import (
+	"errors"
 	"os"
 	"testing"
 
@@ -13,6 +14,9 @@ import (
 func TestSocketXDPGetInfo(t *testing.T) {
 	xdpsockfd, err := unix.Socket(unix.AF_XDP, unix.SOCK_RAW, 0)
 	if err != nil {
+		if errors.Is(err, unix.EPERM) {
+			t.Skipf("creating AF_XDP socket not permitted")
+		}
 		t.Fatal(err)
 	}
 	defer unix.Close(xdpsockfd)


### PR DESCRIPTION
Skip `TestSocketXDPGetInfo` rather than failing it when the user lacks permissions to create AF_XDP sockets.

This allows to run the full test suite as an unprivileged user again.