### PR TITLE
nexthop: Support LWT encapsulation

### DIFF
--- a/nexthop.go
+++ b/nexthop.go
@@ -13,6 +13,7 @@ type Nexthop struct {
 	OIF       uint32
 	Gateway   net.IP
 	Protocol  RouteProtocol
+	Encap     Encap
 }
 
 func (h *Nexthop) String() string {
@@ -22,6 +23,12 @@ func (h *Nexthop) String() string {
 		"OIF: " + strconv.FormatUint(uint64(h.OIF), 10),
 		"Gateway: " + h.Gateway.String(),
 		"Protocol: " + h.Protocol.String(),
+		"Encap: " + func() string {
+			if h.Encap != nil {
+				return h.Encap.String()
+			}
+			return "<nil>"
+		}(),
 	}
 	return fmt.Sprintf("{%s}", strings.Join(elems, " "))
 }

--- a/nexthop_test.go
+++ b/nexthop_test.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/vishvananda/netlink/nl"
 	"golang.org/x/sys/unix"
 )
 
@@ -151,5 +152,62 @@ func TestNexthopAddListDelReplace(t *testing.T) {
 	}
 	if !resNH2.Gateway.Equal(nh2.Gateway) {
 		t.Fatalf("Nexthop Gateway mismatch: expected %s, got %s", nh2.Gateway, resNH2.Gateway)
+	}
+}
+
+func TestNexthopEncap(t *testing.T) {
+	t.Cleanup(setUpNetlinkTest(t))
+
+	// get loopback interface
+	loop, err := LinkByName("lo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// bring the interface up
+	if err = LinkSetUp(loop); err != nil {
+		t.Fatal(err)
+	}
+
+	nh := &Nexthop{
+		ID:  1,
+		OIF: uint32(loop.Attrs().Index),
+		Encap: &SEG6Encap{
+			Mode: nl.SEG6_IPTUN_MODE_ENCAP,
+			Segments: []net.IP{
+				net.ParseIP("2001:db8:1234::"),
+			},
+		},
+	}
+
+	if err = NexthopAdd(nh); err != nil {
+		t.Fatal(err)
+	}
+
+	nhs, err := NexthopList()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nhs) != 1 {
+		t.Fatalf("Expected 1 nexthop, got %d", len(nhs))
+	}
+
+	// Check we can read what we wrote
+	resNH := nhs[0]
+	if resNH.Encap == nil {
+		t.Fatal("Nexthop Encap is nil")
+	}
+	seg6Encap, ok := resNH.Encap.(*SEG6Encap)
+	if !ok {
+		t.Fatalf("Nexthop Encap is not SEG6Encap, got %T", resNH.Encap)
+	}
+	if seg6Encap.Mode != nl.SEG6_IPTUN_MODE_ENCAP {
+		t.Fatalf("Nexthop Encap Mode mismatch: expected %d, got %d", nl.SEG6_IPTUN_MODE_ENCAP, seg6Encap.Mode)
+	}
+	if len(seg6Encap.Segments) != 1 {
+		t.Fatalf("Expected 1 segment, got %d", len(seg6Encap.Segments))
+	}
+	if !seg6Encap.Segments[0].Equal(net.ParseIP("2001:db8:1234::")) {
+		t.Fatalf("Nexthop Encap Segment mismatch: expected %s, got %s", "2001:db8:1234::", seg6Encap.Segments[0])
 	}
 }

--- a/route_linux.go
+++ b/route_linux.go
@@ -1569,38 +1569,46 @@ func deserializeRoute(m []byte) (Route, error) {
 
 	if len(encap.Value) != 0 && len(encapType.Value) != 0 {
 		typ := int(native.Uint16(encapType.Value[0:2]))
-		var e Encap
-		switch typ {
-		case nl.LWTUNNEL_ENCAP_MPLS:
-			e = &MPLSEncap{}
-			if err := e.Decode(encap.Value); err != nil {
-				return route, err
-			}
-		case nl.LWTUNNEL_ENCAP_SEG6:
-			e = &SEG6Encap{}
-			if err := e.Decode(encap.Value); err != nil {
-				return route, err
-			}
-		case nl.LWTUNNEL_ENCAP_SEG6_LOCAL:
-			e = &SEG6LocalEncap{}
-			if err := e.Decode(encap.Value); err != nil {
-				return route, err
-			}
-		case nl.LWTUNNEL_ENCAP_BPF:
-			e = &BpfEncap{}
-			if err := e.Decode(encap.Value); err != nil {
-				return route, err
-			}
-		case nl.LWTUNNEL_ENCAP_IP6:
-			e = &IP6tnlEncap{}
-			if err := e.Decode(encap.Value); err != nil {
-				return route, err
-			}
+		e, err := decodeEncap(typ, encap.Value)
+		if err != nil {
+			return route, err
 		}
 		route.Encap = e
 	}
 
 	return route, nil
+}
+
+func decodeEncap(typ int, v []byte) (Encap, error) {
+	var e Encap
+	switch typ {
+	case nl.LWTUNNEL_ENCAP_MPLS:
+		e = &MPLSEncap{}
+		if err := e.Decode(v); err != nil {
+			return nil, err
+		}
+	case nl.LWTUNNEL_ENCAP_SEG6:
+		e = &SEG6Encap{}
+		if err := e.Decode(v); err != nil {
+			return nil, err
+		}
+	case nl.LWTUNNEL_ENCAP_SEG6_LOCAL:
+		e = &SEG6LocalEncap{}
+		if err := e.Decode(v); err != nil {
+			return nil, err
+		}
+	case nl.LWTUNNEL_ENCAP_BPF:
+		e = &BpfEncap{}
+		if err := e.Decode(v); err != nil {
+			return nil, err
+		}
+	case nl.LWTUNNEL_ENCAP_IP6:
+		e = &IP6tnlEncap{}
+		if err := e.Decode(v); err != nil {
+			return nil, err
+		}
+	}
+	return e, nil
 }
 
 // RouteGetOptions contains a set of options to use with


### PR DESCRIPTION
Add support for Light Weight Tunnel encapsulation in the nexthop object. Since the netlink encoding is exactly the same as the one for route, we can reuse most of the encoding/decoding code. What we needed to do was supporting NHA_ENCAP_TYPE and NHA_ENCAP types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added encapsulation support for nexthops with multiple encap types and ensured encapsulation is included when creating nexthops; route decoding now centralizes encap handling.
* **Bug Fixes**
  * Nexthop string output is now safe for nil receivers and shows encap presence or absence.
* **Tests**
  * Added tests for nexthop encapsulation and string handling to validate create/retrieve behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->