### PR TITLE
fix: Update go.mod to match ci's version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.22
+        go-version: 1.23
 
     - name: Kernel Modules
       run: ./.github/scripts/modprobe.sh
@@ -35,7 +35,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.22
+        go-version: 1.23
           
     - name: Build
       run: go build ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vishvananda/netlink
 
-go 1.12
+go 1.23
 
 require (
 	github.com/vishvananda/netns v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,4 @@
 github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zdEY=
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
-golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
 golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
Fixes 
- https://github.com/vishvananda/netlink/issues/1016

We have a go version in go.mod that is not valid. Current package cannot be built with go 1.12

Updated go.mod to be in sync with what we are using in our CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Go toolchain to 1.23 across CI pipelines and updated the module Go version directive to 1.23.

* **Impact**
  * Requires Go 1.23+ for local builds and development.
  * Benefits from language/runtime improvements; no changes to public APIs or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->