### PR TITLE
xdp: support network namespaces

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -1033,15 +1033,25 @@ func (h *Handle) LinkSetNsFd(link Link, fd int) error {
 // LinkSetXdpFd adds a bpf function to the driver. The fd must be a bpf
 // program loaded with bpf(type=BPF_PROG_TYPE_XDP)
 func LinkSetXdpFd(link Link, fd int) error {
-	return LinkSetXdpFdWithFlags(link, fd, 0)
+	return pkgHandle.LinkSetXdpFdWithFlags(link, fd, 0)
+}
+
+func (h *Handle) LinkSetXdpFd(link Link, fd int) error {
+	return h.LinkSetXdpFdWithFlags(link, fd, 0)
 }
 
 // LinkSetXdpFdWithFlags adds a bpf function to the driver with the given
 // options. The fd must be a bpf program loaded with bpf(type=BPF_PROG_TYPE_XDP)
 func LinkSetXdpFdWithFlags(link Link, fd, flags int) error {
+	return pkgHandle.LinkSetXdpFdWithFlags(link, fd, flags)
+}
+
+// LinkSetXdpFdWithFlags adds a bpf function to the driver with the given
+// options. The fd must be a bpf program loaded with bpf(type=BPF_PROG_TYPE_XDP)
+func (h *Handle) LinkSetXdpFdWithFlags(link Link, fd, flags int) error {
 	base := link.Attrs()
-	ensureIndex(base)
-	req := nl.NewNetlinkRequest(unix.RTM_SETLINK, unix.NLM_F_ACK)
+	h.ensureIndex(base)
+	req := h.newNetlinkRequest(unix.RTM_SETLINK, unix.NLM_F_ACK)
 
 	msg := nl.NewIfInfomsg(unix.AF_UNSPEC)
 	msg.Index = int32(base.Index)


### PR DESCRIPTION
Support setting XDP programs on interfaces in namespaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * XDP program attachment now supports configurable flags for enhanced control over network interface behavior.

* **Refactor**
  * Reorganized internal XDP operations architecture to improve consistency and maintainability while preserving backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->