### PR TITLE
chore: bump github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,10 +11,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: 1.23
 
@@ -30,10 +30,10 @@ jobs:
     # on macOS, which helps catch missing build tags.
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: 1.23
           


### PR DESCRIPTION
bump actions/checkout to v4
bump actions/setup-go to v5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to use newer GitHub Actions for code checkout and Go setup on Linux and macOS runners.
  * Go version remains 1.23; no changes to build logic or application behavior.
  * Anticipated benefits include improved reliability, security updates, and potentially faster build/setup times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->