### PR TITLE
parsing of tc pedit action

### DIFF
--- a/filter_linux.go
+++ b/filter_linux.go
@@ -840,6 +840,73 @@ func parsePolice(data syscall.NetlinkRouteAttr, police *PoliceAction) {
 	}
 }
 
+func parsePeditExtendedKeys(pedit *nl.TcPedit, action *PeditAction) {
+	// Group keys by header type
+	keysByType := make(map[nl.PeditHeaderType][]nl.TcPeditKey)
+	for i := 0; i < int(pedit.Sel.NKeys); i++ {
+		if i >= len(pedit.KeysEx) || i >= len(pedit.Keys) {
+			break
+		}
+		hdrType := pedit.KeysEx[i].HeaderType
+		keysByType[hdrType] = append(keysByType[hdrType], pedit.Keys[i])
+	}
+
+	for hdrType, keys := range keysByType {
+		switch hdrType {
+		case nl.TCA_PEDIT_KEY_EX_HDR_TYPE_ETH:
+			srcMac, dstMac := nl.ParsePeditEthKeys(keys)
+			if srcMac != nil {
+				action.SrcMacAddr = srcMac
+			}
+			if dstMac != nil {
+				action.DstMacAddr = dstMac
+			}
+
+		case nl.TCA_PEDIT_KEY_EX_HDR_TYPE_IP4:
+			srcIP, dstIP := nl.ParsePeditIP4Keys(keys)
+			if srcIP != nil {
+				action.SrcIP = srcIP
+			}
+			if dstIP != nil {
+				action.DstIP = dstIP
+			}
+
+		case nl.TCA_PEDIT_KEY_EX_HDR_TYPE_IP6:
+			srcIP, dstIP := nl.ParsePeditIP6Keys(keys)
+			if srcIP != nil {
+				action.SrcIP = srcIP
+			}
+			if dstIP != nil {
+				action.DstIP = dstIP
+			}
+
+		case nl.TCA_PEDIT_KEY_EX_HDR_TYPE_TCP:
+			srcPort, dstPort := nl.ParsePeditL4Keys(keys)
+			if srcPort > 0 {
+				action.SrcPort = srcPort
+			}
+			if dstPort > 0 {
+				action.DstPort = dstPort
+			}
+			if srcPort > 0 || dstPort > 0 {
+				action.Proto = unix.IPPROTO_TCP
+			}
+
+		case nl.TCA_PEDIT_KEY_EX_HDR_TYPE_UDP:
+			srcPort, dstPort := nl.ParsePeditL4Keys(keys)
+			if srcPort > 0 {
+				action.SrcPort = srcPort
+			}
+			if dstPort > 0 {
+				action.DstPort = dstPort
+			}
+			if srcPort > 0 || dstPort > 0 {
+				action.Proto = unix.IPPROTO_UDP
+			}
+		}
+	}
+}
+
 func parseActions(tables []syscall.NetlinkRouteAttr) ([]Action, error) {
 	var actions []Action
 	for _, table := range tables {
@@ -884,6 +951,7 @@ func parseActions(tables []syscall.NetlinkRouteAttr) ([]Action, error) {
 					break nextattr
 				}
 			case nl.TCA_OPTIONS:
+				var pedit *nl.TcPedit
 				adata, err := nl.ParseRouteAttr(aattr.Value)
 				if err != nil {
 					return nil, err
@@ -1018,6 +1086,25 @@ func parseActions(tables []syscall.NetlinkRouteAttr) ([]Action, error) {
 						}
 					case "police":
 						parsePolice(adatum, action.(*PoliceAction))
+					case "pedit":
+						switch adatum.Attr.Type {
+						case nl.TCA_PEDIT_PARMS, nl.TCA_PEDIT_PARMS_EX:
+							sel, keys := nl.DeserializeTcPedit(adatum.Value)
+							if pedit == nil {
+								pedit = &nl.TcPedit{}
+							}
+							pedit.Sel = *sel
+							pedit.Keys = keys
+							toAttrs(&pedit.Sel.TcGen, action.Attrs())
+						case nl.TCA_PEDIT_KEYS_EX:
+							if pedit == nil {
+								pedit = &nl.TcPedit{}
+							}
+							pedit.KeysEx = nl.DeserializeTcPeditKeysEx(adatum.Value)
+						}
+						if pedit != nil && len(pedit.Keys) > 0 && len(pedit.Keys) == len(pedit.KeysEx) {
+							parsePeditExtendedKeys(pedit, action.(*PeditAction))
+						}
 					}
 				}
 			case nl.TCA_ACT_STATS:


### PR DESCRIPTION
This PR adds Pedit action attributes parsing leveraging `HeaderType` set in `TCA_PEDIT_KEYS_EX`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded packet-editing support across Ethernet, IPv4, IPv6 and TCP/UDP headers, including automatic proto detection when ports are present and support for extended key formats.
  * New parsing utilities to extract and apply source/destination MACs, IPs and L4 ports from editing rules.
* **Bug Fixes / Reliability**
  * Improved deserialization and state propagation for extended packet-edit configurations to ensure consistent rule application.
* **Tests**
  * Added unit tests covering MAC, IPv4, IPv6 and L4 port parsing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->