### PR TITLE
Migrate to net/netip

### DIFF
--- a/addr.go
+++ b/addr.go
@@ -2,19 +2,19 @@ package netlink
 
 import (
 	"fmt"
-	"net"
+	"net/netip"
 	"strings"
 )
 
 // Addr represents an IP address from netlink. Netlink ip addresses
-// include a mask, so it stores the address as a net.IPNet.
+// include a mask, so it stores the address as a netip.Prefix.
 type Addr struct {
-	*net.IPNet
+	netip.Prefix
 	Label       string
 	Flags       int
 	Scope       int
-	Peer        *net.IPNet
-	Broadcast   net.IP
+	Peer        netip.Prefix
+	Broadcast   netip.Addr
 	PreferedLft int
 	ValidLft    int
 	LinkIndex   int
@@ -22,7 +22,7 @@ type Addr struct {
 
 // String returns $ip/$netmask $label
 func (a Addr) String() string {
-	return strings.TrimSpace(fmt.Sprintf("%s %s", a.IPNet, a.Label))
+	return strings.TrimSpace(fmt.Sprintf("%s %s", a.Prefix, a.Label))
 }
 
 // ParseAddr parses the string representation of an address in the
@@ -38,20 +38,14 @@ func ParseAddr(s string) (*Addr, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Addr{IPNet: m, Label: label}, nil
+	return &Addr{Prefix: m, Label: label}, nil
 }
 
-// Equal returns true if both Addrs have the same net.IPNet value.
+// Equal returns true if both Addrs have the same netip.Prefix value.
 func (a Addr) Equal(x Addr) bool {
-	sizea, _ := a.Mask.Size()
-	sizeb, _ := x.Mask.Size()
-	// ignore label for comparison
-	return a.IP.Equal(x.IP) && sizea == sizeb
+	return a.Prefix == x.Prefix
 }
 
 func (a Addr) PeerEqual(x Addr) bool {
-	sizea, _ := a.Peer.Mask.Size()
-	sizeb, _ := x.Peer.Mask.Size()
-	// ignore label for comparison
-	return a.Peer.IP.Equal(x.Peer.IP) && sizea == sizeb
+	return a.Peer == x.Peer
 }

--- a/addr_linux.go
+++ b/addr_linux.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"syscall"
 
 	"github.com/vishvananda/netlink/nl"
@@ -17,7 +18,7 @@ import (
 //
 // If `addr` is an IPv4 address and the broadcast address is not given, it
 // will be automatically computed based on the IP mask if /30 or larger.
-// If `net.IPv4zero` is given as the broadcast address, broadcast is disabled.
+// If `0.0.0.0` is given as the broadcast address, broadcast is disabled.
 func AddrAdd(link Link, addr *Addr) error {
 	return pkgHandle.AddrAdd(link, addr)
 }
@@ -28,7 +29,7 @@ func AddrAdd(link Link, addr *Addr) error {
 //
 // If `addr` is an IPv4 address and the broadcast address is not given, it
 // will be automatically computed based on the IP mask if /30 or larger.
-// If `net.IPv4zero` is given as the broadcast address, broadcast is disabled.
+// If `0.0.0.0` is given as the broadcast address, broadcast is disabled.
 func (h *Handle) AddrAdd(link Link, addr *Addr) error {
 	req := h.newNetlinkRequest(unix.RTM_NEWADDR, unix.NLM_F_CREATE|unix.NLM_F_EXCL|unix.NLM_F_ACK)
 	return h.addrHandle(link, addr, req)
@@ -40,7 +41,7 @@ func (h *Handle) AddrAdd(link Link, addr *Addr) error {
 //
 // If `addr` is an IPv4 address and the broadcast address is not given, it
 // will be automatically computed based on the IP mask if /30 or larger.
-// If `net.IPv4zero` is given as the broadcast address, broadcast is disabled.
+// If `0.0.0.0` is given as the broadcast address, broadcast is disabled.
 func AddrReplace(link Link, addr *Addr) error {
 	return pkgHandle.AddrReplace(link, addr)
 }
@@ -51,7 +52,7 @@ func AddrReplace(link Link, addr *Addr) error {
 //
 // If `addr` is an IPv4 address and the broadcast address is not given, it
 // will be automatically computed based on the IP mask if /30 or larger.
-// If `net.IPv4zero` is given as the broadcast address, broadcast is disabled.
+// If `0.0.0.0` is given as the broadcast address, broadcast is disabled.
 func (h *Handle) AddrReplace(link Link, addr *Addr) error {
 	req := h.newNetlinkRequest(unix.RTM_NEWADDR, unix.NLM_F_CREATE|unix.NLM_F_REPLACE|unix.NLM_F_ACK)
 	return h.addrHandle(link, addr, req)
@@ -73,7 +74,7 @@ func (h *Handle) AddrDel(link Link, addr *Addr) error {
 }
 
 func (h *Handle) addrHandle(link Link, addr *Addr, req *nl.NetlinkRequest) error {
-	family := nl.GetIPFamily(addr.IP)
+	family := nl.GetIPFamily(addr.Addr())
 	msg := nl.NewIfAddrmsg(family)
 	msg.Scope = uint8(addr.Scope)
 	if link == nil {
@@ -83,30 +84,22 @@ func (h *Handle) addrHandle(link Link, addr *Addr, req *nl.NetlinkRequest) error
 		h.ensureIndex(base)
 		msg.Index = uint32(base.Index)
 	}
-	mask := addr.Mask
-	if addr.Peer != nil {
-		mask = addr.Peer.Mask
+
+	prefixlen := addr.Bits()
+	if addr.Peer.IsValid() {
+		prefixlen = addr.Peer.Bits()
 	}
-	prefixlen, masklen := mask.Size()
+
 	msg.Prefixlen = uint8(prefixlen)
 	req.AddData(msg)
 
-	var localAddrData []byte
-	if family == FAMILY_V4 {
-		localAddrData = addr.IP.To4()
-	} else {
-		localAddrData = addr.IP.To16()
-	}
+	localAddrData := addr.Addr().AsSlice()
 
 	localData := nl.NewRtAttr(unix.IFA_LOCAL, localAddrData)
 	req.AddData(localData)
 	var peerAddrData []byte
-	if addr.Peer != nil {
-		if family == FAMILY_V4 {
-			peerAddrData = addr.Peer.IP.To4()
-		} else {
-			peerAddrData = addr.Peer.IP.To16()
-		}
+	if addr.Peer.IsValid() {
+		peerAddrData = addr.Peer.Addr().AsSlice()
 	} else {
 		peerAddrData = localAddrData
 	}
@@ -129,20 +122,17 @@ func (h *Handle) addrHandle(link Link, addr *Addr, req *nl.NetlinkRequest) error
 		// Automatically set the broadcast address if it is unset and the
 		// subnet is large enough to sensibly have one (/30 or larger).
 		// See: RFC 3021
-		if addr.Broadcast == nil && prefixlen < 31 {
-			calcBroadcast := make(net.IP, masklen/8)
+		if !addr.Broadcast.IsValid() && prefixlen < 31 {
+			mask := net.CIDRMask(prefixlen, 32)
+			calcBroadcast := [4]byte{}
 			for i := range localAddrData {
 				calcBroadcast[i] = localAddrData[i] | ^mask[i]
 			}
-			addr.Broadcast = calcBroadcast
+			addr.Broadcast = netip.AddrFrom4(calcBroadcast)
 		}
 
-		if net.IPv4zero.Equal(addr.Broadcast) {
-			addr.Broadcast = nil
-		}
-
-		if addr.Broadcast != nil {
-			req.AddData(nl.NewRtAttr(unix.IFA_BROADCAST, addr.Broadcast))
+		if addr.Broadcast.IsValid() {
+			req.AddData(nl.NewRtAttr(unix.IFA_BROADCAST, addr.Broadcast.AsSlice()))
 		}
 
 		if addr.Label != "" {
@@ -236,27 +226,37 @@ func parseAddr(m []byte) (addr Addr, family int, err error) {
 	family = int(msg.Family)
 	addr.LinkIndex = int(msg.Index)
 
-	var local, dst *net.IPNet
+	var local, dst netip.Prefix
 	for _, attr := range attrs {
 		switch attr.Attr.Type {
 		case unix.IFA_ADDRESS:
-			dst = &net.IPNet{
-				IP:   attr.Value,
-				Mask: net.CIDRMask(int(msg.Prefixlen), 8*len(attr.Value)),
+			a, ok := netip.AddrFromSlice(attr.Value)
+			if !ok {
+				return Addr{}, 0, fmt.Errorf("IFA_ADDRESS: invalid address")
+			}
+			dst, err = a.Prefix(int(msg.Prefixlen))
+			if err != nil {
+				return Addr{}, 0, fmt.Errorf("IFA_ADDRESS: %w", err)
 			}
 		case unix.IFA_LOCAL:
+			a, ok := netip.AddrFromSlice(attr.Value)
+			if !ok {
+				return Addr{}, 0, fmt.Errorf("IFA_LOCAL: invalid address")
+			}
+
 			// iproute2 manual:
 			// If a peer address is specified, the local address
 			// cannot have a prefix length. The network prefix is
 			// associated with the peer rather than with the local
 			// address.
-			n := 8 * len(attr.Value)
-			local = &net.IPNet{
-				IP:   attr.Value,
-				Mask: net.CIDRMask(n, n),
-			}
+			local, _ = a.Prefix(a.BitLen())
 		case unix.IFA_BROADCAST:
-			addr.Broadcast = attr.Value
+			a, ok := netip.AddrFromSlice(attr.Value)
+			if !ok {
+				return Addr{}, 0, fmt.Errorf("IFA_BROADCAST: invalid address")
+			}
+
+			addr.Broadcast = a
 		case unix.IFA_LABEL:
 			addr.Label = string(attr.Value[:len(attr.Value)-1])
 		case unix.IFA_FLAGS:
@@ -275,15 +275,15 @@ func parseAddr(m []byte) (addr Addr, family int, err error) {
 	//
 	// But obviously, as there are IPv6 PtP addresses, too,
 	// IFA_LOCAL should also be handled for IPv6.
-	if local != nil {
-		if family == FAMILY_V4 && dst != nil && local.IP.Equal(dst.IP) {
-			addr.IPNet = dst
+	if local.IsValid() {
+		if family == FAMILY_V4 && dst.IsValid() && local.Addr() == dst.Addr() {
+			addr.Prefix = dst
 		} else {
-			addr.IPNet = local
+			addr.Prefix = local
 			addr.Peer = dst
 		}
 	} else {
-		addr.IPNet = dst
+		addr.Prefix = dst
 	}
 
 	addr.Scope = int(msg.Scope)
@@ -292,7 +292,7 @@ func parseAddr(m []byte) (addr Addr, family int, err error) {
 }
 
 type AddrUpdate struct {
-	LinkAddress net.IPNet
+	LinkAddress netip.Prefix
 	LinkIndex   int
 	Flags       int
 	Scope       int
@@ -416,7 +416,7 @@ func addrSubscribeAt(newNs, curNs netns.NsHandle, ch chan<- AddrUpdate, done <-c
 					continue
 				}
 
-				ch <- AddrUpdate{LinkAddress: *addr.IPNet,
+				ch <- AddrUpdate{LinkAddress: addr.Prefix,
 					LinkIndex:   addr.LinkIndex,
 					NewAddr:     msgType == unix.RTM_NEWADDR,
 					Flags:       addr.Flags,

--- a/bridge_linux_test.go
+++ b/bridge_linux_test.go
@@ -3,6 +3,7 @@ package netlink
 import (
 	"fmt"
 	"io/ioutil"
+	"net/netip"
 	"testing"
 )
 
@@ -97,7 +98,7 @@ func TestBridgeVlanTunnelInfo(t *testing.T) {
 	// ip link add vxlan0 type vxlan dstport 4789 nolearning external local 10.0.1.1
 	vxlan := &Vxlan{
 		// local
-		SrcAddr:  []byte("10.0.1.1"),
+		SrcAddr:  netip.MustParseAddr("10.0.1.1"),
 		Learning: false,
 		// external
 		FlowBased: true,

--- a/cmd/ipset-test/main.go
+++ b/cmd/ipset-test/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"net/netip"
 	"os"
 	"sort"
 
@@ -145,7 +146,8 @@ func cmdAddDel(f func(string, *netlink.IPSetEntry) error) func([]string) {
 func cmdTest(args []string) {
 	setName := args[0]
 	element := args[1]
-	ip := net.ParseIP(element)
+	ip, err := netip.ParseAddr(element)
+	check(err)
 	entry := &netlink.IPSetEntry{
 		Timeout: timeoutVal,
 		IP:      ip,

--- a/conntrack_linux.go
+++ b/conntrack_linux.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"net"
+	"net/netip"
 	"time"
 
 	"github.com/vishvananda/netlink/nl"
@@ -255,11 +255,11 @@ func (*ProtoInfoDCCP) Protocol() string { return "dccp" }
 // For the time being, the structure below allows to parse and extract the base information of a flow
 type IPTuple struct {
 	Bytes    uint64
-	DstIP    net.IP
+	DstIP    netip.Addr
 	DstPort  uint16
 	Packets  uint64
 	Protocol uint8
-	SrcIP    net.IP
+	SrcIP    netip.Addr
 	SrcPort  uint16
 }
 
@@ -279,9 +279,9 @@ func (t *IPTuple) toNlData(family uint8) ([]*nl.RtAttr, error) {
 	}
 
 	ctTupleIP := nl.NewRtAttr(unix.NLA_F_NESTED|nl.CTA_TUPLE_IP, nil)
-	ctTupleIPSrc := nl.NewRtAttr(srcIPsFlag, t.SrcIP)
+	ctTupleIPSrc := nl.NewRtAttr(srcIPsFlag, t.SrcIP.AsSlice())
 	ctTupleIP.AddChild(ctTupleIPSrc)
-	ctTupleIPDst := nl.NewRtAttr(dstIPsFlag, t.DstIP)
+	ctTupleIPDst := nl.NewRtAttr(dstIPsFlag, t.DstIP.AsSlice())
 	ctTupleIP.AddChild(ctTupleIPDst)
 
 	ctTupleProto := nl.NewRtAttr(unix.NLA_F_NESTED|nl.CTA_TUPLE_PROTO, nil)
@@ -421,9 +421,9 @@ func parseIpTuple(reader *bytes.Reader, tpl *IPTuple) uint8 {
 		_, t, _, v := parseNfAttrTLV(reader)
 		switch t {
 		case nl.CTA_IP_V4_SRC, nl.CTA_IP_V6_SRC:
-			tpl.SrcIP = v
+			tpl.SrcIP, _ = netip.AddrFromSlice(v)
 		case nl.CTA_IP_V4_DST, nl.CTA_IP_V6_DST:
-			tpl.DstIP = v
+			tpl.DstIP, _ = netip.AddrFromSlice(v)
 		}
 	}
 	// Get total length of nested protocol-specific info.
@@ -742,7 +742,7 @@ type CustomConntrackFilter interface {
 }
 
 type ConntrackFilter struct {
-	ipNetFilter map[ConntrackFilterType]*net.IPNet
+	ipNetFilter map[ConntrackFilterType]netip.Prefix
 	portFilter  map[ConntrackFilterType]uint16
 	protoFilter uint8
 	labelFilter map[ConntrackFilterType][][]byte
@@ -750,12 +750,12 @@ type ConntrackFilter struct {
 }
 
 // AddIPNet adds a IP subnet to the conntrack filter
-func (f *ConntrackFilter) AddIPNet(tp ConntrackFilterType, ipNet *net.IPNet) error {
-	if ipNet == nil {
+func (f *ConntrackFilter) AddIPNet(tp ConntrackFilterType, ipNet netip.Prefix) error {
+	if !ipNet.IsValid() {
 		return fmt.Errorf("Filter attribute empty")
 	}
 	if f.ipNetFilter == nil {
-		f.ipNetFilter = make(map[ConntrackFilterType]*net.IPNet)
+		f.ipNetFilter = make(map[ConntrackFilterType]netip.Prefix)
 	}
 	if _, ok := f.ipNetFilter[tp]; ok {
 		return errors.New("Filter attribute already present")
@@ -765,8 +765,8 @@ func (f *ConntrackFilter) AddIPNet(tp ConntrackFilterType, ipNet *net.IPNet) err
 }
 
 // AddIP adds an IP to the conntrack filter
-func (f *ConntrackFilter) AddIP(tp ConntrackFilterType, ip net.IP) error {
-	if ip == nil {
+func (f *ConntrackFilter) AddIP(tp ConntrackFilterType, ip netip.Addr) error {
+	if !ip.IsValid() {
 		return fmt.Errorf("Filter attribute empty")
 	}
 	return f.AddIPNet(tp, NewIPNet(ip))

--- a/conntrack_test.go
+++ b/conntrack_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
+	"net/netip"
 	"os"
 	"os/exec"
 	"runtime"
@@ -202,7 +203,7 @@ func TestConntrackTableList(t *testing.T) {
 	var found int
 	for _, flow := range flows {
 		if flow.Forward.Protocol == 17 &&
-			flow.Forward.DstIP.Equal(net.ParseIP("127.0.0.10")) &&
+			flow.Forward.DstIP == netip.MustParseAddr("127.0.0.10") &&
 			flow.Forward.DstPort == 3000 &&
 			(flow.Forward.SrcPort >= 2000 && flow.Forward.SrcPort <= 2005) {
 			found++
@@ -269,7 +270,7 @@ func TestConntrackTableFlush(t *testing.T) {
 	var found int
 	for _, flow := range flows {
 		if flow.Forward.Protocol == 17 &&
-			flow.Forward.DstIP.Equal(net.ParseIP("127.0.0.10")) &&
+			flow.Forward.DstIP == netip.MustParseAddr("127.0.0.10") &&
 			flow.Forward.DstPort == 4000 &&
 			(flow.Forward.SrcPort >= 3000 && flow.Forward.SrcPort <= 3005) {
 			found++
@@ -291,7 +292,7 @@ func TestConntrackTableFlush(t *testing.T) {
 	found = 0
 	for _, flow := range flows {
 		if flow.Forward.Protocol == 17 &&
-			flow.Forward.DstIP.Equal(net.ParseIP("127.0.0.10")) &&
+			flow.Forward.DstIP == netip.MustParseAddr("127.0.0.10") &&
 			flow.Forward.DstPort == 4000 &&
 			(flow.Forward.SrcPort >= 3000 && flow.Forward.SrcPort <= 3005) {
 			found++
@@ -343,13 +344,13 @@ func TestConntrackTableDelete(t *testing.T) {
 	var groupB int
 	for _, flow := range flows {
 		if flow.Forward.Protocol == 17 &&
-			flow.Forward.DstIP.Equal(net.ParseIP("127.0.0.10")) &&
+			flow.Forward.DstIP == netip.MustParseAddr("127.0.0.10") &&
 			flow.Forward.DstPort == 6000 &&
 			(flow.Forward.SrcPort >= 5000 && flow.Forward.SrcPort <= 5005) {
 			groupA++
 		}
 		if flow.Forward.Protocol == 17 &&
-			flow.Forward.DstIP.Equal(net.ParseIP("127.0.0.20")) &&
+			flow.Forward.DstIP == netip.MustParseAddr("127.0.0.20") &&
 			flow.Forward.DstPort == 8000 &&
 			(flow.Forward.SrcPort >= 7000 && flow.Forward.SrcPort <= 7005) {
 			groupB++
@@ -361,7 +362,7 @@ func TestConntrackTableDelete(t *testing.T) {
 
 	// Create a filter to erase groupB flows
 	filter := &ConntrackFilter{}
-	filter.AddIP(ConntrackOrigDstIP, net.ParseIP("127.0.0.20"))
+	filter.AddIP(ConntrackOrigDstIP, netip.MustParseAddr("127.0.0.20"))
 	filter.AddProtocol(17)
 	filter.AddPort(ConntrackOrigDstPort, 8000)
 
@@ -383,13 +384,13 @@ func TestConntrackTableDelete(t *testing.T) {
 	groupB = 0
 	for _, flow := range flows {
 		if flow.Forward.Protocol == 17 &&
-			flow.Forward.DstIP.Equal(net.ParseIP("127.0.0.10")) &&
+			flow.Forward.DstIP == netip.MustParseAddr("127.0.0.10") &&
 			flow.Forward.DstPort == 6000 &&
 			(flow.Forward.SrcPort >= 5000 && flow.Forward.SrcPort <= 5005) {
 			groupA++
 		}
 		if flow.Forward.Protocol == 17 &&
-			flow.Forward.DstIP.Equal(net.ParseIP("127.0.0.20")) &&
+			flow.Forward.DstIP == netip.MustParseAddr("127.0.0.20") &&
 			flow.Forward.DstPort == 8000 &&
 			(flow.Forward.SrcPort >= 7000 && flow.Forward.SrcPort <= 7005) {
 			groupB++
@@ -408,15 +409,15 @@ func TestConntrackFilter(t *testing.T) {
 	flowList = append(flowList, ConntrackFlow{
 		FamilyType: unix.AF_INET,
 		Forward: IPTuple{
-			SrcIP:    net.ParseIP("10.0.0.1"),
-			DstIP:    net.ParseIP("20.0.0.1"),
+			SrcIP:    netip.MustParseAddr("10.0.0.1"),
+			DstIP:    netip.MustParseAddr("20.0.0.1"),
 			SrcPort:  1000,
 			DstPort:  2000,
 			Protocol: 17,
 		},
 		Reverse: IPTuple{
-			SrcIP:    net.ParseIP("20.0.0.1"),
-			DstIP:    net.ParseIP("192.168.1.1"),
+			SrcIP:    netip.MustParseAddr("20.0.0.1"),
+			DstIP:    netip.MustParseAddr("192.168.1.1"),
 			SrcPort:  2000,
 			DstPort:  1000,
 			Protocol: 17,
@@ -425,15 +426,15 @@ func TestConntrackFilter(t *testing.T) {
 		ConntrackFlow{
 			FamilyType: unix.AF_INET,
 			Forward: IPTuple{
-				SrcIP:    net.ParseIP("10.0.0.2"),
-				DstIP:    net.ParseIP("20.0.0.2"),
+				SrcIP:    netip.MustParseAddr("10.0.0.2"),
+				DstIP:    netip.MustParseAddr("20.0.0.2"),
 				SrcPort:  5000,
 				DstPort:  6000,
 				Protocol: 6,
 			},
 			Reverse: IPTuple{
-				SrcIP:    net.ParseIP("20.0.0.2"),
-				DstIP:    net.ParseIP("192.168.1.1"),
+				SrcIP:    netip.MustParseAddr("20.0.0.2"),
+				DstIP:    netip.MustParseAddr("192.168.1.1"),
 				SrcPort:  6000,
 				DstPort:  5000,
 				Protocol: 6,
@@ -444,15 +445,15 @@ func TestConntrackFilter(t *testing.T) {
 		ConntrackFlow{
 			FamilyType: unix.AF_INET6,
 			Forward: IPTuple{
-				SrcIP:    net.ParseIP("eeee:eeee:eeee:eeee:eeee:eeee:eeee:eeee"),
-				DstIP:    net.ParseIP("dddd:dddd:dddd:dddd:dddd:dddd:dddd:dddd"),
+				SrcIP:    netip.MustParseAddr("eeee:eeee:eeee:eeee:eeee:eeee:eeee:eeee"),
+				DstIP:    netip.MustParseAddr("dddd:dddd:dddd:dddd:dddd:dddd:dddd:dddd"),
 				SrcPort:  1000,
 				DstPort:  2000,
 				Protocol: 132,
 			},
 			Reverse: IPTuple{
-				SrcIP:    net.ParseIP("dddd:dddd:dddd:dddd:dddd:dddd:dddd:dddd"),
-				DstIP:    net.ParseIP("eeee:eeee:eeee:eeee:eeee:eeee:eeee:eeee"),
+				SrcIP:    netip.MustParseAddr("dddd:dddd:dddd:dddd:dddd:dddd:dddd:dddd"),
+				DstIP:    netip.MustParseAddr("eeee:eeee:eeee:eeee:eeee:eeee:eeee:eeee"),
 				SrcPort:  2000,
 				DstPort:  1000,
 				Protocol: 132,
@@ -470,11 +471,11 @@ func TestConntrackFilter(t *testing.T) {
 
 	// Adding same attribute should fail
 	filter := &ConntrackFilter{}
-	err := filter.AddIP(ConntrackOrigSrcIP, net.ParseIP("10.0.0.1"))
+	err := filter.AddIP(ConntrackOrigSrcIP, netip.MustParseAddr("10.0.0.1"))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if err := filter.AddIP(ConntrackOrigSrcIP, net.ParseIP("10.0.0.1")); err == nil {
+	if err := filter.AddIP(ConntrackOrigSrcIP, netip.MustParseAddr("10.0.0.1")); err == nil {
 		t.Fatalf("Error, it should fail adding same attribute to the filter")
 	}
 	err = filter.AddProtocol(6)
@@ -525,13 +526,13 @@ func TestConntrackFilter(t *testing.T) {
 
 	// SrcIP filter
 	filterV4 = &ConntrackFilter{}
-	err = filterV4.AddIP(ConntrackOrigSrcIP, net.ParseIP("10.0.0.1"))
+	err = filterV4.AddIP(ConntrackOrigSrcIP, netip.MustParseAddr("10.0.0.1"))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
 	filterV6 = &ConntrackFilter{}
-	err = filterV6.AddIP(ConntrackOrigSrcIP, net.ParseIP("eeee:eeee:eeee:eeee:eeee:eeee:eeee:eeee"))
+	err = filterV6.AddIP(ConntrackOrigSrcIP, netip.MustParseAddr("eeee:eeee:eeee:eeee:eeee:eeee:eeee:eeee"))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -543,13 +544,13 @@ func TestConntrackFilter(t *testing.T) {
 
 	// DstIp filter
 	filterV4 = &ConntrackFilter{}
-	err = filterV4.AddIP(ConntrackOrigDstIP, net.ParseIP("20.0.0.1"))
+	err = filterV4.AddIP(ConntrackOrigDstIP, netip.MustParseAddr("20.0.0.1"))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
 	filterV6 = &ConntrackFilter{}
-	err = filterV6.AddIP(ConntrackOrigDstIP, net.ParseIP("dddd:dddd:dddd:dddd:dddd:dddd:dddd:dddd"))
+	err = filterV6.AddIP(ConntrackOrigDstIP, netip.MustParseAddr("dddd:dddd:dddd:dddd:dddd:dddd:dddd:dddd"))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -561,13 +562,13 @@ func TestConntrackFilter(t *testing.T) {
 
 	// SrcIP for NAT
 	filterV4 = &ConntrackFilter{}
-	err = filterV4.AddIP(ConntrackReplySrcIP, net.ParseIP("20.0.0.1"))
+	err = filterV4.AddIP(ConntrackReplySrcIP, netip.MustParseAddr("20.0.0.1"))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
 	filterV6 = &ConntrackFilter{}
-	err = filterV6.AddIP(ConntrackReplySrcIP, net.ParseIP("dddd:dddd:dddd:dddd:dddd:dddd:dddd:dddd"))
+	err = filterV6.AddIP(ConntrackReplySrcIP, netip.MustParseAddr("dddd:dddd:dddd:dddd:dddd:dddd:dddd:dddd"))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -579,13 +580,13 @@ func TestConntrackFilter(t *testing.T) {
 
 	// DstIP for NAT
 	filterV4 = &ConntrackFilter{}
-	err = filterV4.AddIP(ConntrackReplyDstIP, net.ParseIP("192.168.1.1"))
+	err = filterV4.AddIP(ConntrackReplyDstIP, netip.MustParseAddr("192.168.1.1"))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
 	filterV6 = &ConntrackFilter{}
-	err = filterV6.AddIP(ConntrackReplyDstIP, net.ParseIP("dddd:dddd:dddd:dddd:dddd:dddd:dddd:dddd"))
+	err = filterV6.AddIP(ConntrackReplyDstIP, netip.MustParseAddr("dddd:dddd:dddd:dddd:dddd:dddd:dddd:dddd"))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -597,13 +598,13 @@ func TestConntrackFilter(t *testing.T) {
 
 	// AnyIp for Nat
 	filterV4 = &ConntrackFilter{}
-	err = filterV4.AddIP(ConntrackReplyAnyIP, net.ParseIP("192.168.1.1"))
+	err = filterV4.AddIP(ConntrackReplyAnyIP, netip.MustParseAddr("192.168.1.1"))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
 	filterV6 = &ConntrackFilter{}
-	err = filterV6.AddIP(ConntrackReplyAnyIP, net.ParseIP("eeee:eeee:eeee:eeee:eeee:eeee:eeee:eeee"))
+	err = filterV6.AddIP(ConntrackReplyAnyIP, netip.MustParseAddr("eeee:eeee:eeee:eeee:eeee:eeee:eeee:eeee"))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -1071,15 +1072,15 @@ func TestConntrackUpdateV4(t *testing.T) {
 	flow := ConntrackFlow{
 		FamilyType: FAMILY_V4,
 		Forward: IPTuple{
-			SrcIP:    net.IP{234, 234, 234, 234},
-			DstIP:    net.IP{123, 123, 123, 123},
+			SrcIP:    netip.MustParseAddr("234.234.234.234"),
+			DstIP:    netip.MustParseAddr("123.123.123.123"),
 			SrcPort:  48385,
 			DstPort:  53,
 			Protocol: unix.IPPROTO_TCP,
 		},
 		Reverse: IPTuple{
-			SrcIP:    net.IP{123, 123, 123, 123},
-			DstIP:    net.IP{234, 234, 234, 234},
+			SrcIP:    netip.MustParseAddr("123.123.123.123"),
+			DstIP:    netip.MustParseAddr("234.234.234.234"),
 			SrcPort:  53,
 			DstPort:  48385,
 			Protocol: unix.IPPROTO_TCP,
@@ -1109,7 +1110,7 @@ func TestConntrackUpdateV4(t *testing.T) {
 	}
 
 	filter := ConntrackFilter{
-		ipNetFilter: map[ConntrackFilterType]*net.IPNet{
+		ipNetFilter: map[ConntrackFilterType]netip.Prefix{
 			ConntrackOrigSrcIP:  NewIPNet(flow.Forward.SrcIP),
 			ConntrackOrigDstIP:  NewIPNet(flow.Forward.DstIP),
 			ConntrackReplySrcIP: NewIPNet(flow.Reverse.SrcIP),
@@ -1204,15 +1205,15 @@ func TestConntrackUpdateV6(t *testing.T) {
 	flow := ConntrackFlow{
 		FamilyType: FAMILY_V6,
 		Forward: IPTuple{
-			SrcIP:    net.ParseIP("2001:db8::68"),
-			DstIP:    net.ParseIP("2001:db9::32"),
+			SrcIP:    netip.MustParseAddr("2001:db8::68"),
+			DstIP:    netip.MustParseAddr("2001:db9::32"),
 			SrcPort:  48385,
 			DstPort:  53,
 			Protocol: unix.IPPROTO_TCP,
 		},
 		Reverse: IPTuple{
-			SrcIP:    net.ParseIP("2001:db9::32"),
-			DstIP:    net.ParseIP("2001:db8::68"),
+			SrcIP:    netip.MustParseAddr("2001:db9::32"),
+			DstIP:    netip.MustParseAddr("2001:db8::68"),
 			SrcPort:  53,
 			DstPort:  48385,
 			Protocol: unix.IPPROTO_TCP,
@@ -1242,7 +1243,7 @@ func TestConntrackUpdateV6(t *testing.T) {
 	}
 
 	filter := ConntrackFilter{
-		ipNetFilter: map[ConntrackFilterType]*net.IPNet{
+		ipNetFilter: map[ConntrackFilterType]netip.Prefix{
 			ConntrackOrigSrcIP:  NewIPNet(flow.Forward.SrcIP),
 			ConntrackOrigDstIP:  NewIPNet(flow.Forward.DstIP),
 			ConntrackReplySrcIP: NewIPNet(flow.Reverse.SrcIP),
@@ -1335,15 +1336,15 @@ func TestConntrackCreateV4(t *testing.T) {
 	flow := ConntrackFlow{
 		FamilyType: FAMILY_V4,
 		Forward: IPTuple{
-			SrcIP:    net.IP{234, 234, 234, 234},
-			DstIP:    net.IP{123, 123, 123, 123},
+			SrcIP:    netip.MustParseAddr("234.234.234.234"),
+			DstIP:    netip.MustParseAddr("123.123.123.123"),
 			SrcPort:  48385,
 			DstPort:  53,
 			Protocol: unix.IPPROTO_TCP,
 		},
 		Reverse: IPTuple{
-			SrcIP:    net.IP{123, 123, 123, 123},
-			DstIP:    net.IP{234, 234, 234, 234},
+			SrcIP:    netip.MustParseAddr("123.123.123.123"),
+			DstIP:    netip.MustParseAddr("234.234.234.234"),
 			SrcPort:  53,
 			DstPort:  48385,
 			Protocol: unix.IPPROTO_TCP,
@@ -1368,7 +1369,7 @@ func TestConntrackCreateV4(t *testing.T) {
 	}
 
 	filter := ConntrackFilter{
-		ipNetFilter: map[ConntrackFilterType]*net.IPNet{
+		ipNetFilter: map[ConntrackFilterType]netip.Prefix{
 			ConntrackOrigSrcIP:  NewIPNet(flow.Forward.SrcIP),
 			ConntrackOrigDstIP:  NewIPNet(flow.Forward.DstIP),
 			ConntrackReplySrcIP: NewIPNet(flow.Reverse.SrcIP),
@@ -1430,15 +1431,15 @@ func TestConntrackCreateV6(t *testing.T) {
 	flow := ConntrackFlow{
 		FamilyType: FAMILY_V6,
 		Forward: IPTuple{
-			SrcIP:    net.ParseIP("2001:db8::68"),
-			DstIP:    net.ParseIP("2001:db9::32"),
+			SrcIP:    netip.MustParseAddr("2001:db8::68"),
+			DstIP:    netip.MustParseAddr("2001:db9::32"),
 			SrcPort:  48385,
 			DstPort:  53,
 			Protocol: unix.IPPROTO_TCP,
 		},
 		Reverse: IPTuple{
-			SrcIP:    net.ParseIP("2001:db9::32"),
-			DstIP:    net.ParseIP("2001:db8::68"),
+			SrcIP:    netip.MustParseAddr("2001:db9::32"),
+			DstIP:    netip.MustParseAddr("2001:db8::68"),
 			SrcPort:  53,
 			DstPort:  48385,
 			Protocol: unix.IPPROTO_TCP,
@@ -1463,7 +1464,7 @@ func TestConntrackCreateV6(t *testing.T) {
 	}
 
 	filter := ConntrackFilter{
-		ipNetFilter: map[ConntrackFilterType]*net.IPNet{
+		ipNetFilter: map[ConntrackFilterType]netip.Prefix{
 			ConntrackOrigSrcIP:  NewIPNet(flow.Forward.SrcIP),
 			ConntrackOrigDstIP:  NewIPNet(flow.Forward.DstIP),
 			ConntrackReplySrcIP: NewIPNet(flow.Reverse.SrcIP),
@@ -1504,15 +1505,15 @@ func TestConntrackFlowToNlData(t *testing.T) {
 	flowV4 := ConntrackFlow{
 		FamilyType: FAMILY_V4,
 		Forward: IPTuple{
-			SrcIP:    net.IP{234, 234, 234, 234},
-			DstIP:    net.IP{123, 123, 123, 123},
+			SrcIP:    netip.MustParseAddr("234.234.234.234"),
+			DstIP:    netip.MustParseAddr("123.123.123.123"),
 			SrcPort:  48385,
 			DstPort:  53,
 			Protocol: unix.IPPROTO_TCP,
 		},
 		Reverse: IPTuple{
-			SrcIP:    net.IP{123, 123, 123, 123},
-			DstIP:    net.IP{234, 234, 234, 234},
+			SrcIP:    netip.MustParseAddr("123.123.123.123"),
+			DstIP:    netip.MustParseAddr("234.234.234.234"),
 			SrcPort:  53,
 			DstPort:  48385,
 			Protocol: unix.IPPROTO_TCP,
@@ -1526,15 +1527,15 @@ func TestConntrackFlowToNlData(t *testing.T) {
 	flowV6 := ConntrackFlow{
 		FamilyType: FAMILY_V6,
 		Forward: IPTuple{
-			SrcIP:    net.ParseIP("2001:db8::68"),
-			DstIP:    net.ParseIP("2001:db9::32"),
+			SrcIP:    netip.MustParseAddr("2001:db8::68"),
+			DstIP:    netip.MustParseAddr("2001:db9::32"),
 			SrcPort:  48385,
 			DstPort:  53,
 			Protocol: unix.IPPROTO_TCP,
 		},
 		Reverse: IPTuple{
-			SrcIP:    net.ParseIP("2001:db9::32"),
-			DstIP:    net.ParseIP("2001:db8::68"),
+			SrcIP:    netip.MustParseAddr("2001:db9::32"),
+			DstIP:    netip.MustParseAddr("2001:db8::68"),
 			SrcPort:  53,
 			DstPort:  48385,
 			Protocol: unix.IPPROTO_TCP,
@@ -1621,11 +1622,11 @@ func tuplesEqual(t1, t2 IPTuple) bool {
 		return false
 	}
 
-	if !t1.DstIP.Equal(t2.DstIP) {
+	if t1.DstIP != t2.DstIP {
 		return false
 	}
 
-	if !t1.SrcIP.Equal(t2.SrcIP) {
+	if t1.SrcIP != t2.SrcIP {
 		return false
 	}
 

--- a/filter.go
+++ b/filter.go
@@ -3,6 +3,7 @@ package netlink
 import (
 	"fmt"
 	"net"
+	"net/netip"
 )
 
 type Filter interface {
@@ -317,8 +318,8 @@ const (
 type TunnelKeyAction struct {
 	ActionAttrs
 	Action   TunnelKeyAct
-	SrcAddr  net.IP
-	DstAddr  net.IP
+	SrcAddr  netip.Addr
+	DstAddr  netip.Addr
 	KeyID    uint32
 	DestPort uint16
 }
@@ -491,8 +492,8 @@ type PeditAction struct {
 	Proto      uint8
 	SrcMacAddr net.HardwareAddr
 	DstMacAddr net.HardwareAddr
-	SrcIP      net.IP
-	DstIP      net.IP
+	SrcIP      netip.Addr
+	DstIP      netip.Addr
 	SrcPort    uint16
 	DstPort    uint16
 }

--- a/filter_linux.go
+++ b/filter_linux.go
@@ -6,7 +6,9 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math/bits"
 	"net"
+	"net/netip"
 	"syscall"
 
 	"github.com/vishvananda/netlink/nl"
@@ -55,15 +57,11 @@ func (filter *U32) Type() string {
 type Flower struct {
 	FilterAttrs
 	ClassId         uint32
-	DestIP          net.IP
-	DestIPMask      net.IPMask
-	SrcIP           net.IP
-	SrcIPMask       net.IPMask
+	Dest            netip.Prefix
+	Src             netip.Prefix
 	EthType         uint16
-	EncDestIP       net.IP
-	EncDestIPMask   net.IPMask
-	EncSrcIP        net.IP
-	EncSrcIPMask    net.IPMask
+	EncDest         netip.Prefix
+	EncSrc          netip.Prefix
 	EncDestPort     uint16
 	EncKeyId        uint32
 	SrcMac          net.HardwareAddr
@@ -90,26 +88,18 @@ func (filter *Flower) Type() string {
 	return "flower"
 }
 
-func (filter *Flower) encodeIP(parent *nl.RtAttr, ip net.IP, mask net.IPMask, v4Type, v6Type int, v4MaskType, v6MaskType int) {
+func (filter *Flower) encodeIP(parent *nl.RtAttr, ip netip.Prefix, v4Type, v6Type int, v4MaskType, v6MaskType int) {
 	ipType := v4Type
 	maskType := v4MaskType
 
-	encodeMask := mask
-	if mask == nil {
-		encodeMask = net.CIDRMask(32, 32)
-	}
-	v4IP := ip.To4()
-	if v4IP == nil {
+	encodeMask := net.CIDRMask(ip.Bits(), ip.Addr().BitLen())
+
+	if ip.Addr().Is6() {
 		ipType = v6Type
 		maskType = v6MaskType
-		if mask == nil {
-			encodeMask = net.CIDRMask(128, 128)
-		}
-	} else {
-		ip = v4IP
 	}
 
-	parent.AddRtAttr(ipType, ip)
+	parent.AddRtAttr(ipType, ip.Addr().AsSlice())
 	parent.AddRtAttr(maskType, encodeMask)
 }
 
@@ -117,23 +107,23 @@ func (filter *Flower) encode(parent *nl.RtAttr) error {
 	if filter.EthType != 0 {
 		parent.AddRtAttr(nl.TCA_FLOWER_KEY_ETH_TYPE, htons(filter.EthType))
 	}
-	if filter.SrcIP != nil {
-		filter.encodeIP(parent, filter.SrcIP, filter.SrcIPMask,
+	if filter.Src.IsValid() {
+		filter.encodeIP(parent, filter.Src,
 			nl.TCA_FLOWER_KEY_IPV4_SRC, nl.TCA_FLOWER_KEY_IPV6_SRC,
 			nl.TCA_FLOWER_KEY_IPV4_SRC_MASK, nl.TCA_FLOWER_KEY_IPV6_SRC_MASK)
 	}
-	if filter.DestIP != nil {
-		filter.encodeIP(parent, filter.DestIP, filter.DestIPMask,
+	if filter.Dest.IsValid() {
+		filter.encodeIP(parent, filter.Dest,
 			nl.TCA_FLOWER_KEY_IPV4_DST, nl.TCA_FLOWER_KEY_IPV6_DST,
 			nl.TCA_FLOWER_KEY_IPV4_DST_MASK, nl.TCA_FLOWER_KEY_IPV6_DST_MASK)
 	}
-	if filter.EncSrcIP != nil {
-		filter.encodeIP(parent, filter.EncSrcIP, filter.EncSrcIPMask,
+	if filter.EncSrc.IsValid() {
+		filter.encodeIP(parent, filter.EncSrc,
 			nl.TCA_FLOWER_KEY_ENC_IPV4_SRC, nl.TCA_FLOWER_KEY_ENC_IPV6_SRC,
 			nl.TCA_FLOWER_KEY_ENC_IPV4_SRC_MASK, nl.TCA_FLOWER_KEY_ENC_IPV6_SRC_MASK)
 	}
-	if filter.EncDestIP != nil {
-		filter.encodeIP(parent, filter.EncDestIP, filter.EncSrcIPMask,
+	if filter.EncDest.IsValid() {
+		filter.encodeIP(parent, filter.EncDest,
 			nl.TCA_FLOWER_KEY_ENC_IPV4_DST, nl.TCA_FLOWER_KEY_ENC_IPV6_DST,
 			nl.TCA_FLOWER_KEY_ENC_IPV4_DST_MASK, nl.TCA_FLOWER_KEY_ENC_IPV6_DST_MASK)
 	}
@@ -207,26 +197,55 @@ func (filter *Flower) encode(parent *nl.RtAttr) error {
 }
 
 func (filter *Flower) decode(data []syscall.NetlinkRouteAttr) error {
+	var srcIP, dstIP, encSrcIP, encDstIP netip.Addr
+	var srcLen, dstLen, encSrcLen, encDstLen int
+
+	maskLen := func(d []byte) (r int) {
+		for _, v := range d {
+			r += bits.OnesCount8(v)
+		}
+		return
+	}
+
 	for _, datum := range data {
 		switch datum.Attr.Type {
 		case nl.TCA_FLOWER_KEY_ETH_TYPE:
 			filter.EthType = ntohs(datum.Value)
 		case nl.TCA_FLOWER_KEY_IPV4_SRC, nl.TCA_FLOWER_KEY_IPV6_SRC:
-			filter.SrcIP = datum.Value
+			addr, ok := netip.AddrFromSlice(datum.Value)
+			if !ok {
+				return fmt.Errorf("attr %d: invalid address", datum.Attr.Type)
+			}
+			srcIP = addr
 		case nl.TCA_FLOWER_KEY_IPV4_SRC_MASK, nl.TCA_FLOWER_KEY_IPV6_SRC_MASK:
-			filter.SrcIPMask = datum.Value
+			srcLen = maskLen(datum.Value)
 		case nl.TCA_FLOWER_KEY_IPV4_DST, nl.TCA_FLOWER_KEY_IPV6_DST:
-			filter.DestIP = datum.Value
+			addr, ok := netip.AddrFromSlice(datum.Value)
+			if !ok {
+				return fmt.Errorf("attr %d: invalid address", datum.Attr.Type)
+			}
+
+			dstIP = addr
 		case nl.TCA_FLOWER_KEY_IPV4_DST_MASK, nl.TCA_FLOWER_KEY_IPV6_DST_MASK:
-			filter.DestIPMask = datum.Value
+			dstLen = maskLen(datum.Value)
 		case nl.TCA_FLOWER_KEY_ENC_IPV4_SRC, nl.TCA_FLOWER_KEY_ENC_IPV6_SRC:
-			filter.EncSrcIP = datum.Value
+			addr, ok := netip.AddrFromSlice(datum.Value)
+			if !ok {
+				return fmt.Errorf("attr %d: invalid address", datum.Attr.Type)
+			}
+
+			encSrcIP = addr
 		case nl.TCA_FLOWER_KEY_ENC_IPV4_SRC_MASK, nl.TCA_FLOWER_KEY_ENC_IPV6_SRC_MASK:
-			filter.EncSrcIPMask = datum.Value
+			encSrcLen = maskLen(datum.Value)
 		case nl.TCA_FLOWER_KEY_ENC_IPV4_DST, nl.TCA_FLOWER_KEY_ENC_IPV6_DST:
-			filter.EncDestIP = datum.Value
+			addr, ok := netip.AddrFromSlice(datum.Value)
+			if !ok {
+				return fmt.Errorf("attr %d: invalid address", datum.Attr.Type)
+			}
+
+			encDstIP = addr
 		case nl.TCA_FLOWER_KEY_ENC_IPV4_DST_MASK, nl.TCA_FLOWER_KEY_ENC_IPV6_DST_MASK:
-			filter.EncDestIPMask = datum.Value
+			encDstLen = maskLen(datum.Value)
 		case nl.TCA_FLOWER_KEY_ENC_UDP_DST_PORT:
 			filter.EncDestPort = ntohs(datum.Value)
 		case nl.TCA_FLOWER_KEY_ENC_KEY_ID:
@@ -277,6 +296,36 @@ func (filter *Flower) decode(data []syscall.NetlinkRouteAttr) error {
 			filter.ClassId = native.Uint32(datum.Value)
 		}
 	}
+
+	var err error
+	if srcIP.IsValid() {
+		filter.Src, err = srcIP.Prefix(srcLen)
+		if err != nil {
+			return err
+		}
+	}
+
+	if dstIP.IsValid() {
+		filter.Dest, err = dstIP.Prefix(dstLen)
+		if err != nil {
+			return err
+		}
+	}
+
+	if encSrcIP.IsValid() {
+		filter.EncSrc, err = encSrcIP.Prefix(encSrcLen)
+		if err != nil {
+			return err
+		}
+	}
+
+	if encDstIP.IsValid() {
+		filter.EncDest, err = encDstIP.Prefix(encDstLen)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -698,17 +747,17 @@ func EncodeActions(attr *nl.RtAttr, actions []Action) error {
 			aopts.AddRtAttr(nl.TCA_TUNNEL_KEY_PARMS, tun.Serialize())
 			if action.Action == TCA_TUNNEL_KEY_SET {
 				aopts.AddRtAttr(nl.TCA_TUNNEL_KEY_ENC_KEY_ID, htonl(action.KeyID))
-				if v4 := action.SrcAddr.To4(); v4 != nil {
-					aopts.AddRtAttr(nl.TCA_TUNNEL_KEY_ENC_IPV4_SRC, v4[:])
-				} else if v6 := action.SrcAddr.To16(); v6 != nil {
-					aopts.AddRtAttr(nl.TCA_TUNNEL_KEY_ENC_IPV6_SRC, v6[:])
+				if action.SrcAddr.Is4() {
+					aopts.AddRtAttr(nl.TCA_TUNNEL_KEY_ENC_IPV4_SRC, action.SrcAddr.AsSlice())
+				} else if action.SrcAddr.Is6() {
+					aopts.AddRtAttr(nl.TCA_TUNNEL_KEY_ENC_IPV6_SRC, action.SrcAddr.AsSlice())
 				} else {
 					return fmt.Errorf("invalid src addr %s for tunnel_key action", action.SrcAddr)
 				}
-				if v4 := action.DstAddr.To4(); v4 != nil {
-					aopts.AddRtAttr(nl.TCA_TUNNEL_KEY_ENC_IPV4_DST, v4[:])
-				} else if v6 := action.DstAddr.To16(); v6 != nil {
-					aopts.AddRtAttr(nl.TCA_TUNNEL_KEY_ENC_IPV6_DST, v6[:])
+				if action.DstAddr.Is4() {
+					aopts.AddRtAttr(nl.TCA_TUNNEL_KEY_ENC_IPV4_DST, action.DstAddr.AsSlice())
+				} else if action.DstAddr.Is6() {
+					aopts.AddRtAttr(nl.TCA_TUNNEL_KEY_ENC_IPV6_DST, action.DstAddr.AsSlice())
 				} else {
 					return fmt.Errorf("invalid dst addr %s for tunnel_key action", action.DstAddr)
 				}
@@ -799,10 +848,10 @@ func EncodeActions(attr *nl.RtAttr, actions []Action) error {
 			if action.DstMacAddr != nil {
 				pedit.SetEthDst(action.DstMacAddr)
 			}
-			if action.SrcIP != nil {
+			if action.SrcIP.IsValid() {
 				pedit.SetSrcIP(action.SrcIP)
 			}
-			if action.DstIP != nil {
+			if action.DstIP.IsValid() {
 				pedit.SetDstIP(action.DstIP)
 			}
 			if action.SrcPort != 0 {
@@ -923,9 +972,9 @@ func parseActions(tables []syscall.NetlinkRouteAttr) ([]Action, error) {
 						case nl.TCA_TUNNEL_KEY_ENC_KEY_ID:
 							action.(*TunnelKeyAction).KeyID = networkOrder.Uint32(adatum.Value[0:4])
 						case nl.TCA_TUNNEL_KEY_ENC_IPV6_SRC, nl.TCA_TUNNEL_KEY_ENC_IPV4_SRC:
-							action.(*TunnelKeyAction).SrcAddr = adatum.Value[:]
+							action.(*TunnelKeyAction).SrcAddr, _ = netip.AddrFromSlice(adatum.Value)
 						case nl.TCA_TUNNEL_KEY_ENC_IPV6_DST, nl.TCA_TUNNEL_KEY_ENC_IPV4_DST:
-							action.(*TunnelKeyAction).DstAddr = adatum.Value[:]
+							action.(*TunnelKeyAction).DstAddr, _ = netip.AddrFromSlice(adatum.Value)
 						case nl.TCA_TUNNEL_KEY_ENC_DST_PORT:
 							action.(*TunnelKeyAction).DestPort = ntohs(adatum.Value)
 						case nl.TCA_TUNNEL_KEY_TM:

--- a/fou.go
+++ b/fou.go
@@ -1,16 +1,14 @@
 package netlink
 
-import (
-	"net"
-)
+import "net/netip"
 
 type Fou struct {
 	Family    int
 	Port      int
 	Protocol  int
 	EncapType int
-	Local     net.IP
-	Peer      net.IP
+	Local     netip.Addr
+	Peer      netip.Addr
 	PeerPort  int
 	IfIndex   int
 }

--- a/fou_linux.go
+++ b/fou_linux.go
@@ -6,7 +6,7 @@ package netlink
 import (
 	"encoding/binary"
 	"errors"
-	"net"
+	"net/netip"
 
 	"github.com/vishvananda/netlink/nl"
 	"golang.org/x/sys/unix"
@@ -189,9 +189,9 @@ func deserializeFouMsg(msg []byte) Fou {
 		case FOU_ATTR_TYPE:
 			fou.EncapType = int(attr.Value[0])
 		case FOU_ATTR_LOCAL_V4, FOU_ATTR_LOCAL_V6:
-			fou.Local = net.IP(attr.Value)
+			fou.Local, _ = netip.AddrFromSlice(attr.Value)
 		case FOU_ATTR_PEER_V4, FOU_ATTR_PEER_V6:
-			fou.Peer = net.IP(attr.Value)
+			fou.Peer, _ = netip.AddrFromSlice(attr.Value)
 		case FOU_ATTR_PEER_PORT:
 			fou.PeerPort = int(networkOrder.Uint16(attr.Value))
 		case FOU_ATTR_IFINDEX:

--- a/fou_test.go
+++ b/fou_test.go
@@ -4,7 +4,7 @@
 package netlink
 
 import (
-	"net"
+	"net/netip"
 	"testing"
 )
 
@@ -54,11 +54,11 @@ func TestFouDeserializeMsg(t *testing.T) {
 		t.Errorf("expected encap type %d, got %d", FOU_ENCAP_GUE, fou.EncapType)
 	}
 
-	if expected := net.IPv4(1, 2, 3, 4); !fou.Local.Equal(expected) {
+	if expected := netip.MustParseAddr("1.2.3.4"); fou.Local != expected {
 		t.Errorf("expected local %v, got %v", expected, fou.Local)
 	}
 
-	if expected := net.IPv4(5, 6, 7, 8); !fou.Peer.Equal(expected) {
+	if expected := netip.MustParseAddr("5.6.7.8"); fou.Peer != expected {
 		t.Errorf("expected peer %v, got %v", expected, fou.Peer)
 	}
 

--- a/gtp_test.go
+++ b/gtp_test.go
@@ -4,7 +4,7 @@
 package netlink
 
 import (
-	"net"
+	"net/netip"
 	"testing"
 )
 
@@ -19,8 +19,8 @@ func TestPDPv0AddDel(t *testing.T) {
 		t.Fatal(err)
 	}
 	err = GTPPDPAdd(link, &PDP{
-		PeerAddress: net.ParseIP("1.1.1.1"),
-		MSAddress:   net.ParseIP("2.2.2.2"),
+		PeerAddress: netip.MustParseAddr("1.1.1.1"),
+		MSAddress:   netip.MustParseAddr("2.2.2.2"),
 		TID:         10,
 	})
 	if err != nil {
@@ -33,7 +33,7 @@ func TestPDPv0AddDel(t *testing.T) {
 	if len(list) != 1 {
 		t.Fatal("Failed to add v0 PDP")
 	}
-	pdp, err := GTPPDPByMSAddress(link, net.ParseIP("2.2.2.2"))
+	pdp, err := GTPPDPByMSAddress(link, netip.MustParseAddr("2.2.2.2"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,8 +71,8 @@ func TestPDPv1AddDel(t *testing.T) {
 		t.Fatal(err)
 	}
 	err = GTPPDPAdd(link, &PDP{
-		PeerAddress: net.ParseIP("1.1.1.1"),
-		MSAddress:   net.ParseIP("2.2.2.2"),
+		PeerAddress: netip.MustParseAddr("1.1.1.1"),
+		MSAddress:   netip.MustParseAddr("2.2.2.2"),
 		Version:     1,
 		ITEI:        10,
 		OTEI:        10,
@@ -87,7 +87,7 @@ func TestPDPv1AddDel(t *testing.T) {
 	if len(list) != 1 {
 		t.Fatal("Failed to add v1 PDP")
 	}
-	pdp, err := GTPPDPByMSAddress(link, net.ParseIP("2.2.2.2"))
+	pdp, err := GTPPDPByMSAddress(link, netip.MustParseAddr("2.2.2.2"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/handle_test.go
+++ b/handle_test.go
@@ -8,7 +8,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"net"
+	"net/netip"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -180,8 +180,8 @@ var (
 
 func getXfrmState(thread int) *XfrmState {
 	return &XfrmState{
-		Src:   net.IPv4(byte(192), byte(168), 1, byte(1+thread)),
-		Dst:   net.IPv4(byte(192), byte(168), 2, byte(1+thread)),
+		Src:   netip.AddrFrom4([4]byte{192, 168, 1, byte(1 + thread)}),
+		Dst:   netip.AddrFrom4([4]byte{192, 168, 2, byte(1 + thread)}),
 		Proto: XFRM_PROTO_AH,
 		Mode:  XFRM_MODE_TUNNEL,
 		Spi:   thread,
@@ -193,17 +193,19 @@ func getXfrmState(thread int) *XfrmState {
 }
 
 func getXfrmPolicy(thread int) *XfrmPolicy {
+	subnet, _ := netip.AddrFrom4([4]byte{10, 10, byte(thread), 0}).Prefix(24)
+
 	return &XfrmPolicy{
-		Src:     &net.IPNet{IP: net.IPv4(byte(10), byte(10), byte(thread), 0), Mask: []byte{255, 255, 255, 0}},
-		Dst:     &net.IPNet{IP: net.IPv4(byte(10), byte(10), byte(thread), 0), Mask: []byte{255, 255, 255, 0}},
+		Src:     subnet,
+		Dst:     subnet,
 		Proto:   17,
 		DstPort: 1234,
 		SrcPort: 5678,
 		Dir:     XFRM_DIR_OUT,
 		Tmpls: []XfrmPolicyTmpl{
 			{
-				Src:   net.IPv4(byte(192), byte(168), 1, byte(thread)),
-				Dst:   net.IPv4(byte(192), byte(168), 2, byte(thread)),
+				Src:   netip.AddrFrom4([4]byte{192, 168, 1, byte(thread)}),
+				Dst:   netip.AddrFrom4([4]byte{192, 168, 2, byte(thread)}),
 				Proto: XFRM_PROTO_ESP,
 				Mode:  XFRM_MODE_TUNNEL,
 			},

--- a/handle_unspecified.go
+++ b/handle_unspecified.go
@@ -5,6 +5,7 @@ package netlink
 
 import (
 	"net"
+	"net/netip"
 	"time"
 
 	"github.com/vishvananda/netns"
@@ -276,7 +277,7 @@ func (h *Handle) RouteDel(route *Route) error {
 	return ErrNotImplemented
 }
 
-func (h *Handle) RouteGet(destination net.IP) ([]Route, error) {
+func (h *Handle) RouteGet(destination netip.Addr) ([]Route, error) {
 	return nil, ErrNotImplemented
 }
 

--- a/ipset_linux_test.go
+++ b/ipset_linux_test.go
@@ -3,6 +3,7 @@ package netlink
 import (
 	"bytes"
 	"net"
+	"net/netip"
 	"os"
 	"testing"
 
@@ -142,7 +143,7 @@ func TestIpsetCreateListAddDelDestroy(t *testing.T) {
 		t.Errorf("expected timeout to be 3, but got '%d'", *results[0].Timeout)
 	}
 
-	ip := net.ParseIP("10.99.99.99")
+	ip := netip.MustParseAddr("10.99.99.99")
 	exist, err := IpsetTest("my-test-ipset-1", &IPSetEntry{
 		IP: ip,
 	})
@@ -193,7 +194,7 @@ func TestIpsetCreateListAddDelDestroy(t *testing.T) {
 
 	err = IpsetDel("my-test-ipset-1", &IPSetEntry{
 		Comment: "test comment",
-		IP:      net.ParseIP("10.99.99.99"),
+		IP:      netip.MustParseAddr("10.99.99.99"),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -244,7 +245,7 @@ func TestIpsetCreateListAddDelDestroyWithTestCases(t *testing.T) {
 			},
 			entry: &IPSetEntry{
 				Comment: "test comment",
-				IP:      net.ParseIP("10.99.99.99"),
+				IP:      netip.MustParseAddr("10.99.99.99"),
 				Replace: false,
 			},
 		},
@@ -261,7 +262,7 @@ func TestIpsetCreateListAddDelDestroyWithTestCases(t *testing.T) {
 			},
 			entry: &IPSetEntry{
 				Comment: "test comment",
-				IP:      net.ParseIP("10.99.99.0"),
+				IP:      netip.MustParseAddr("10.99.99.0"),
 				CIDR:    24,
 				Replace: false,
 			},
@@ -279,9 +280,9 @@ func TestIpsetCreateListAddDelDestroyWithTestCases(t *testing.T) {
 			},
 			entry: &IPSetEntry{
 				Comment: "test comment",
-				IP:      net.ParseIP("10.99.99.0"),
+				IP:      netip.MustParseAddr("10.99.99.0"),
 				CIDR:    24,
-				IP2:     net.ParseIP("10.99.0.0"),
+				IP2:     netip.MustParseAddr("10.99.0.0"),
 				CIDR2:   24,
 				Replace: false,
 			},
@@ -299,8 +300,8 @@ func TestIpsetCreateListAddDelDestroyWithTestCases(t *testing.T) {
 			},
 			entry: &IPSetEntry{
 				Comment: "test comment",
-				IP:      net.ParseIP("10.99.99.0"),
-				IP2:     net.ParseIP("10.99.0.0"),
+				IP:      netip.MustParseAddr("10.99.99.0"),
+				IP2:     netip.MustParseAddr("10.99.0.0"),
 				Replace: false,
 			},
 		},
@@ -317,7 +318,7 @@ func TestIpsetCreateListAddDelDestroyWithTestCases(t *testing.T) {
 			},
 			entry: &IPSetEntry{
 				Comment:  "test comment",
-				IP:       net.ParseIP("10.99.99.1"),
+				IP:       netip.MustParseAddr("10.99.99.1"),
 				Protocol: &protocalTCP,
 				Port:     &port,
 				Replace:  false,
@@ -336,9 +337,9 @@ func TestIpsetCreateListAddDelDestroyWithTestCases(t *testing.T) {
 			},
 			entry: &IPSetEntry{
 				Comment:  "test comment",
-				IP:       net.ParseIP("10.99.99.0"),
+				IP:       netip.MustParseAddr("10.99.99.0"),
 				CIDR:     24,
-				IP2:      net.ParseIP("10.99.0.0"),
+				IP2:      netip.MustParseAddr("10.99.0.0"),
 				CIDR2:    24,
 				Protocol: &protocalTCP,
 				Port:     &port,
@@ -375,7 +376,7 @@ func TestIpsetCreateListAddDelDestroyWithTestCases(t *testing.T) {
 			},
 			entry: &IPSetEntry{
 				Comment: "test comment",
-				IP:      net.ParseIP("10.99.99.0"),
+				IP:      netip.MustParseAddr("10.99.99.0"),
 				CIDR:    24,
 				IFace:   "eth0",
 				Replace: false,
@@ -394,7 +395,7 @@ func TestIpsetCreateListAddDelDestroyWithTestCases(t *testing.T) {
 			},
 			entry: &IPSetEntry{
 				Comment: "test comment",
-				IP:      net.ParseIP("10.99.99.0"),
+				IP:      netip.MustParseAddr("10.99.99.0"),
 				Mark:    &timeout,
 				Replace: false,
 			},
@@ -413,7 +414,7 @@ func TestIpsetCreateListAddDelDestroyWithTestCases(t *testing.T) {
 			},
 			entry: &IPSetEntry{
 				Comment: "test comment",
-				IP:      net.ParseIP("::1"),
+				IP:      netip.MustParseAddr("::1"),
 				CIDR:    128,
 				Replace: false,
 			},
@@ -432,9 +433,9 @@ func TestIpsetCreateListAddDelDestroyWithTestCases(t *testing.T) {
 			},
 			entry: &IPSetEntry{
 				Comment: "test comment",
-				IP:      net.ParseIP("::1"),
+				IP:      netip.MustParseAddr("::1"),
 				CIDR:    128,
-				IP2:     net.ParseIP("::2"),
+				IP2:     netip.MustParseAddr("::2"),
 				CIDR2:   128,
 				Replace: false,
 			},
@@ -492,8 +493,8 @@ func TestIpsetCreateListAddDelDestroyWithTestCases(t *testing.T) {
 				t.Fatalf("expected 1 entry be created, got '%d'", len(result.Entries))
 			}
 
-			if tC.entry.IP != nil {
-				if !tC.entry.IP.Equal(result.Entries[0].IP) {
+			if tC.entry.IP.IsValid() {
+				if tC.entry.IP != result.Entries[0].IP {
 					t.Fatalf("expected entry to be '%v', got '%v'", tC.entry.IP, result.Entries[0].IP)
 				}
 			}
@@ -504,8 +505,8 @@ func TestIpsetCreateListAddDelDestroyWithTestCases(t *testing.T) {
 				}
 			}
 
-			if tC.entry.IP2 != nil {
-				if !tC.entry.IP2.Equal(result.Entries[0].IP2) {
+			if tC.entry.IP2.IsValid() {
+				if tC.entry.IP2 != result.Entries[0].IP2 {
 					t.Fatalf("expected entry.ip2 to be '%v', got '%v'", tC.entry.IP2, result.Entries[0].IP2)
 				}
 			}
@@ -603,7 +604,7 @@ func TestIpsetBitmapCreateListWithTestCases(t *testing.T) {
 			},
 			entry: &IPSetEntry{
 				Comment: "test comment",
-				IP:      net.ParseIP("10.99.99.0"),
+				IP:      netip.MustParseAddr("10.99.99.0"),
 				CIDR:    26,
 				Mark:    &timeout,
 				Replace: false,
@@ -630,7 +631,7 @@ func TestIpsetBitmapCreateListWithTestCases(t *testing.T) {
 					t.Fatalf("expected port range %d-%d, got %d-%d", tC.options.PortFrom, tC.options.PortTo, result.PortFrom, result.PortTo)
 				}
 			} else if tC.typename == "bitmap:ip" {
-				if result.IPFrom == nil || result.IPTo == nil || result.IPFrom.Equal(tC.options.IPFrom) || result.IPTo.Equal(tC.options.IPTo) {
+				if !result.IPFrom.IsValid() || !result.IPTo.IsValid() || result.IPFrom == tC.options.IPFrom || result.IPTo == tC.options.IPTo {
 					t.Fatalf("expected ip range %v-%v, got %v-%v", tC.options.IPFrom, tC.options.IPTo, result.IPFrom, result.IPTo)
 				}
 			}
@@ -666,7 +667,7 @@ func TestIpsetSwap(t *testing.T) {
 	}()
 
 	err = IpsetAdd(ipset1, &IPSetEntry{
-		IP: net.ParseIP("10.99.99.99"),
+		IP: netip.MustParseAddr("10.99.99.99"),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -707,15 +708,6 @@ func TestIpsetSwap(t *testing.T) {
 	assertHasOneEntry(ipset2)
 }
 
-func nextIP(ip net.IP) {
-	for j := len(ip) - 1; j >= 0; j-- {
-		ip[j]++
-		if ip[j] > 0 {
-			break
-		}
-	}
-}
-
 // TestIpsetMaxElements tests that we can create an ipset containing
 // 128k elements, which is double the default size (64k elements).
 func TestIpsetMaxElements(t *testing.T) {
@@ -735,7 +727,7 @@ func TestIpsetMaxElements(t *testing.T) {
 		_ = IpsetDestroy(ipsetName)
 	}()
 
-	ip := net.ParseIP("10.0.0.0")
+	ip := netip.MustParseAddr("10.0.0.0")
 	for i := uint32(0); i < maxElements; i++ {
 		err = IpsetAdd(ipsetName, &IPSetEntry{
 			IP: ip,
@@ -743,7 +735,7 @@ func TestIpsetMaxElements(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		nextIP(ip)
+		ip = ip.Next()
 	}
 
 	result, err := IpsetList(ipsetName)

--- a/link.go
+++ b/link.go
@@ -3,6 +3,7 @@ package netlink
 import (
 	"fmt"
 	"net"
+	"net/netip"
 	"os"
 	"strconv"
 )
@@ -488,8 +489,8 @@ type Vxlan struct {
 	LinkAttrs
 	VxlanId        int
 	VtepDevIndex   int
-	SrcAddr        net.IP
-	Group          net.IP
+	SrcAddr        netip.Addr
+	Group          netip.Addr
 	TTL            int
 	TOS            int
 	Learning       bool
@@ -898,7 +899,7 @@ type Bond struct {
 	DownDelay       int
 	UseCarrier      int
 	ArpInterval     int
-	ArpIpTargets    []net.IP
+	ArpIpTargets    []netip.Addr
 	ArpValidate     BondArpValidate
 	ArpAllTargets   BondArpAllTargets
 	Primary         int
@@ -1068,7 +1069,7 @@ func (v *VrfSlave) SlaveType() string {
 type Geneve struct {
 	LinkAttrs
 	ID                uint32 // vni
-	Remote            net.IP
+	Remote            netip.Addr
 	Ttl               uint8
 	Tos               uint8
 	Dport             uint16
@@ -1107,8 +1108,8 @@ type Gretap struct {
 	OKey       uint32
 	EncapSport uint16
 	EncapDport uint16
-	Local      net.IP
-	Remote     net.IP
+	Local      netip.Addr
+	Remote     netip.Addr
 	IFlags     uint16
 	OFlags     uint16
 	PMtuDisc   uint8
@@ -1125,7 +1126,7 @@ func (gretap *Gretap) Attrs() *LinkAttrs {
 }
 
 func (gretap *Gretap) Type() string {
-	if gretap.Local.To4() == nil {
+	if gretap.Local.Is6() {
 		return "ip6gretap"
 	}
 	return "gretap"
@@ -1137,8 +1138,8 @@ type Iptun struct {
 	Tos        uint8
 	PMtuDisc   uint8
 	Link       uint32
-	Local      net.IP
-	Remote     net.IP
+	Local      netip.Addr
+	Remote     netip.Addr
 	EncapSport uint16
 	EncapDport uint16
 	EncapType  uint16
@@ -1158,8 +1159,8 @@ func (iptun *Iptun) Type() string {
 type Ip6tnl struct {
 	LinkAttrs
 	Link       uint32
-	Local      net.IP
-	Remote     net.IP
+	Local      netip.Addr
+	Remote     netip.Addr
 	Ttl        uint8
 	Tos        uint8
 	Flags      uint32
@@ -1219,8 +1220,8 @@ type Sittun struct {
 	Tos        uint8
 	PMtuDisc   uint8
 	Proto      uint8
-	Local      net.IP
-	Remote     net.IP
+	Local      netip.Addr
+	Remote     netip.Addr
 	EncapLimit uint8
 	EncapType  uint16
 	EncapFlags uint16
@@ -1241,8 +1242,8 @@ type Vti struct {
 	IKey   uint32
 	OKey   uint32
 	Link   uint32
-	Local  net.IP
-	Remote net.IP
+	Local  netip.Addr
+	Remote netip.Addr
 }
 
 func (vti *Vti) Attrs() *LinkAttrs {
@@ -1250,7 +1251,7 @@ func (vti *Vti) Attrs() *LinkAttrs {
 }
 
 func (vti *Vti) Type() string {
-	if vti.Local.To4() == nil {
+	if vti.Local.Is6() {
 		return "vti6"
 	}
 	return "vti"
@@ -1263,8 +1264,8 @@ type Gretun struct {
 	OFlags     uint16
 	IKey       uint32
 	OKey       uint32
-	Local      net.IP
-	Remote     net.IP
+	Local      netip.Addr
+	Remote     netip.Addr
 	Ttl        uint8
 	Tos        uint8
 	PMtuDisc   uint8
@@ -1280,7 +1281,7 @@ func (gretun *Gretun) Attrs() *LinkAttrs {
 }
 
 func (gretun *Gretun) Type() string {
-	if gretun.Local.To4() == nil {
+	if gretun.Local.Is6() {
 		return "ip6gre"
 	}
 	return "gre"

--- a/link_linux.go
+++ b/link_linux.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"net/netip"
 	"os"
 	"strconv"
 	"strings"
@@ -1205,26 +1206,18 @@ func addVxlanAttrs(vxlan *Vxlan, linkInfo *nl.RtAttr) {
 	if vxlan.VtepDevIndex != 0 {
 		data.AddRtAttr(nl.IFLA_VXLAN_LINK, nl.Uint32Attr(uint32(vxlan.VtepDevIndex)))
 	}
-	if vxlan.SrcAddr != nil {
-		ip := vxlan.SrcAddr.To4()
-		if ip != nil {
-			data.AddRtAttr(nl.IFLA_VXLAN_LOCAL, []byte(ip))
+	if vxlan.SrcAddr.IsValid() {
+		if vxlan.SrcAddr.Is4() {
+			data.AddRtAttr(nl.IFLA_VXLAN_LOCAL, vxlan.SrcAddr.AsSlice())
 		} else {
-			ip = vxlan.SrcAddr.To16()
-			if ip != nil {
-				data.AddRtAttr(nl.IFLA_VXLAN_LOCAL6, []byte(ip))
-			}
+			data.AddRtAttr(nl.IFLA_VXLAN_LOCAL6, vxlan.SrcAddr.AsSlice())
 		}
 	}
-	if vxlan.Group != nil {
-		group := vxlan.Group.To4()
-		if group != nil {
-			data.AddRtAttr(nl.IFLA_VXLAN_GROUP, []byte(group))
+	if vxlan.Group.IsValid() {
+		if vxlan.Group.Is4() {
+			data.AddRtAttr(nl.IFLA_VXLAN_GROUP, vxlan.Group.AsSlice())
 		} else {
-			group = vxlan.Group.To16()
-			if group != nil {
-				data.AddRtAttr(nl.IFLA_VXLAN_GROUP6, []byte(group))
-			}
+			data.AddRtAttr(nl.IFLA_VXLAN_GROUP6, vxlan.Group.AsSlice())
 		}
 	}
 
@@ -1294,15 +1287,8 @@ func addBondAttrs(bond *Bond, linkInfo *nl.RtAttr) {
 	if bond.ArpIpTargets != nil {
 		msg := data.AddRtAttr(nl.IFLA_BOND_ARP_IP_TARGET, nil)
 		for i := range bond.ArpIpTargets {
-			ip := bond.ArpIpTargets[i].To4()
-			if ip != nil {
-				msg.AddRtAttr(i, []byte(ip))
-				continue
-			}
-			ip = bond.ArpIpTargets[i].To16()
-			if ip != nil {
-				msg.AddRtAttr(i, []byte(ip))
-			}
+			ip := bond.ArpIpTargets[i]
+			msg.AddRtAttr(i, ip.AsSlice())
 		}
 	}
 	if bond.ArpValidate >= 0 {
@@ -2968,13 +2954,13 @@ func parseVxlanData(link Link, data []syscall.NetlinkRouteAttr) {
 		case nl.IFLA_VXLAN_LINK:
 			vxlan.VtepDevIndex = int(native.Uint32(datum.Value[0:4]))
 		case nl.IFLA_VXLAN_LOCAL:
-			vxlan.SrcAddr = net.IP(datum.Value[0:4])
+			vxlan.SrcAddr, _ = netip.AddrFromSlice(datum.Value[0:4])
 		case nl.IFLA_VXLAN_LOCAL6:
-			vxlan.SrcAddr = net.IP(datum.Value[0:16])
+			vxlan.SrcAddr, _ = netip.AddrFromSlice(datum.Value[0:16])
 		case nl.IFLA_VXLAN_GROUP:
-			vxlan.Group = net.IP(datum.Value[0:4])
+			vxlan.Group, _ = netip.AddrFromSlice(datum.Value[0:4])
 		case nl.IFLA_VXLAN_GROUP6:
-			vxlan.Group = net.IP(datum.Value[0:16])
+			vxlan.Group, _ = netip.AddrFromSlice(datum.Value[0:16])
 		case nl.IFLA_VXLAN_TTL:
 			vxlan.TTL = int(datum.Value[0])
 		case nl.IFLA_VXLAN_TOS:
@@ -3079,21 +3065,17 @@ func parseBondData(link Link, data []syscall.NetlinkRouteAttr) {
 	}
 }
 
-func parseBondArpIpTargets(value []byte) []net.IP {
+func parseBondArpIpTargets(value []byte) []netip.Addr {
 	data, err := nl.ParseRouteAttr(value)
 	if err != nil {
 		return nil
 	}
 
-	targets := []net.IP{}
+	targets := []netip.Addr{}
 	for i := range data {
-		target := net.IP(data[i].Value)
-		if ip := target.To4(); ip != nil {
-			targets = append(targets, ip)
-			continue
-		}
-		if ip := target.To16(); ip != nil {
-			targets = append(targets, ip)
+		addr, ok := netip.AddrFromSlice(data[i].Value)
+		if ok {
+			targets = append(targets, addr)
 		}
 	}
 
@@ -3272,11 +3254,11 @@ func addGeneveAttrs(geneve *Geneve, linkInfo *nl.RtAttr) {
 		data.AddRtAttr(nl.IFLA_GENEVE_COLLECT_METADATA, []byte{})
 	}
 
-	if ip := geneve.Remote; ip != nil {
-		if ip4 := ip.To4(); ip4 != nil {
-			data.AddRtAttr(nl.IFLA_GENEVE_REMOTE, ip.To4())
+	if ip := geneve.Remote; ip.IsValid() {
+		if ip.Is4() {
+			data.AddRtAttr(nl.IFLA_GENEVE_REMOTE, ip.AsSlice())
 		} else {
-			data.AddRtAttr(nl.IFLA_GENEVE_REMOTE6, []byte(ip))
+			data.AddRtAttr(nl.IFLA_GENEVE_REMOTE6, ip.AsSlice())
 		}
 	}
 
@@ -3315,7 +3297,7 @@ func parseGeneveData(link Link, data []syscall.NetlinkRouteAttr) {
 		case nl.IFLA_GENEVE_ID:
 			geneve.ID = native.Uint32(datum.Value[0:4])
 		case nl.IFLA_GENEVE_REMOTE, nl.IFLA_GENEVE_REMOTE6:
-			geneve.Remote = datum.Value
+			geneve.Remote, _ = netip.AddrFromSlice(datum.Value)
 		case nl.IFLA_GENEVE_PORT:
 			geneve.Dport = ntohs(datum.Value[0:2])
 		case nl.IFLA_GENEVE_TTL:
@@ -3346,18 +3328,12 @@ func addGretapAttrs(gretap *Gretap, linkInfo *nl.RtAttr) {
 		return
 	}
 
-	if ip := gretap.Local; ip != nil {
-		if ip.To4() != nil {
-			ip = ip.To4()
-		}
-		data.AddRtAttr(nl.IFLA_GRE_LOCAL, []byte(ip))
+	if ip := gretap.Local; ip.IsValid() {
+		data.AddRtAttr(nl.IFLA_GRE_LOCAL, ip.AsSlice())
 	}
 
-	if ip := gretap.Remote; ip != nil {
-		if ip.To4() != nil {
-			ip = ip.To4()
-		}
-		data.AddRtAttr(nl.IFLA_GRE_REMOTE, []byte(ip))
+	if ip := gretap.Remote; ip.IsValid() {
+		data.AddRtAttr(nl.IFLA_GRE_REMOTE, ip.AsSlice())
 	}
 
 	if gretap.IKey != 0 {
@@ -3395,9 +3371,9 @@ func parseGretapData(link Link, data []syscall.NetlinkRouteAttr) {
 		case nl.IFLA_GRE_IKEY:
 			gre.OKey = ntohl(datum.Value[0:4])
 		case nl.IFLA_GRE_LOCAL:
-			gre.Local = net.IP(datum.Value)
+			gre.Local, _ = netip.AddrFromSlice(datum.Value)
 		case nl.IFLA_GRE_REMOTE:
-			gre.Remote = net.IP(datum.Value)
+			gre.Remote, _ = netip.AddrFromSlice(datum.Value)
 		case nl.IFLA_GRE_ENCAP_SPORT:
 			gre.EncapSport = ntohs(datum.Value[0:2])
 		case nl.IFLA_GRE_ENCAP_DPORT:
@@ -3431,18 +3407,12 @@ func addGretunAttrs(gre *Gretun, linkInfo *nl.RtAttr) {
 		return
 	}
 
-	if ip := gre.Local; ip != nil {
-		if ip.To4() != nil {
-			ip = ip.To4()
-		}
-		data.AddRtAttr(nl.IFLA_GRE_LOCAL, []byte(ip))
+	if ip := gre.Local; ip.IsValid() {
+		data.AddRtAttr(nl.IFLA_GRE_LOCAL, ip.AsSlice())
 	}
 
-	if ip := gre.Remote; ip != nil {
-		if ip.To4() != nil {
-			ip = ip.To4()
-		}
-		data.AddRtAttr(nl.IFLA_GRE_REMOTE, []byte(ip))
+	if ip := gre.Remote; ip.IsValid() {
+		data.AddRtAttr(nl.IFLA_GRE_REMOTE, ip.AsSlice())
 	}
 
 	if gre.IKey != 0 {
@@ -3480,9 +3450,9 @@ func parseGretunData(link Link, data []syscall.NetlinkRouteAttr) {
 		case nl.IFLA_GRE_OKEY:
 			gre.OKey = ntohl(datum.Value[0:4])
 		case nl.IFLA_GRE_LOCAL:
-			gre.Local = net.IP(datum.Value)
+			gre.Local, _ = netip.AddrFromSlice(datum.Value)
 		case nl.IFLA_GRE_REMOTE:
-			gre.Remote = net.IP(datum.Value)
+			gre.Remote, _ = netip.AddrFromSlice(datum.Value)
 		case nl.IFLA_GRE_IFLAGS:
 			gre.IFlags = ntohs(datum.Value[0:2])
 		case nl.IFLA_GRE_OFLAGS:
@@ -3551,14 +3521,12 @@ func addIptunAttrs(iptun *Iptun, linkInfo *nl.RtAttr) {
 		return
 	}
 
-	ip := iptun.Local.To4()
-	if ip != nil {
-		data.AddRtAttr(nl.IFLA_IPTUN_LOCAL, []byte(ip))
+	if iptun.Local.Is4() {
+		data.AddRtAttr(nl.IFLA_IPTUN_LOCAL, iptun.Local.AsSlice())
 	}
 
-	ip = iptun.Remote.To4()
-	if ip != nil {
-		data.AddRtAttr(nl.IFLA_IPTUN_REMOTE, []byte(ip))
+	if iptun.Remote.Is4() {
+		data.AddRtAttr(nl.IFLA_IPTUN_REMOTE, iptun.Remote.AsSlice())
 	}
 
 	if iptun.Link != 0 {
@@ -3579,9 +3547,9 @@ func parseIptunData(link Link, data []syscall.NetlinkRouteAttr) {
 	for _, datum := range data {
 		switch datum.Attr.Type {
 		case nl.IFLA_IPTUN_LOCAL:
-			iptun.Local = net.IP(datum.Value[0:4])
+			iptun.Local, _ = netip.AddrFromSlice(datum.Value[0:4])
 		case nl.IFLA_IPTUN_REMOTE:
-			iptun.Remote = net.IP(datum.Value[0:4])
+			iptun.Remote, _ = netip.AddrFromSlice(datum.Value[0:4])
 		case nl.IFLA_IPTUN_TTL:
 			iptun.Ttl = uint8(datum.Value[0])
 		case nl.IFLA_IPTUN_TOS:
@@ -3617,14 +3585,12 @@ func addIp6tnlAttrs(ip6tnl *Ip6tnl, linkInfo *nl.RtAttr) {
 		data.AddRtAttr(nl.IFLA_IPTUN_LINK, nl.Uint32Attr(ip6tnl.Link))
 	}
 
-	ip := ip6tnl.Local.To16()
-	if ip != nil {
-		data.AddRtAttr(nl.IFLA_IPTUN_LOCAL, []byte(ip))
+	if ip6tnl.Local.Is6() {
+		data.AddRtAttr(nl.IFLA_IPTUN_LOCAL, ip6tnl.Local.AsSlice())
 	}
 
-	ip = ip6tnl.Remote.To16()
-	if ip != nil {
-		data.AddRtAttr(nl.IFLA_IPTUN_REMOTE, []byte(ip))
+	if ip6tnl.Remote.Is6() {
+		data.AddRtAttr(nl.IFLA_IPTUN_REMOTE, ip6tnl.Remote.AsSlice())
 	}
 
 	data.AddRtAttr(nl.IFLA_IPTUN_TTL, nl.Uint8Attr(ip6tnl.Ttl))
@@ -3644,9 +3610,9 @@ func parseIp6tnlData(link Link, data []syscall.NetlinkRouteAttr) {
 	for _, datum := range data {
 		switch datum.Attr.Type {
 		case nl.IFLA_IPTUN_LOCAL:
-			ip6tnl.Local = net.IP(datum.Value[:16])
+			ip6tnl.Local, _ = netip.AddrFromSlice(datum.Value[:16])
 		case nl.IFLA_IPTUN_REMOTE:
-			ip6tnl.Remote = net.IP(datum.Value[:16])
+			ip6tnl.Remote, _ = netip.AddrFromSlice(datum.Value[:16])
 		case nl.IFLA_IPTUN_TTL:
 			ip6tnl.Ttl = datum.Value[0]
 		case nl.IFLA_IPTUN_TOS:
@@ -3680,14 +3646,12 @@ func addSittunAttrs(sittun *Sittun, linkInfo *nl.RtAttr) {
 		data.AddRtAttr(nl.IFLA_IPTUN_LINK, nl.Uint32Attr(sittun.Link))
 	}
 
-	ip := sittun.Local.To4()
-	if ip != nil {
-		data.AddRtAttr(nl.IFLA_IPTUN_LOCAL, []byte(ip))
+	if sittun.Local.Is4() {
+		data.AddRtAttr(nl.IFLA_IPTUN_LOCAL, sittun.Local.AsSlice())
 	}
 
-	ip = sittun.Remote.To4()
-	if ip != nil {
-		data.AddRtAttr(nl.IFLA_IPTUN_REMOTE, []byte(ip))
+	if sittun.Remote.Is4() {
+		data.AddRtAttr(nl.IFLA_IPTUN_REMOTE, sittun.Remote.AsSlice())
 	}
 
 	if sittun.Ttl > 0 {
@@ -3710,9 +3674,9 @@ func parseSittunData(link Link, data []syscall.NetlinkRouteAttr) {
 	for _, datum := range data {
 		switch datum.Attr.Type {
 		case nl.IFLA_IPTUN_LOCAL:
-			sittun.Local = net.IP(datum.Value[0:4])
+			sittun.Local, _ = netip.AddrFromSlice(datum.Value[0:4])
 		case nl.IFLA_IPTUN_REMOTE:
-			sittun.Remote = net.IP(datum.Value[0:4])
+			sittun.Remote, _ = netip.AddrFromSlice(datum.Value[0:4])
 		case nl.IFLA_IPTUN_TTL:
 			sittun.Ttl = datum.Value[0]
 		case nl.IFLA_IPTUN_TOS:
@@ -3736,29 +3700,12 @@ func parseSittunData(link Link, data []syscall.NetlinkRouteAttr) {
 func addVtiAttrs(vti *Vti, linkInfo *nl.RtAttr) {
 	data := linkInfo.AddRtAttr(nl.IFLA_INFO_DATA, nil)
 
-	family := FAMILY_V4
-	if vti.Local.To4() == nil {
-		family = FAMILY_V6
+	if vti.Local.IsValid() {
+		data.AddRtAttr(nl.IFLA_VTI_LOCAL, vti.Local.AsSlice())
 	}
 
-	var ip net.IP
-
-	if family == FAMILY_V4 {
-		ip = vti.Local.To4()
-	} else {
-		ip = vti.Local
-	}
-	if ip != nil {
-		data.AddRtAttr(nl.IFLA_VTI_LOCAL, []byte(ip))
-	}
-
-	if family == FAMILY_V4 {
-		ip = vti.Remote.To4()
-	} else {
-		ip = vti.Remote
-	}
-	if ip != nil {
-		data.AddRtAttr(nl.IFLA_VTI_REMOTE, []byte(ip))
+	if vti.Remote.IsValid() {
+		data.AddRtAttr(nl.IFLA_VTI_REMOTE, vti.Remote.AsSlice())
 	}
 
 	if vti.Link != 0 {
@@ -3774,9 +3721,9 @@ func parseVtiData(link Link, data []syscall.NetlinkRouteAttr) {
 	for _, datum := range data {
 		switch datum.Attr.Type {
 		case nl.IFLA_VTI_LOCAL:
-			vti.Local = net.IP(datum.Value)
+			vti.Local, _ = netip.AddrFromSlice(datum.Value)
 		case nl.IFLA_VTI_REMOTE:
-			vti.Remote = net.IP(datum.Value)
+			vti.Remote, _ = netip.AddrFromSlice(datum.Value)
 		case nl.IFLA_VTI_IKEY:
 			vti.IKey = ntohl(datum.Value[0:4])
 		case nl.IFLA_VTI_OKEY:

--- a/neigh.go
+++ b/neigh.go
@@ -3,6 +3,7 @@ package netlink
 import (
 	"fmt"
 	"net"
+	"net/netip"
 )
 
 // Neigh represents a link layer neighbor from netlink.
@@ -13,9 +14,9 @@ type Neigh struct {
 	Type         int
 	Flags        int
 	FlagsExt     int
-	IP           net.IP
+	IP           netip.Addr
 	HardwareAddr net.HardwareAddr
-	LLIPAddr     net.IP //Used in the case of NHRP
+	LLIPAddr     netip.Addr //Used in the case of NHRP
 	Vlan         int
 	VNI          int
 	MasterIndex  int

--- a/netlink.go
+++ b/netlink.go
@@ -10,7 +10,7 @@ package netlink
 
 import (
 	"errors"
-	"net"
+	"net/netip"
 )
 
 var (
@@ -18,23 +18,20 @@ var (
 	ErrNotImplemented = errors.New("not implemented")
 )
 
-// ParseIPNet parses a string in ip/net format and returns a net.IPNet.
+// ParseIPNet parses a string in ip/net format and returns a netip.Prefix.
 // This is valuable because addresses in netlink are often IPNets and
 // ParseCIDR returns an IPNet with the IP part set to the base IP of the
 // range.
-func ParseIPNet(s string) (*net.IPNet, error) {
-	ip, ipNet, err := net.ParseCIDR(s)
-	if err != nil {
-		return nil, err
-	}
-	ipNet.IP = ip
-	return ipNet, nil
+func ParseIPNet(s string) (netip.Prefix, error) {
+	return netip.ParsePrefix(s)
 }
 
 // NewIPNet generates an IPNet from an ip address using a netmask of 32 or 128.
-func NewIPNet(ip net.IP) *net.IPNet {
-	if ip.To4() != nil {
-		return &net.IPNet{IP: ip, Mask: net.CIDRMask(32, 32)}
-	}
-	return &net.IPNet{IP: ip, Mask: net.CIDRMask(128, 128)}
+func NewIPNet(ip netip.Addr) netip.Prefix {
+	return netip.PrefixFrom(ip, ip.BitLen())
 }
+
+var (
+	v4zero = netip.MustParseAddr("0.0.0.0")
+	v6zero = netip.MustParseAddr("::0")
+)

--- a/netlink_unspecified.go
+++ b/netlink_unspecified.go
@@ -3,7 +3,10 @@
 
 package netlink
 
-import "net"
+import (
+	"net"
+	"net/netip"
+)
 
 func LinkSetUp(link Link) error {
 	return ErrNotImplemented
@@ -217,7 +220,7 @@ func RouteDel(route *Route) error {
 	return ErrNotImplemented
 }
 
-func RouteGet(destination net.IP) ([]Route, error) {
+func RouteGet(destination netip.Addr) ([]Route, error) {
 	return nil, ErrNotImplemented
 }
 

--- a/nl/nl_linux.go
+++ b/nl/nl_linux.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"net"
 	"os"
 	"runtime"
 	"sync"
@@ -14,6 +13,8 @@ import (
 	"syscall"
 	"time"
 	"unsafe"
+
+	"net/netip"
 
 	"github.com/vishvananda/netns"
 	"golang.org/x/sys/unix"
@@ -67,14 +68,12 @@ func (e errDumpInterrupted) Is(target error) bool {
 	return target == unix.EINTR
 }
 
-// GetIPFamily returns the family type of a net.IP.
-func GetIPFamily(ip net.IP) int {
-	if len(ip) <= net.IPv4len {
+// GetIPFamily returns the family type of a netip.Addr.
+func GetIPFamily(ip netip.Addr) int {
+	if ip.Is4() {
 		return FAMILY_V4
 	}
-	if ip.To4() != nil {
-		return FAMILY_V4
-	}
+
 	return FAMILY_V6
 }
 

--- a/nl/tc_linux.go
+++ b/nl/tc_linux.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
+	"net/netip"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -1454,8 +1455,10 @@ func (p *TcPedit) SetEthSrc(mac net.HardwareAddr) {
 	p.Sel.NKeys++
 }
 
-func (p *TcPedit) SetIPv6Src(ip6 net.IP) {
-	u32 := NativeEndian().Uint32(ip6[:4])
+func (p *TcPedit) SetIPv6Src(ip6 netip.Addr) {
+	ip6s := ip6.As16()
+
+	u32 := NativeEndian().Uint32(ip6s[:4])
 
 	tKey := TcPeditKey{}
 	tKeyEx := TcPeditKeyEx{}
@@ -1469,7 +1472,7 @@ func (p *TcPedit) SetIPv6Src(ip6 net.IP) {
 	p.KeysEx = append(p.KeysEx, tKeyEx)
 	p.Sel.NKeys++
 
-	u32 = NativeEndian().Uint32(ip6[4:8])
+	u32 = NativeEndian().Uint32(ip6s[4:8])
 	tKey = TcPeditKey{}
 	tKeyEx = TcPeditKeyEx{}
 
@@ -1483,7 +1486,7 @@ func (p *TcPedit) SetIPv6Src(ip6 net.IP) {
 
 	p.Sel.NKeys++
 
-	u32 = NativeEndian().Uint32(ip6[8:12])
+	u32 = NativeEndian().Uint32(ip6s[8:12])
 	tKey = TcPeditKey{}
 	tKeyEx = TcPeditKeyEx{}
 
@@ -1497,7 +1500,7 @@ func (p *TcPedit) SetIPv6Src(ip6 net.IP) {
 
 	p.Sel.NKeys++
 
-	u32 = NativeEndian().Uint32(ip6[12:16])
+	u32 = NativeEndian().Uint32(ip6s[12:16])
 	tKey = TcPeditKey{}
 	tKeyEx = TcPeditKeyEx{}
 
@@ -1512,24 +1515,25 @@ func (p *TcPedit) SetIPv6Src(ip6 net.IP) {
 	p.Sel.NKeys++
 }
 
-func (p *TcPedit) SetDstIP(ip net.IP) {
-	if ip.To4() != nil {
+func (p *TcPedit) SetDstIP(ip netip.Addr) {
+	if ip.Is4() {
 		p.SetIPv4Dst(ip)
 	} else {
 		p.SetIPv6Dst(ip)
 	}
 }
 
-func (p *TcPedit) SetSrcIP(ip net.IP) {
-	if ip.To4() != nil {
+func (p *TcPedit) SetSrcIP(ip netip.Addr) {
+	if ip.Is4() {
 		p.SetIPv4Src(ip)
 	} else {
 		p.SetIPv6Src(ip)
 	}
 }
 
-func (p *TcPedit) SetIPv6Dst(ip6 net.IP) {
-	u32 := NativeEndian().Uint32(ip6[:4])
+func (p *TcPedit) SetIPv6Dst(ip6 netip.Addr) {
+	ip6s := ip6.As16()
+	u32 := NativeEndian().Uint32(ip6s[:4])
 
 	tKey := TcPeditKey{}
 	tKeyEx := TcPeditKeyEx{}
@@ -1543,7 +1547,7 @@ func (p *TcPedit) SetIPv6Dst(ip6 net.IP) {
 	p.KeysEx = append(p.KeysEx, tKeyEx)
 	p.Sel.NKeys++
 
-	u32 = NativeEndian().Uint32(ip6[4:8])
+	u32 = NativeEndian().Uint32(ip6s[4:8])
 	tKey = TcPeditKey{}
 	tKeyEx = TcPeditKeyEx{}
 
@@ -1557,7 +1561,7 @@ func (p *TcPedit) SetIPv6Dst(ip6 net.IP) {
 
 	p.Sel.NKeys++
 
-	u32 = NativeEndian().Uint32(ip6[8:12])
+	u32 = NativeEndian().Uint32(ip6s[8:12])
 	tKey = TcPeditKey{}
 	tKeyEx = TcPeditKeyEx{}
 
@@ -1571,7 +1575,7 @@ func (p *TcPedit) SetIPv6Dst(ip6 net.IP) {
 
 	p.Sel.NKeys++
 
-	u32 = NativeEndian().Uint32(ip6[12:16])
+	u32 = NativeEndian().Uint32(ip6s[12:16])
 	tKey = TcPeditKey{}
 	tKeyEx = TcPeditKeyEx{}
 
@@ -1586,8 +1590,8 @@ func (p *TcPedit) SetIPv6Dst(ip6 net.IP) {
 	p.Sel.NKeys++
 }
 
-func (p *TcPedit) SetIPv4Src(ip net.IP) {
-	u32 := NativeEndian().Uint32(ip.To4())
+func (p *TcPedit) SetIPv4Src(ip netip.Addr) {
+	u32 := NativeEndian().Uint32(ip.AsSlice())
 
 	tKey := TcPeditKey{}
 	tKeyEx := TcPeditKeyEx{}
@@ -1602,8 +1606,8 @@ func (p *TcPedit) SetIPv4Src(ip net.IP) {
 	p.Sel.NKeys++
 }
 
-func (p *TcPedit) SetIPv4Dst(ip net.IP) {
-	u32 := NativeEndian().Uint32(ip.To4())
+func (p *TcPedit) SetIPv4Dst(ip netip.Addr) {
+	u32 := NativeEndian().Uint32(ip.AsSlice())
 
 	tKey := TcPeditKey{}
 	tKeyEx := TcPeditKeyEx{}

--- a/route.go
+++ b/route.go
@@ -2,7 +2,7 @@ package netlink
 
 import (
 	"fmt"
-	"net"
+	"net/netip"
 	"strings"
 )
 
@@ -64,9 +64,9 @@ type Route struct {
 	LinkIndex        int
 	ILinkIndex       int
 	Scope            Scope
-	Dst              *net.IPNet
-	Src              net.IP
-	Gw               net.IP
+	Dst              netip.Prefix
+	Src              netip.Addr
+	Gw               netip.Addr
 	MultiPath        []*NexthopInfo
 	Protocol         RouteProtocol
 	Priority         int
@@ -140,9 +140,9 @@ func (r Route) Equal(x Route) bool {
 	return r.LinkIndex == x.LinkIndex &&
 		r.ILinkIndex == x.ILinkIndex &&
 		r.Scope == x.Scope &&
-		ipNetEqual(r.Dst, x.Dst) &&
-		r.Src.Equal(x.Src) &&
-		r.Gw.Equal(x.Gw) &&
+		r.Dst == x.Dst &&
+		r.Src == x.Src &&
+		r.Gw == x.Gw &&
 		nexthopInfoSlice(r.MultiPath).Equal(x.MultiPath) &&
 		r.Protocol == x.Protocol &&
 		r.Priority == x.Priority &&
@@ -187,7 +187,7 @@ type RouteUpdate struct {
 type NexthopInfo struct {
 	LinkIndex int
 	Hops      int
-	Gw        net.IP
+	Gw        netip.Addr
 	Flags     int
 	NewDst    Destination
 	Encap     Encap
@@ -215,7 +215,7 @@ func (n *NexthopInfo) String() string {
 func (n NexthopInfo) Equal(x NexthopInfo) bool {
 	return n.LinkIndex == x.LinkIndex &&
 		n.Hops == x.Hops &&
-		n.Gw.Equal(x.Gw) &&
+		n.Gw == x.Gw &&
 		n.Flags == x.Flags &&
 		(n.NewDst == x.NewDst || (n.NewDst != nil && n.NewDst.Equal(x.NewDst))) &&
 		(n.Encap == x.Encap || (n.Encap != nil && n.Encap.Equal(x.Encap)))
@@ -236,17 +236,4 @@ func (n nexthopInfoSlice) Equal(x []*NexthopInfo) bool {
 		}
 	}
 	return true
-}
-
-// ipNetEqual returns true iff both IPNet are equal
-func ipNetEqual(ipn1 *net.IPNet, ipn2 *net.IPNet) bool {
-	if ipn1 == ipn2 {
-		return true
-	}
-	if ipn1 == nil || ipn2 == nil {
-		return false
-	}
-	m1, _ := ipn1.Mask.Size()
-	m2, _ := ipn2.Mask.Size()
-	return m1 == m2 && ipn1.IP.Equal(ipn2.IP)
 }

--- a/rule.go
+++ b/rule.go
@@ -2,7 +2,7 @@ package netlink
 
 import (
 	"fmt"
-	"net"
+	"net/netip"
 )
 
 // Rule represents a netlink rule.
@@ -15,8 +15,8 @@ type Rule struct {
 	Tos               uint
 	TunID             uint
 	Goto              int
-	Src               *net.IPNet
-	Dst               *net.IPNet
+	Src               netip.Prefix
+	Dst               netip.Prefix
 	Flow              int
 	IifName           string
 	OifName           string
@@ -33,12 +33,12 @@ type Rule struct {
 
 func (r Rule) String() string {
 	from := "all"
-	if r.Src != nil && r.Src.String() != "<nil>" {
+	if r.Src.IsValid() {
 		from = r.Src.String()
 	}
 
 	to := "all"
-	if r.Dst != nil && r.Dst.String() != "<nil>" {
+	if r.Dst.IsValid() {
 		to = r.Dst.String()
 	}
 

--- a/socket.go
+++ b/socket.go
@@ -1,13 +1,13 @@
 package netlink
 
-import "net"
+import "net/netip"
 
 // SocketID identifies a single socket.
 type SocketID struct {
 	SourcePort      uint16
 	DestinationPort uint16
-	Source          net.IP
-	Destination     net.IP
+	Source          netip.Addr
+	Destination     netip.Addr
 	Interface       uint32
 	Cookie          [2]uint32
 }

--- a/socket_test.go
+++ b/socket_test.go
@@ -5,6 +5,7 @@ package netlink
 
 import (
 	"net"
+	"net/netip"
 	"os/user"
 	"strconv"
 	"syscall"
@@ -15,7 +16,7 @@ func TestSocketGet(t *testing.T) {
 	t.Cleanup(setUpNetlinkTestWithLoopback(t))
 
 	type Addr struct {
-		IP   net.IP
+		IP   netip.Addr
 		Port int
 	}
 
@@ -23,10 +24,10 @@ func TestSocketGet(t *testing.T) {
 		var addr Addr
 		switch v := a.(type) {
 		case *net.UDPAddr:
-			addr.IP = v.IP
+			addr.IP, _ = netip.AddrFromSlice(v.IP)
 			addr.Port = v.Port
 		case *net.TCPAddr:
-			addr.IP = v.IP
+			addr.IP, _ = netip.AddrFromSlice(v.IP)
 			addr.Port = v.Port
 		}
 		return addr
@@ -40,10 +41,10 @@ func TestSocketGet(t *testing.T) {
 
 		localAddr, remoteAddr := getAddr(local), getAddr(remote)
 
-		if got, want := socket.ID.Source, localAddr.IP; !got.Equal(want) {
+		if got, want := socket.ID.Source, localAddr.IP; got != want {
 			t.Fatalf("local ip = %v, want %v", got, want)
 		}
-		if got, want := socket.ID.Destination, remoteAddr.IP; !got.Equal(want) {
+		if got, want := socket.ID.Destination, remoteAddr.IP; got != want {
 			t.Fatalf("remote ip = %v, want %v", got, want)
 		}
 		if got, want := int(socket.ID.SourcePort), localAddr.Port; got != want {

--- a/xfrm_state_linux.go
+++ b/xfrm_state_linux.go
@@ -3,7 +3,7 @@ package netlink
 import (
 	"errors"
 	"fmt"
-	"net"
+	"net/netip"
 	"time"
 	"unsafe"
 
@@ -53,7 +53,7 @@ type XfrmStateEncap struct {
 	Type            EncapType
 	SrcPort         int
 	DstPort         int
-	OriginalAddress net.IP
+	OriginalAddress netip.Addr
 }
 
 func (e XfrmStateEncap) String() string {
@@ -102,8 +102,8 @@ func (r XfrmReplayState) String() string {
 // XfrmState represents the state of an ipsec policy. It optionally
 // contains an XfrmStateAlgo for encryption and one for authentication.
 type XfrmState struct {
-	Dst           net.IP
-	Src           net.IP
+	Dst           netip.Addr
+	Src           netip.Addr
 	Proto         Proto
 	Mode          Mode
 	Spi           int
@@ -461,8 +461,8 @@ func (h *Handle) xfrmStateGetOrDelete(state *XfrmState, nlProto int) (*XfrmState
 		out := nl.NewRtAttr(nl.XFRMA_MARK, writeMark(state.Mark))
 		req.AddData(out)
 	}
-	if state.Src != nil {
-		out := nl.NewRtAttr(nl.XFRMA_SRCADDR, state.Src.To16())
+	if state.Src.IsValid() {
+		out := nl.NewRtAttr(nl.XFRMA_SRCADDR, state.Src.AsSlice())
 		req.AddData(out)
 	}
 

--- a/xfrm_state_linux_test.go
+++ b/xfrm_state_linux_test.go
@@ -3,7 +3,7 @@ package netlink
 import (
 	"bytes"
 	"encoding/hex"
-	"net"
+	"net/netip"
 	"strings"
 	"testing"
 	"time"
@@ -90,8 +90,8 @@ func TestXfrmStateFlush(t *testing.T) {
 
 	state1 := getBaseState()
 	state2 := getBaseState()
-	state2.Src = net.ParseIP("127.1.0.1")
-	state2.Dst = net.ParseIP("127.1.0.2")
+	state2.Src = netip.MustParseAddr("127.1.0.1")
+	state2.Dst = netip.MustParseAddr("127.1.0.2")
 	state2.Proto = XFRM_PROTO_AH
 	state2.Mode = XFRM_MODE_TUNNEL
 	state2.Spi = 20
@@ -359,7 +359,7 @@ func TestXfrmStateWithOutputMarkAndMask(t *testing.T) {
 	}
 }
 func genStateSelectorForV6Payload() *XfrmPolicy {
-	_, wildcardV6Net, _ := net.ParseCIDR("::/0")
+	wildcardV6Net := netip.MustParsePrefix("::/0")
 	return &XfrmPolicy{
 		Src: wildcardV6Net,
 		Dst: wildcardV6Net,
@@ -367,7 +367,7 @@ func genStateSelectorForV6Payload() *XfrmPolicy {
 }
 
 func genStateSelectorForV4Payload() *XfrmPolicy {
-	_, wildcardV4Net, _ := net.ParseCIDR("0.0.0.0/0")
+	wildcardV4Net := netip.MustParsePrefix("0.0.0.0/0")
 	return &XfrmPolicy{
 		Src: wildcardV4Net,
 		Dst: wildcardV4Net,
@@ -377,8 +377,8 @@ func genStateSelectorForV4Payload() *XfrmPolicy {
 func getBaseState() *XfrmState {
 	return &XfrmState{
 		// Force 4 byte notation for the IPv4 addresses
-		Src:   net.ParseIP("127.0.0.1").To4(),
-		Dst:   net.ParseIP("127.0.0.2").To4(),
+		Src:   netip.MustParseAddr("127.0.0.1"),
+		Dst:   netip.MustParseAddr("127.0.0.2"),
 		Proto: XFRM_PROTO_ESP,
 		Mode:  XFRM_MODE_TUNNEL,
 		Spi:   1,
@@ -400,8 +400,8 @@ func getBaseState() *XfrmState {
 func getBaseStateV4oV6() *XfrmState {
 	return &XfrmState{
 		// Force 4 byte notation for the IPv4 addressesd
-		Src:   net.ParseIP("2001:dead::1").To16(),
-		Dst:   net.ParseIP("2001:beef::1").To16(),
+		Src:   netip.MustParseAddr("2001:dead::1"),
+		Dst:   netip.MustParseAddr("2001:beef::1"),
 		Proto: XFRM_PROTO_ESP,
 		Mode:  XFRM_MODE_TUNNEL,
 		Spi:   1,
@@ -424,8 +424,8 @@ func getBaseStateV4oV6() *XfrmState {
 func getBaseStateV6oV4() *XfrmState {
 	return &XfrmState{
 		// Force 4 byte notation for the IPv4 addressesd
-		Src:   net.ParseIP("192.168.1.1").To4(),
-		Dst:   net.ParseIP("192.168.2.2").To4(),
+		Src:   netip.MustParseAddr("192.168.1.1"),
+		Dst:   netip.MustParseAddr("192.168.2.2"),
 		Proto: XFRM_PROTO_ESP,
 		Mode:  XFRM_MODE_TUNNEL,
 		Spi:   1,
@@ -450,8 +450,8 @@ func getAeadState() *XfrmState {
 	k, _ := hex.DecodeString("d0562776bf0e75830ba3f7f8eb6c09b555aa1177")
 	return &XfrmState{
 		// Leave IPv4 addresses in Ipv4 in IPv6 notation
-		Src:   net.ParseIP("192.168.1.1"),
-		Dst:   net.ParseIP("192.168.2.2"),
+		Src:   netip.MustParseAddr("192.168.1.1"),
+		Dst:   netip.MustParseAddr("192.168.2.2"),
 		Proto: XFRM_PROTO_ESP,
 		Mode:  XFRM_MODE_TUNNEL,
 		Spi:   2,
@@ -484,7 +484,7 @@ func compareStates(a, b *XfrmState) bool {
 		}
 	}
 
-	return a.Src.Equal(b.Src) && a.Dst.Equal(b.Dst) &&
+	return a.Src == b.Src && a.Dst == b.Dst &&
 		a.Mode == b.Mode && a.Spi == b.Spi && a.Proto == b.Proto &&
 		a.Ifid == b.Ifid &&
 		compareAlgo(a.Auth, b.Auth) &&


### PR DESCRIPTION
This is a proposal on what migrating netlink to use the newer `net/netip`  package for IP and subnet types could look like.

## Why

* Address https://github.com/vishvananda/netlink/issues/1114
* Benefit from the `net/netip` improvements (an article on the topic: https://dev.to/rezmoss/understanding-gos-netnetip-addr-type-a-deep-dive-17-j7b)
*  Align netip with other network libs that have moved to this new implementation, such as https://github.com/osrg/gobgp v4

## Consideration

This change is big, some of it was tested but a large part was not. This is provided as a PoC, not release-qualiy change.

This is of course a breaking change to the public API for everything where the caller passes / receives IPs or subnets