### PR TITLE
Isolate RuleListFiltered subtests

### DIFF
--- a/rule_test.go
+++ b/rule_test.go
@@ -73,7 +73,6 @@ func TestRuleAddDel(t *testing.T) {
 
 func TestRuleListFiltered(t *testing.T) {
 	skipUnlessRoot(t)
-	defer setUpNetlinkTest(t)()
 
 	t.Run("IPv4", testRuleListFilteredIPv4)
 	t.Run("IPv6", testRuleListFilteredIPv6)
@@ -95,8 +94,6 @@ func testRuleListFilteredIPv6(t *testing.T) {
 }
 
 func runRuleListFiltered(t *testing.T, family int, srcNet, dstNet *net.IPNet) {
-	defaultRules, _ := RuleList(family)
-
 	tests := []struct {
 		name       string
 		ruleFilter *Rule
@@ -112,7 +109,11 @@ func runRuleListFiltered(t *testing.T, family int, srcNet, dstNet *net.IPNet) {
 			preRun:     func() *Rule { return nil },
 			postRun:    func(r *Rule) {},
 			setupWant: func(_ *Rule) ([]Rule, bool) {
-				return defaultRules, false
+				rules, err := RuleList(family)
+				if err != nil {
+					t.Fatalf("Failed to list rules: %v", err)
+				}
+				return rules, false
 			},
 		},
 		{
@@ -583,6 +584,7 @@ func runRuleListFiltered(t *testing.T, family int, srcNet, dstNet *net.IPNet) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			defer setUpNetlinkTest(t)()
 			rule := tt.preRun()
 			wantRules, wantErr := tt.setupWant(rule)
 


### PR DESCRIPTION
Refactors the TestRuleListFiltered test to run each subtest in its own network namespace. This prevents state leakage between subtests, resolving intermittent test failures caused by rules created in one test interfering with subsequent tests.

The test logic for verifying all rules is also simplified by moving the rule listing into the setup phase for that specific test case, removing conditional logic from the main test loop.

Fixes: #1108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of network rule listing tests by moving setup into each subtest for better isolation.
  * Added explicit error handling to fail fast when rule listing encounters problems, avoiding silent failures.
  * Simplified test flow by removing shared precomputed defaults and using live rule listings per case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->