### PR TITLE
filter: fix TCA_FLOWER_FLAGS endianness for little-endian systems

### DIFF
--- a/filter_linux.go
+++ b/filter_linux.go
@@ -197,7 +197,7 @@ func (filter *Flower) encode(parent *nl.RtAttr) error {
 	if filter.SkipSw {
 		flags |= nl.TCA_CLS_FLAGS_SKIP_SW
 	}
-	parent.AddRtAttr(nl.TCA_FLOWER_FLAGS, htonl(flags))
+	parent.AddRtAttr(nl.TCA_FLOWER_FLAGS, nl.Uint32Attr(flags))
 
 	actionsAttr := parent.AddRtAttr(nl.TCA_FLOWER_ACT, nil)
 	if err := EncodeActions(actionsAttr, filter.Actions); err != nil {


### PR DESCRIPTION
 ## Summary
  Fix incorrect byte order for `TCA_FLOWER_FLAGS` (skip_hw/skip_sw) on little-endian architectures.

  Fixes #1149

  ## Problem
  `htonl()` encodes flags in big-endian, but netlink `NLA_U32` attributes expect native endian. On x86, this flips `0x00000001` to `0x01000000`, causing
  `EINVAL` or flags being silently ignored.

  ## Fix
  ```diff
  - parent.AddRtAttr(nl.TCA_FLOWER_FLAGS, htonl(flags))
  + parent.AddRtAttr(nl.TCA_FLOWER_FLAGS, nl.Uint32Attr(flags))
   ```

  Testing

  - Verified flower filter with SkipHw: true now works correctly on x86_64
  - Matches tc CLI behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated network filter attribute encoding to use standard utility helpers for improved consistency and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->