### PR TITLE
Remove netlink subscription in socket_linux.go

### DIFF
--- a/socket_linux.go
+++ b/socket_linux.go
@@ -261,11 +261,6 @@ func (h *Handle) SocketDestroy(local, remote net.Addr) error {
 		return ErrNotImplemented
 	}
 
-	s, err := nl.Subscribe(unix.NETLINK_INET_DIAG)
-	if err != nil {
-		return err
-	}
-	defer s.Close()
 	req := h.newNetlinkRequest(nl.SOCK_DESTROY, unix.NLM_F_ACK)
 	req.AddData(&socketRequest{
 		Family:   unix.AF_INET,
@@ -279,7 +274,7 @@ func (h *Handle) SocketDestroy(local, remote net.Addr) error {
 		},
 	})
 
-	_, err = req.Execute(unix.NETLINK_INET_DIAG, 0)
+	_, err := req.Execute(unix.NETLINK_INET_DIAG, 0)
 	return err
 }
 


### PR DESCRIPTION
Removed netlink subscription that seems was a left over from the cleanup in https://github.com/vishvananda/netlink/commit/a57a7bd6b256ee7215ff5a934cf4c11d306547ab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fewer rare errors when destroying sockets on Linux, improving reliability during teardown.

* **Refactor**
  * Simplified socket teardown flow to remove unnecessary subscription and cleanup steps, reducing complexity and potential failure points.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->