### PR TITLE
fix: gofmt

### DIFF
--- a/devlink_linux.go
+++ b/devlink_linux.go
@@ -858,7 +858,7 @@ func (h *Handle) DevlinkSplitPort(port *DevlinkPort, count uint32) error {
 }
 
 func DevlinkSplitPort(port *DevlinkPort, count uint32) error {
-	return pkgHandle.DevlinkSplitPort(port, count);
+	return pkgHandle.DevlinkSplitPort(port, count)
 }
 
 // DevlinkUnsplitPort: unsplit devlink port
@@ -876,7 +876,7 @@ func (h *Handle) DevlinkUnsplitPort(port *DevlinkPort) error {
 }
 
 func DevlinkUnsplitPort(port *DevlinkPort) error {
-	return pkgHandle.DevlinkUnsplitPort(port);
+	return pkgHandle.DevlinkUnsplitPort(port)
 }
 
 // DevlinkSetDeviceParam set specific parameter for devlink device


### PR DESCRIPTION
gofmt to fix build error:
```
make

! gofmt -l ./*.go | grep -q .
make: *** [fmt-.] Error 1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Minor code formatting adjustments to internal functions with no impact on functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->