### PR TITLE
vdpa: support vdpa dev set mac

### DIFF
--- a/nl/vdpa_linux.go
+++ b/nl/vdpa_linux.go
@@ -14,6 +14,7 @@ const (
 	VDPA_CMD_DEV_GET        /* can dump */
 	VDPA_CMD_DEV_CONFIG_GET /* can dump */
 	VDPA_CMD_DEV_VSTATS_GET
+	VDPA_CMD_DEV_ATTR_SET
 )
 
 const (


### PR DESCRIPTION
The Linux kernel supports setting mac addresses to existing vdpa devices since 6.12. The feature was introduced by commit 2f87e9cf.

This commit brings support for that feature to the netlink library by introducing the `VDPASetAttr` function.

Note that even though setting the mac address is the only supported operation currently, the implementation has been left open for MTU, MaxVQP and Feature setting. In other words, it relies on whether the kernel supports it or not, and just feeds the kernel's error back to the caller. That way, no further changes will be needed in the future, if support for those operations is implemented.

Well... apart from tests, as they currently assume those are not supported.

This is implements a iproute's `vdpa dev set name <name> mac <mac>` equivalent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support to configure vDPA device attributes via netlink: MAC address, MTU, max virtual queue pairs, and device features.
* **Behavior Notes**
  * Attempts to set some attributes may currently return "not supported"; empty update requests are rejected.
* **Tests**
  * Added unit tests covering MAC updates, invalid device handling, empty-params rejection, and unsupported-attribute cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->