### PR TITLE
add ConntrackDelete command

### DIFF
--- a/conntrack_linux.go
+++ b/conntrack_linux.go
@@ -391,6 +391,8 @@ func (s *ConntrackFlow) toNlData() ([]*nl.RtAttr, error) {
 	//	<BEuint64>
 	//	<len, CTA_LABELS>
 	//	<binary data>
+	//	<len, CTA_ZONE>
+	//	<BEuint16>
 	//	<len, NLA_F_NESTED|CTA_PROTOINFO>
 
 	// CTA_TUPLE_ORIG
@@ -437,6 +439,11 @@ func (s *ConntrackFlow) toNlData() ([]*nl.RtAttr, error) {
 		default:
 			return nil, errors.New("couldn't generate netlink data for conntrack: field 'ProtoInfo' only supports TCP or nil")
 		}
+	}
+
+	if s.Zone != 0 {
+		ctZone := nl.NewRtAttr(nl.CTA_ZONE, nl.BEUint16Attr(s.Zone))
+		payload = append(payload, ctZone)
 	}
 
 	return payload, nil

--- a/conntrack_test.go
+++ b/conntrack_test.go
@@ -1541,6 +1541,8 @@ func TestConntrackDeleteV4(t *testing.T) {
 		t.Fatalf("failed to create netlink handle: %s", err)
 	}
 
+	ctZone := uint16(123)
+
 	flow := ConntrackFlow{
 		FamilyType: FAMILY_V4,
 		Forward: IPTuple{
@@ -1562,6 +1564,7 @@ func TestConntrackDeleteV4(t *testing.T) {
 		ProtoInfo: &ProtoInfoTCP{
 			State: nl.TCP_CONNTRACK_ESTABLISHED,
 		},
+		Zone: ctZone,
 	}
 
 	// Create the entry using the handle
@@ -1586,6 +1589,7 @@ func TestConntrackDeleteV4(t *testing.T) {
 			ConntrackOrigDstPort: flow.Forward.DstPort,
 		},
 		protoFilter: unix.IPPROTO_TCP,
+		zoneFilter:  &ctZone,
 	}
 	var match *ConntrackFlow
 	for _, f := range flows {
@@ -1645,6 +1649,8 @@ func TestConntrackDeleteV6(t *testing.T) {
 		t.Fatalf("failed to create netlink handle: %s", err)
 	}
 
+	ctZone := uint16(123)
+
 	flow := ConntrackFlow{
 		FamilyType: FAMILY_V6,
 		Forward: IPTuple{
@@ -1666,6 +1672,7 @@ func TestConntrackDeleteV6(t *testing.T) {
 		ProtoInfo: &ProtoInfoTCP{
 			State: nl.TCP_CONNTRACK_ESTABLISHED,
 		},
+		Zone: ctZone,
 	}
 
 	// Create the entry using the handle
@@ -1690,6 +1697,7 @@ func TestConntrackDeleteV6(t *testing.T) {
 			ConntrackOrigDstPort: flow.Forward.DstPort,
 		},
 		protoFilter: unix.IPPROTO_TCP,
+		zoneFilter:  &ctZone,
 	}
 	var match *ConntrackFlow
 	for _, f := range flows {


### PR DESCRIPTION
Add a new ConntrackDelete() function that operates directly on flows, same as the ConntrackCreate() and ConntrackUpdate() functions.

We already have ConntrackDeleteFilters() that is very useful to batch operations and to express the intent based on filter matches, but having the function that operate on flows allow to create much more complex filtering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add ability to delete connection-tracking flows for both IPv4 and IPv6 via the public API, following existing create/update patterns.
  * Conntrack flow handling now includes zone attribute support when present.

* **Tests**
  * Add tests covering IPv4 and IPv6 conntrack deletion workflows, validating create/list/delete and cleanup in isolated network namespaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->