### PR TITLE
fix: always set vxlan udpcsum attribute

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -1319,12 +1319,10 @@ func addVxlanAttrs(vxlan *Vxlan, linkInfo *nl.RtAttr) {
 	data.AddRtAttr(nl.IFLA_VXLAN_RSC, boolAttr(vxlan.RSC))
 	data.AddRtAttr(nl.IFLA_VXLAN_L2MISS, boolAttr(vxlan.L2miss))
 	data.AddRtAttr(nl.IFLA_VXLAN_L3MISS, boolAttr(vxlan.L3miss))
+	data.AddRtAttr(nl.IFLA_VXLAN_UDP_CSUM, boolAttr(vxlan.UDPCSum))
 	data.AddRtAttr(nl.IFLA_VXLAN_UDP_ZERO_CSUM6_TX, boolAttr(vxlan.UDP6ZeroCSumTx))
 	data.AddRtAttr(nl.IFLA_VXLAN_UDP_ZERO_CSUM6_RX, boolAttr(vxlan.UDP6ZeroCSumRx))
 
-	if vxlan.UDPCSum {
-		data.AddRtAttr(nl.IFLA_VXLAN_UDP_CSUM, boolAttr(vxlan.UDPCSum))
-	}
 	if vxlan.GBP {
 		data.AddRtAttr(nl.IFLA_VXLAN_GBP, []byte{})
 	}


### PR DESCRIPTION
fixes #1144

we should always explicitly set this attribute for consistency between kernel versions, since the default udpcsum behaviour changes between versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VXLAN network configuration to consistently communicate UDP checksum settings to the system, ensuring more reliable network tunnel behavior in all scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->