### PR TITLE
Add a basic support for nexthop

### DIFF
--- a/nexthop.go
+++ b/nexthop.go
@@ -1,0 +1,27 @@
+package netlink
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+)
+
+type Nexthop struct {
+	ID        uint32
+	Blackhole bool
+	OIF       uint32
+	Gateway   net.IP
+	Protocol  RouteProtocol
+}
+
+func (h *Nexthop) String() string {
+	elems := []string{
+		"ID: " + strconv.FormatUint(uint64(h.ID), 10),
+		"Blackhole: " + strconv.FormatBool(h.Blackhole),
+		"OIF: " + strconv.FormatUint(uint64(h.OIF), 10),
+		"Gateway: " + h.Gateway.String(),
+		"Protocol: " + h.Protocol.String(),
+	}
+	return fmt.Sprintf("{%s}", strings.Join(elems, " "))
+}

--- a/nexthop_linux.go
+++ b/nexthop_linux.go
@@ -1,0 +1,286 @@
+package netlink
+
+import (
+	"errors"
+	"net"
+
+	"github.com/vishvananda/netlink/nl"
+	"golang.org/x/sys/unix"
+)
+
+// NexthopAdd will add a nexthop to the system.
+// Equivalent to: `ip nexthop add $nexthop`
+func NexthopAdd(nh *Nexthop) error {
+	return pkgHandle.NexthopAdd(nh)
+}
+
+// NexthopAdd will add a nexthop to the system.
+// Equivalent to: `ip nexthop add $nexthop`
+func (h *Handle) NexthopAdd(nh *Nexthop) error {
+	flags := unix.NLM_F_CREATE | unix.NLM_F_EXCL | unix.NLM_F_ACK
+	req := h.newNetlinkRequest(unix.RTM_NEWNEXTHOP, flags)
+	if err := prepareNewNexthop(nh, req, &nl.Nhmsg{}); err != nil {
+		return err
+	}
+	_, err := req.Execute(unix.NETLINK_ROUTE, 0)
+	return err
+}
+
+// NexthopReplace will replace a nexthop in the system.
+// Equivalent to: `ip nexthop replace $nexthop`
+func NexthopReplace(nh *Nexthop) error {
+	return pkgHandle.NexthopReplace(nh)
+}
+
+// NexthopReplace will replace a nexthop in the system.
+// Equivalent to: `ip nexthop replace $nexthop`
+func (h *Handle) NexthopReplace(nh *Nexthop) error {
+	flags := unix.NLM_F_CREATE | unix.NLM_F_REPLACE | unix.NLM_F_ACK
+	req := h.newNetlinkRequest(unix.RTM_NEWNEXTHOP, flags)
+	if err := prepareNewNexthop(nh, req, &nl.Nhmsg{}); err != nil {
+		return err
+	}
+	_, err := req.Execute(unix.NETLINK_ROUTE, 0)
+	return err
+}
+
+// NexthopDel will delete a nexthop from the system.
+// Equivalent to: `ip nexthop del $nexthop`
+func NexthopDel(nh *Nexthop) error {
+	return pkgHandle.NexthopDel(nh)
+}
+
+// NexthopDel will delete a nexthop from the system.
+// Equivalent to: `ip nexthop del $nexthop`
+func (h *Handle) NexthopDel(nh *Nexthop) error {
+	req := h.newNetlinkRequest(unix.RTM_DELNEXTHOP, unix.NLM_F_ACK)
+	if err := prepareDelNexthop(nh, req, &nl.Nhmsg{}); err != nil {
+		return err
+	}
+	_, err := req.Execute(unix.NETLINK_ROUTE, 0)
+	return err
+}
+
+// NexthopList gets a list of nexthop in the system.
+// Equivalent to: `ip nexthop show`.
+//
+// If the returned error is [ErrDumpInterrupted], results may be inconsistent
+// or incomplete.
+func NexthopList() ([]Nexthop, error) {
+	return pkgHandle.NexthopList()
+}
+
+// NexthopList gets a list of nexthop in the system.
+// Equivalent to: `ip nexthop show`.
+//
+// If the returned error is [ErrDumpInterrupted], results may be inconsistent
+// or incomplete.
+func (h *Handle) NexthopList() ([]Nexthop, error) {
+	req := h.newNetlinkRequest(unix.RTM_GETNEXTHOP, unix.NLM_F_DUMP)
+
+	nhmsg := &nl.Nhmsg{}
+	nhmsg.Family = FAMILY_ALL
+	req.AddData(nhmsg)
+
+	var (
+		parseErr error
+		nhs      []Nexthop
+	)
+	executeErr := req.ExecuteIter(unix.NETLINK_ROUTE, 0, func(m []byte) bool {
+		nh, err := parseNhmsg(m)
+		if err != nil {
+			parseErr = err
+			return false
+		}
+		nhs = append(nhs, *nh)
+		return true
+	})
+	if executeErr != nil && !errors.Is(executeErr, ErrDumpInterrupted) {
+		return nil, executeErr
+	}
+	if parseErr != nil {
+		return nil, parseErr
+	}
+	return nhs, executeErr
+}
+
+// Mapping of NHA_* => encode/decode functions. Don't use this map directly.
+// Use encodeNexthopAttrs/decodeNexthopAttrs instead.
+var nexthopAttrHandlers = map[uint16]struct {
+	// encode encodes the corresponding attribute from Nexthop into RtAttr.
+	// It should return nil if the attribute is not set.
+	encode func(*Nexthop) *nl.RtAttr
+	// decode decodes the corresponding attribute from RtAttr into Nexthop
+	// It must perform bounds check for the given attribute's data and does
+	// nothing if the attribute encoding is invalid.
+	decode func(*Nexthop, *nl.RtAttr)
+	// match reports whether the given Nexthop
+}{
+	unix.NHA_ID: {
+		encode: func(nh *Nexthop) *nl.RtAttr {
+			if nh.ID > 0 {
+				b := make([]byte, 4)
+				native.PutUint32(b, nh.ID)
+				return nl.NewRtAttr(unix.NHA_ID, b)
+			}
+			return nil
+		},
+		decode: func(nh *Nexthop, attr *nl.RtAttr) {
+			if len(attr.Data) < 4 {
+				return
+			}
+			nh.ID = native.Uint32(attr.Data[0:4])
+		},
+	},
+	unix.NHA_BLACKHOLE: {
+		encode: func(nh *Nexthop) *nl.RtAttr {
+			if nh.Blackhole {
+				return nl.NewRtAttr(unix.NHA_BLACKHOLE, nil)
+			}
+			return nil
+		},
+		decode: func(nh *Nexthop, attr *nl.RtAttr) {
+			nh.Blackhole = true
+		},
+	},
+	unix.NHA_OIF: {
+		encode: func(nh *Nexthop) *nl.RtAttr {
+			if nh.OIF > 0 {
+				b := make([]byte, 4)
+				native.PutUint32(b, nh.OIF)
+				return nl.NewRtAttr(unix.NHA_OIF, b)
+			}
+			return nil
+		},
+		decode: func(nh *Nexthop, attr *nl.RtAttr) {
+			if len(attr.Data) < 4 {
+				return
+			}
+			nh.OIF = native.Uint32(attr.Data[0:4])
+		},
+	},
+	unix.NHA_GATEWAY: {
+		encode: func(nh *Nexthop) *nl.RtAttr {
+			if nh.Gateway != nil {
+				if gw4 := nh.Gateway.To4(); gw4 != nil {
+					return nl.NewRtAttr(unix.NHA_GATEWAY, gw4)
+				}
+				return nl.NewRtAttr(unix.NHA_GATEWAY, nh.Gateway)
+			}
+			return nil
+		},
+		decode: func(nh *Nexthop, attr *nl.RtAttr) {
+			if len(attr.Data) != 0 {
+				nh.Gateway = make(net.IP, len(attr.Data))
+				copy(nh.Gateway, attr.Data)
+			}
+		},
+	},
+}
+
+// encodeNexthopAttrs encodes the attributes in the Nexthop into the slice of
+// RtAttr. The targetAttrs specifies which attributes to encode. This is needed
+// because for each operations, there are different supported attributes.
+func encodeNexthopAttrs(nh *Nexthop, targetAttrs []uint16) []*nl.RtAttr {
+	var rtAttrs []*nl.RtAttr
+
+	for _, attrType := range targetAttrs {
+		handler, found := nexthopAttrHandlers[attrType]
+		if !found || handler.encode == nil {
+			continue
+		}
+		attr := handler.encode(nh)
+		if attr != nil {
+			rtAttrs = append(rtAttrs, attr)
+		}
+	}
+
+	return rtAttrs
+}
+
+// decodeNexthopAttrs decodes the attributes in the slice of RtAttr into the
+// Nexthop.
+func decodeNexthopAttrs(nh *Nexthop, attrs []*nl.RtAttr) {
+	for _, attr := range attrs {
+		handler, found := nexthopAttrHandlers[attr.Type]
+		if !found || handler.decode == nil {
+			continue
+		}
+		handler.decode(nh, attr)
+	}
+}
+
+func parseNhmsg(m []byte) (*Nexthop, error) {
+	msg := nl.DeserializeNhmsg(m)
+
+	rawAttrs, err := nl.ParseRouteAttr(m[msg.Len():])
+	if err != nil {
+		return nil, err
+	}
+
+	rtAttrs := make([]*nl.RtAttr, 0, len(rawAttrs))
+	for _, rawAttr := range rawAttrs {
+		rtAttrs = append(rtAttrs, nl.NewRtAttr(int(rawAttr.Attr.Type), rawAttr.Value))
+	}
+
+	nh := &Nexthop{
+		Protocol: RouteProtocol(msg.Protocol),
+	}
+
+	decodeNexthopAttrs(nh, rtAttrs)
+
+	return nh, nil
+}
+
+func deriveFamilyFromNexthop(nh *Nexthop) uint8 {
+	if nh.Gateway == nil || nh.Gateway.To4() != nil {
+		return FAMILY_V4
+	}
+	return FAMILY_V6
+}
+
+func prepareNewNexthop(nh *Nexthop, req *nl.NetlinkRequest, msg *nl.Nhmsg) error {
+	var rtAttrs []*nl.RtAttr
+
+	// We can find the supported attributes from the kernel source code:
+	// https://github.com/torvalds/linux/blob/e53642b87a4f4b03a8d7e5f8507fc3cd0c595ea6/net/ipv4/nexthop.c#L32
+	//
+	// We need a special handling for NHA_ID here as for the NEWNEXTHOP
+	// operation, the zero ID is allowed for ID auto allocation.
+	b := make([]byte, 4)
+	native.PutUint32(b, nh.ID)
+	rtAttrs = append(rtAttrs, nl.NewRtAttr(unix.NHA_ID, b))
+
+	rtAttrs = append(rtAttrs, encodeNexthopAttrs(nh, []uint16{
+		unix.NHA_BLACKHOLE,
+		unix.NHA_OIF,
+		unix.NHA_GATEWAY,
+	})...)
+
+	msg.Family = deriveFamilyFromNexthop(nh)
+	msg.Protocol = uint8(nh.Protocol)
+
+	req.AddData(msg)
+	for _, attr := range rtAttrs {
+		req.AddData(attr)
+	}
+
+	return nil
+}
+
+func prepareDelNexthop(nh *Nexthop, req *nl.NetlinkRequest, msg *nl.Nhmsg) error {
+	// We can find the supported attributes from the kernel source code:
+	// https://github.com/torvalds/linux/blob/e53642b87a4f4b03a8d7e5f8507fc3cd0c595ea6/net/ipv4/nexthop.c#L52
+	rtAttrs := encodeNexthopAttrs(nh, []uint16{
+		unix.NHA_ID,
+	})
+
+	msg.Family = deriveFamilyFromNexthop(nh)
+
+	req.AddData(msg)
+	for _, attr := range rtAttrs {
+		req.AddData(attr)
+	}
+
+	return nil
+}

--- a/nexthop_test.go
+++ b/nexthop_test.go
@@ -1,0 +1,155 @@
+//go:build linux
+// +build linux
+
+package netlink
+
+import (
+	"net"
+	"slices"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestNexthopAddListDelReplace(t *testing.T) {
+	t.Cleanup(setUpNetlinkTest(t))
+
+	// get loopback interface
+	loop, err := LinkByName("lo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// bring the interface up
+	if err = LinkSetUp(loop); err != nil {
+		t.Fatal(err)
+	}
+
+	// create dummy interface
+	if err = LinkAdd(&Dummy{LinkAttrs: LinkAttrs{Name: "dummy0"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	// get dummy interface
+	link0, err := LinkByName("dummy0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// bring the interface up
+	if err = LinkSetUp(link0); err != nil {
+		t.Fatal(err)
+	}
+
+	// Assign ip address to dummy interface
+	if err = AddrAdd(link0, &Addr{IPNet: &net.IPNet{
+		IP:   net.ParseIP("10.0.0.2"),
+		Mask: net.CIDRMask(24, 32),
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	nh0 := &Nexthop{
+		// Manually assign ID
+		ID:        1,
+		Blackhole: true,
+	}
+
+	nh1 := &Nexthop{
+		// Auto assign ID
+		ID:       0,
+		OIF:      uint32(link0.Attrs().Index),
+		Gateway:  net.ParseIP("fe80::1234:5678:9abc:def0"),
+		Protocol: unix.RTPROT_BGP,
+	}
+
+	// Test NexthopAdd
+	if err = NexthopAdd(nh0); err != nil {
+		t.Fatal(err)
+	}
+
+	if err = NexthopAdd(nh1); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test NexthopList
+	nhs, err := NexthopList()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nhs) != 2 {
+		t.Fatalf("Expected 2 nexthop, got %d", len(nhs))
+	}
+
+	// Check that the ID assignment (both manual and automatic) worked
+	if nhs[0].ID == nhs[1].ID {
+		t.Fatalf("Duplicate nexthop IDs found: %d", nhs[0].ID)
+	}
+	idx := slices.IndexFunc(nhs, func(nh Nexthop) bool { return nh.ID == nh0.ID })
+	if idx == -1 {
+		t.Fatal("Manually assigned nexthop ID not found")
+	}
+	if nhs[1-idx].ID == 0 {
+		t.Fatal("Nexthop ID was not auto assigned")
+	}
+
+	resNH0 := nhs[idx]
+	resNH1 := nhs[1-idx]
+
+	// Check we can read what we wrote
+	if resNH0.Blackhole != nh0.Blackhole {
+		t.Fatalf("Nexthop Blackhole mismatch: expected %v, got %v", nh0.Blackhole, resNH0.Blackhole)
+	}
+	if resNH1.OIF != nh1.OIF {
+		t.Fatalf("Nexthop OIF mismatch: expected %d, got %d", nh1.OIF, resNH1.OIF)
+	}
+	if !resNH1.Gateway.Equal(nh1.Gateway) {
+		t.Fatalf("Nexthop Gateway mismatch: expected %s, got %s", nh1.Gateway, resNH1.Gateway)
+	}
+	if resNH1.Protocol != nh1.Protocol {
+		t.Fatalf("Nexthop Protocol mismatch: expected %s, got %s", nh1.Protocol, resNH1.Protocol)
+	}
+
+	// Test NexthopDel
+	if err = NexthopDel(nh0); err != nil {
+		t.Fatal(err)
+	}
+	nhs, err = NexthopList()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nhs) != 1 {
+		t.Fatalf("Expected 1 nexthop, got %d", len(nhs))
+	}
+
+	// Test NexthopReplace
+	nh2 := &Nexthop{
+		// Replace nh1
+		ID:       resNH1.ID,
+		Protocol: unix.RTPROT_STATIC,
+		OIF:      uint32(link0.Attrs().Index),
+		Gateway:  net.ParseIP("10.0.0.1"),
+	}
+	if err = NexthopReplace(nh2); err != nil {
+		t.Fatal(err)
+	}
+	nhs, err = NexthopList()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nhs) != 1 {
+		t.Fatalf("Expected 1 nexthop, got %d", len(nhs))
+	}
+
+	// Check we can read what we wrote
+	resNH2 := nhs[0]
+	if resNH2.Protocol != nh2.Protocol {
+		t.Fatalf("Nexthop Protocol mismatch: expected %s, got %s", nh2.Protocol, resNH2.Protocol)
+	}
+	if resNH2.OIF != nh2.OIF {
+		t.Fatalf("Nexthop OIF mismatch: expected %d, got %d", nh2.OIF, resNH2.OIF)
+	}
+	if !resNH2.Gateway.Equal(nh2.Gateway) {
+		t.Fatalf("Nexthop Gateway mismatch: expected %s, got %s", nh2.Gateway, resNH2.Gateway)
+	}
+}

--- a/nl/nexthop_linux.go
+++ b/nl/nexthop_linux.go
@@ -1,0 +1,33 @@
+package nl
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	// This is a workaround for missing SizeofNhmsg in the
+	// golang.org/x/sys/unix. Once the SizeofNhmsg is added there, this
+	// constant can be removed.
+	sizeofNhmsg = 8
+)
+
+type Nhmsg struct {
+	unix.Nhmsg
+}
+
+func (msg *Nhmsg) Len() int {
+	return sizeofNhmsg
+}
+
+func DeserializeNhmsg(b []byte) *Nhmsg {
+	if len(b) < sizeofNhmsg {
+		return nil
+	}
+	return (*Nhmsg)(unsafe.Pointer(&b[0:sizeofNhmsg][0]))
+}
+
+func (msg *Nhmsg) Serialize() []byte {
+	return (*(*[sizeofNhmsg]byte)(unsafe.Pointer(msg)))[:]
+}

--- a/route.go
+++ b/route.go
@@ -100,6 +100,7 @@ type Route struct {
 	FastOpenNoCookie int
 	Expires          int
 	CacheInfo        *RouteCacheInfo
+	NHID             uint32
 }
 
 func (r Route) String() string {
@@ -133,6 +134,9 @@ func (r Route) String() string {
 	if r.Expires != 0 {
 		elems = append(elems, fmt.Sprintf("Expires: %dsec", r.Expires))
 	}
+	if r.NHID != 0 {
+		elems = append(elems, fmt.Sprintf("NHID: %d", r.NHID))
+	}
 	return fmt.Sprintf("{%s}", strings.Join(elems, " "))
 }
 
@@ -155,7 +159,8 @@ func (r Route) Equal(x Route) bool {
 		(r.MPLSDst == x.MPLSDst || (r.MPLSDst != nil && x.MPLSDst != nil && *r.MPLSDst == *x.MPLSDst)) &&
 		(r.NewDst == x.NewDst || (r.NewDst != nil && r.NewDst.Equal(x.NewDst))) &&
 		(r.Via == x.Via || (r.Via != nil && r.Via.Equal(x.Via))) &&
-		(r.Encap == x.Encap || (r.Encap != nil && r.Encap.Equal(x.Encap)))
+		(r.Encap == x.Encap || (r.Encap != nil && r.Encap.Equal(x.Encap))) &&
+		(r.NHID == x.NHID)
 }
 
 func (r *Route) SetFlag(flag NextHopFlag) {


### PR DESCRIPTION
Add a basic support of Linux's `ip nexthop` equivalent. In this PR, I specifically focused on implementing a minimal feature to accomplish IPv4 prefix with IPv6 (link-local) nexthop which is used by various implementation like FRR to support technique called BGP Unnumbered.

The summary of the new features are:
1. Introduce a low level primitive for nexthop in the `nl` package
2. Introduce NexthopAdd/Del/List/Replace APIs (supports NHA_ID/BLACKHOLE/GATEWAY, and protocol field)
3. Introduce NHID field to the Route object which allows attaching nexthop to routes.

Please review commit by commit. Thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full nexthop management: create, replace, delete, list; new Nexthop type with readable String().
  * Low-level nexthop message (Nhmsg) (de)serialization utilities.
  * Routes can reference nexthop IDs (NHID) with corresponding encoding support.

* **Bug Fixes / Reliability**
  * More robust Netlink error/message handling and improved nexthop processing on Linux.

* **Tests**
  * Added integration tests for nexthop add/list/delete/replace and route NHID handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->