### PR TITLE
conntrack: encode conntrack labels if set

### DIFF
--- a/conntrack_linux.go
+++ b/conntrack_linux.go
@@ -366,6 +366,8 @@ func (s *ConntrackFlow) toNlData() ([]*nl.RtAttr, error) {
 	//	<BEuint64>
 	//	<len, CTA_TIMEOUT>
 	//	<BEuint64>
+	//	<len, CTA_LABELS>
+	//	<binary data>
 	//	<len, NLA_F_NESTED|CTA_PROTOINFO>
 
 	// CTA_TUPLE_ORIG
@@ -392,6 +394,14 @@ func (s *ConntrackFlow) toNlData() ([]*nl.RtAttr, error) {
 	ctTimeout := nl.NewRtAttr(nl.CTA_TIMEOUT, nl.BEUint32Attr(s.TimeOut))
 
 	payload = append(payload, ctTupleOrig, ctTupleReply, ctMark, ctTimeout)
+	// Labels: nil => do not send; 16 zero bytes => clear all labels.
+	if s.Labels != nil {
+		if len(s.Labels) != 16 {
+			return nil, fmt.Errorf("conntrack CTA_LABELS must be 16 bytes, got %d", len(s.Labels))
+		}
+		ctLabels := nl.NewRtAttr(nl.CTA_LABELS, s.Labels)
+		payload = append(payload, ctLabels)
+	}
 
 	if s.ProtoInfo != nil {
 		switch p := s.ProtoInfo.(type) {


### PR DESCRIPTION
conntrack: update conntrack labels
    
The logic for updating conntrack labels was missing.
The conntrack labels is an slice of bytes, if is not nil we send
its current value.
The all zeros slice has a special meaning , that wipes out the existing
labels.

There is also some unexpected behavior, the conntrack table does not
reserve space for the labels if there is no label set in any rule,
causing the netlink calls to fail with ENOSPC

Signed-off-by: Antonio Ojea <aojea@google.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-connection labels for conntrack entries exposed via netlink and the public API; labels are 16 bytes and a missing label clears existing labels.

* **Tests**
  * Added end-to-end tests covering creation, update, listing, filtering, clearing, and persistence of conntrack labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->