### PR TITLE
Always check for `EnableErrorMessageReporting` and `SetExtAck()` when creating Netlink sockets.

### DIFF
--- a/nl/nl_linux.go
+++ b/nl/nl_linux.go
@@ -716,6 +716,11 @@ func getNetlinkSocket(protocol int) (*NetlinkSocket, error) {
 		return nil, err
 	}
 
+	if EnableErrorMessageReporting {
+		// ignore error
+		_ = s.SetExtAck(true)
+	}
+
 	return s, nil
 }
 


### PR DESCRIPTION
Please see https://github.com/vishvananda/netlink/issues/1129 with description of the issue from the user perspective.

In technical tems, the netlink library does great job of managing the ExtAcks, but the subtle issue (and arguably a bug) here is that not all code paths that create new Netlink sockets check and `SetExtAck()`.

One can also observe with strace, that indeed socket has no `NETLINK_EXT_ACK` option set and the extended error messages are not communicated on the protocol level.

This PR fixes this issue by always checking `EnableErrorMessageReporting` and setting the ext ack socket option when creating new sockets. We ignore the error here, but it's not ignored on the other code path (in `ExecuteIter`), maybe we should not ignore it  or maybe better ignore it in both places (i.e. if for example a binary is run on an old kernel with no support for ext acks, it still works  without readable errrors).

I also looked a bit into the alternatives: one reasonable one seems to be to add `Handle.SetExtAck()` and make the user to call it explicitly when creating handles. It seems like additional complexity and against the spirit of the kernel documentation, but still viable.

Please take a quick look at the PR.

fixes #1129.


 