### PR TITLE
link_linux: Add generic Headroom and Tailroom attributes.

### DIFF
--- a/link.go
+++ b/link.go
@@ -29,6 +29,8 @@ type LinkAttrs struct {
 	HardwareAddr   net.HardwareAddr
 	Flags          net.Flags
 	RawFlags       uint32
+	Headroom       uint16      // Query only
+	Tailroom       uint16      // Query only
 	ParentIndex    int         // index of the parent link device
 	MasterIndex    int         // must be the index of a bridge
 	Namespace      interface{} // nil | NsPid | NsFd
@@ -410,8 +412,8 @@ type Netkit struct {
 	PeerPolicy    NetkitPolicy
 	Scrub         NetkitScrub
 	PeerScrub     NetkitScrub
-	Headroom      uint16
-	Tailroom      uint16
+	setHeadroom   uint16 // Named due to presence of Headroom in LinkAttrs
+	setTailroom   uint16 // Named due to presence of Tailroom in LinkAttrs
 	supportsScrub bool
 	isPrimary     bool
 	peerLinkAttrs LinkAttrs

--- a/link_linux.go
+++ b/link_linux.go
@@ -35,6 +35,13 @@ const (
 	TUNTAP_MULTI_QUEUE_DEFAULTS TuntapFlag = TUNTAP_MULTI_QUEUE | TUNTAP_NO_PI
 )
 
+// Temporary, until merged into kernel and golang-sys picks them up. See net-next commit:
+// https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git/commit/?id=b73b8146d7ff68e245525adb944a4c998d423d59
+const (
+	IFLA_HEADROOM = 0x44
+	IFLA_TAILROOM = 0x45
+)
+
 var StringToTuntapModeMap = map[string]TuntapMode{
 	"tun": TUNTAP_MODE_TUN,
 	"tap": TUNTAP_MODE_TAP,
@@ -2426,6 +2433,10 @@ func LinkDeserialize(hdr *unix.NlMsghdr, m []byte) (Link, error) {
 			base.ParentDev = string(attr.Value[:len(attr.Value)-1])
 		case unix.IFLA_PARENT_DEV_BUS_NAME:
 			base.ParentDevBus = string(attr.Value[:len(attr.Value)-1])
+		case IFLA_HEADROOM:
+			base.Headroom = native.Uint16(attr.Value[0:2])
+		case IFLA_TAILROOM:
+			base.Tailroom = native.Uint16(attr.Value[0:2])
 		}
 	}
 
@@ -2881,11 +2892,11 @@ func addNetkitAttrs(nk *Netkit, linkInfo *nl.RtAttr, flag int) error {
 
 	// Any headroom or tailroom set on the primary device attributes will result in
 	// the kernel carrying them over into the peer device attributes for us.
-	if nk.Headroom > 0 {
-		data.AddRtAttr(nl.IFLA_NETKIT_HEADROOM, nl.Uint16Attr(nk.Headroom))
+	if nk.setHeadroom > 0 {
+		data.AddRtAttr(nl.IFLA_NETKIT_HEADROOM, nl.Uint16Attr(nk.setHeadroom))
 	}
-	if nk.Tailroom > 0 {
-		data.AddRtAttr(nl.IFLA_NETKIT_TAILROOM, nl.Uint16Attr(nk.Tailroom))
+	if nk.setTailroom > 0 {
+		data.AddRtAttr(nl.IFLA_NETKIT_TAILROOM, nl.Uint16Attr(nk.setTailroom))
 	}
 
 	if (flag & unix.NLM_F_EXCL) == 0 {
@@ -2957,9 +2968,9 @@ func parseNetkitData(link Link, data []syscall.NetlinkRouteAttr) {
 			netkit.supportsScrub = true
 			netkit.PeerScrub = NetkitScrub(native.Uint32(datum.Value[0:4]))
 		case nl.IFLA_NETKIT_HEADROOM:
-			netkit.Headroom = native.Uint16(datum.Value[0:2])
+			netkit.setHeadroom = native.Uint16(datum.Value[0:2])
 		case nl.IFLA_NETKIT_TAILROOM:
-			netkit.Tailroom = native.Uint16(datum.Value[0:2])
+			netkit.setTailroom = native.Uint16(datum.Value[0:2])
 		}
 	}
 }

--- a/link_test.go
+++ b/link_test.go
@@ -89,11 +89,11 @@ func testLinkAddDel(t *testing.T, link Link) {
 			if resultPrimary.SupportsScrub() && resultPrimary.PeerScrub != inputPrimary.PeerScrub {
 				t.Fatalf("Peer Scrub is %d, should be %d", int(resultPrimary.PeerScrub), int(inputPrimary.PeerScrub))
 			}
-			if resultPrimary.Headroom != inputPrimary.Headroom {
-				t.Fatalf("Headroom is %d, should be %d", resultPrimary.Headroom, inputPrimary.Headroom)
+			if resultPrimary.setHeadroom != inputPrimary.setHeadroom {
+				t.Fatalf("Headroom is %d, should be %d", resultPrimary.setHeadroom, inputPrimary.setHeadroom)
 			}
-			if resultPrimary.Tailroom != inputPrimary.Tailroom {
-				t.Fatalf("Tailroom is %d, should be %d", resultPrimary.Tailroom, inputPrimary.Tailroom)
+			if resultPrimary.setTailroom != inputPrimary.setTailroom {
+				t.Fatalf("Tailroom is %d, should be %d", resultPrimary.setTailroom, inputPrimary.setTailroom)
 			}
 			if inputPrimary.Mode == NETKIT_MODE_L2 && inputPrimary.HardwareAddr != nil {
 				if inputPrimary.HardwareAddr.String() != resultPrimary.HardwareAddr.String() {
@@ -131,11 +131,11 @@ func testLinkAddDel(t *testing.T, link Link) {
 				if resultPrimary.Scrub != resultPeer.PeerScrub {
 					t.Fatalf("PeerScrub from peer is %d, should be %d", int(resultPeer.PeerScrub), int(resultPrimary.Scrub))
 				}
-				if resultPrimary.Headroom != resultPeer.Headroom {
-					t.Fatalf("Headroom from peer is %d, should be %d", resultPeer.Headroom, resultPeer.Headroom)
+				if resultPrimary.setHeadroom != resultPeer.setHeadroom {
+					t.Fatalf("Headroom from peer is %d, should be %d", resultPeer.setHeadroom, resultPeer.setHeadroom)
 				}
-				if resultPrimary.Tailroom != resultPeer.Tailroom {
-					t.Fatalf("Tailroom from peer is %d, should be %d", resultPeer.Tailroom, resultPeer.Tailroom)
+				if resultPrimary.setTailroom != resultPeer.setTailroom {
+					t.Fatalf("Tailroom from peer is %d, should be %d", resultPeer.setTailroom, resultPeer.setTailroom)
 				}
 				if inputPrimary.Mode == NETKIT_MODE_L2 && inputPrimary.peerLinkAttrs.HardwareAddr != nil {
 					if inputPrimary.peerLinkAttrs.HardwareAddr.String() != resultPeer.HardwareAddr.String() {
@@ -1285,12 +1285,12 @@ func TestLinkAddDelNetkitWithHeadroom(t *testing.T) {
 			Name:         "foo",
 			HardwareAddr: net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
 		},
-		Mode:       NETKIT_MODE_L2,
-		Policy:     NETKIT_POLICY_FORWARD,
-		PeerPolicy: NETKIT_POLICY_BLACKHOLE,
-		Scrub:      NETKIT_SCRUB_DEFAULT,
-		PeerScrub:  NETKIT_SCRUB_NONE,
-		Headroom:   testHeadroom,
+		Mode:        NETKIT_MODE_L2,
+		Policy:      NETKIT_POLICY_FORWARD,
+		PeerPolicy:  NETKIT_POLICY_BLACKHOLE,
+		Scrub:       NETKIT_SCRUB_DEFAULT,
+		PeerScrub:   NETKIT_SCRUB_NONE,
+		setHeadroom: testHeadroom,
 	}
 	peerAttr := &LinkAttrs{
 		Name:         "bar",
@@ -1310,12 +1310,12 @@ func TestLinkAddDelNetkitWithTailroom(t *testing.T) {
 			Name:         "foo",
 			HardwareAddr: net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
 		},
-		Mode:       NETKIT_MODE_L2,
-		Policy:     NETKIT_POLICY_FORWARD,
-		PeerPolicy: NETKIT_POLICY_BLACKHOLE,
-		Scrub:      NETKIT_SCRUB_DEFAULT,
-		PeerScrub:  NETKIT_SCRUB_NONE,
-		Tailroom:   testTailroom,
+		Mode:        NETKIT_MODE_L2,
+		Policy:      NETKIT_POLICY_FORWARD,
+		PeerPolicy:  NETKIT_POLICY_BLACKHOLE,
+		Scrub:       NETKIT_SCRUB_DEFAULT,
+		PeerScrub:   NETKIT_SCRUB_NONE,
+		setTailroom: testTailroom,
 	}
 	peerAttr := &LinkAttrs{
 		Name:         "bar",
@@ -1335,13 +1335,13 @@ func TestLinkAddDelNetkitWithHeadAndTailroom(t *testing.T) {
 			Name:         "foo",
 			HardwareAddr: net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
 		},
-		Mode:       NETKIT_MODE_L2,
-		Policy:     NETKIT_POLICY_FORWARD,
-		PeerPolicy: NETKIT_POLICY_BLACKHOLE,
-		Scrub:      NETKIT_SCRUB_DEFAULT,
-		PeerScrub:  NETKIT_SCRUB_NONE,
-		Headroom:   testHeadroom,
-		Tailroom:   testTailroom,
+		Mode:        NETKIT_MODE_L2,
+		Policy:      NETKIT_POLICY_FORWARD,
+		PeerPolicy:  NETKIT_POLICY_BLACKHOLE,
+		Scrub:       NETKIT_SCRUB_DEFAULT,
+		PeerScrub:   NETKIT_SCRUB_NONE,
+		setHeadroom: testHeadroom,
+		setTailroom: testTailroom,
 	}
 	peerAttr := &LinkAttrs{
 		Name:         "bar",


### PR DESCRIPTION
Introduce generic IFLA_HEADROOM and IFLA_TAILROOM values that are appropriately deserialised when querying link details via RTNL.

Netlink-specific variables have been renamed to avoid ambiguity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support to read and set link headroom and tailroom where supported (e.g., Linux). These values now appear in link inspection and can be configured for Netkit links.
* **Refactor**
  * Renamed Netkit configuration options for headroom and tailroom to avoid ambiguity. Update any code relying on the old option names.
* **Tests**
  * Updated tests to align with the renamed configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->