### PR TITLE
devlink: move devlink structs to devlink.go

### DIFF
--- a/devlink.go
+++ b/devlink.go
@@ -1,0 +1,124 @@
+package netlink
+
+import "net"
+
+// DevlinkDevEswitchAttr represents device's eswitch attributes
+type DevlinkDevEswitchAttr struct {
+	Mode       string
+	InlineMode string
+	EncapMode  string
+}
+
+// DevlinkDevAttrs represents device attributes
+type DevlinkDevAttrs struct {
+	Eswitch DevlinkDevEswitchAttr
+}
+
+// DevlinkDevice represents device and its attributes
+type DevlinkDevice struct {
+	BusName    string
+	DeviceName string
+	Attrs      DevlinkDevAttrs
+}
+
+// DevlinkPortFn represents port function and its attributes
+type DevlinkPortFn struct {
+	HwAddr  net.HardwareAddr
+	State   uint8
+	OpState uint8
+}
+
+// DevlinkPortFnSetAttrs represents attributes to set
+type DevlinkPortFnSetAttrs struct {
+	FnAttrs     DevlinkPortFn
+	HwAddrValid bool
+	StateValid  bool
+}
+
+// DevlinkPort represents port and its attributes
+type DevlinkPort struct {
+	BusName          string
+	DeviceName       string
+	PortIndex        uint32
+	PortType         uint16
+	NetdeviceName    string
+	NetdevIfIndex    uint32
+	RdmaDeviceName   string
+	PortFlavour      uint16
+	Fn               *DevlinkPortFn
+	PortNumber       *uint32
+	PfNumber         *uint16
+	VfNumber         *uint16
+	SfNumber         *uint32
+	ControllerNumber *uint32
+	External         *bool
+}
+
+type DevLinkPortAddAttrs struct {
+	Controller      uint32
+	SfNumber        uint32
+	PortIndex       uint32
+	PfNumber        uint16
+	SfNumberValid   bool
+	PortIndexValid  bool
+	ControllerValid bool
+}
+
+// DevlinkDeviceInfo represents devlink info
+type DevlinkDeviceInfo struct {
+	Driver         string
+	SerialNumber   string
+	BoardID        string
+	FwApp          string
+	FwAppBoundleID string
+	FwAppName      string
+	FwBoundleID    string
+	FwMgmt         string
+	FwMgmtAPI      string
+	FwMgmtBuild    string
+	FwNetlist      string
+	FwNetlistBuild string
+	FwPsidAPI      string
+	FwUndi         string
+}
+
+// DevlinkResource represents a device resource
+type DevlinkResource struct {
+	Name            string
+	ID              uint64
+	Size            uint64
+	SizeNew         uint64
+	SizeMin         uint64
+	SizeMax         uint64
+	SizeGranularity uint64
+	PendingChange   bool
+	Unit            uint8
+	SizeValid       bool
+	OCCValid        bool
+	OCCSize         uint64
+	Parent          *DevlinkResource
+	Children        []DevlinkResource
+}
+
+// DevlinkResources represents all devlink resources of a devlink device
+type DevlinkResources struct {
+	Bus       string
+	Device    string
+	Resources []DevlinkResource
+}
+
+// DevlinkParam represents parameter of the device
+type DevlinkParam struct {
+	Name      string
+	IsGeneric bool
+	Type      uint8 // possible values are in nl.DEVLINK_PARAM_TYPE_* constants
+	Values    []DevlinkParamValue
+}
+
+// DevlinkParamValue contains values of the parameter
+// Data field contains specific type which can be casted by unsing info from the DevlinkParam.Type field
+type DevlinkParamValue struct {
+	rawData []byte
+	Data    interface{}
+	CMODE   uint8 // possible values are in nl.DEVLINK_PARAM_CMODE_* constants
+}

--- a/devlink_linux.go
+++ b/devlink_linux.go
@@ -3,111 +3,12 @@ package netlink
 import (
 	"errors"
 	"fmt"
-	"net"
 	"strings"
 	"syscall"
 
 	"github.com/vishvananda/netlink/nl"
 	"golang.org/x/sys/unix"
 )
-
-// DevlinkDevEswitchAttr represents device's eswitch attributes
-type DevlinkDevEswitchAttr struct {
-	Mode       string
-	InlineMode string
-	EncapMode  string
-}
-
-// DevlinkDevAttrs represents device attributes
-type DevlinkDevAttrs struct {
-	Eswitch DevlinkDevEswitchAttr
-}
-
-// DevlinkDevice represents device and its attributes
-type DevlinkDevice struct {
-	BusName    string
-	DeviceName string
-	Attrs      DevlinkDevAttrs
-}
-
-// DevlinkPortFn represents port function and its attributes
-type DevlinkPortFn struct {
-	HwAddr  net.HardwareAddr
-	State   uint8
-	OpState uint8
-}
-
-// DevlinkPortFnSetAttrs represents attributes to set
-type DevlinkPortFnSetAttrs struct {
-	FnAttrs     DevlinkPortFn
-	HwAddrValid bool
-	StateValid  bool
-}
-
-// DevlinkPort represents port and its attributes
-type DevlinkPort struct {
-	BusName          string
-	DeviceName       string
-	PortIndex        uint32
-	PortType         uint16
-	NetdeviceName    string
-	NetdevIfIndex    uint32
-	RdmaDeviceName   string
-	PortFlavour      uint16
-	Fn               *DevlinkPortFn
-	PortNumber       *uint32
-	PfNumber         *uint16
-	VfNumber         *uint16
-	SfNumber         *uint32
-	ControllerNumber *uint32
-	External         *bool
-}
-
-type DevLinkPortAddAttrs struct {
-	Controller      uint32
-	SfNumber        uint32
-	PortIndex       uint32
-	PfNumber        uint16
-	SfNumberValid   bool
-	PortIndexValid  bool
-	ControllerValid bool
-}
-
-// DevlinkDeviceInfo represents devlink info
-type DevlinkDeviceInfo struct {
-	Driver         string
-	SerialNumber   string
-	BoardID        string
-	FwApp          string
-	FwAppBoundleID string
-	FwAppName      string
-	FwBoundleID    string
-	FwMgmt         string
-	FwMgmtAPI      string
-	FwMgmtBuild    string
-	FwNetlist      string
-	FwNetlistBuild string
-	FwPsidAPI      string
-	FwUndi         string
-}
-
-// DevlinkResource represents a device resource
-type DevlinkResource struct {
-	Name            string
-	ID              uint64
-	Size            uint64
-	SizeNew         uint64
-	SizeMin         uint64
-	SizeMax         uint64
-	SizeGranularity uint64
-	PendingChange   bool
-	Unit            uint8
-	SizeValid       bool
-	OCCValid        bool
-	OCCSize         uint64
-	Parent          *DevlinkResource
-	Children        []DevlinkResource
-}
 
 // parseAttributes parses provided Netlink Attributes and populates DevlinkResource, returns error if occured
 func (dlr *DevlinkResource) parseAttributes(attrs map[uint16]syscall.NetlinkRouteAttr) error {
@@ -201,13 +102,6 @@ func (dlr *DevlinkResource) parseAttributes(attrs map[uint16]syscall.NetlinkRout
 	return nil
 }
 
-// DevlinkResources represents all devlink resources of a devlink device
-type DevlinkResources struct {
-	Bus       string
-	Device    string
-	Resources []DevlinkResource
-}
-
 // parseAttributes parses provided Netlink Attributes and populates DevlinkResources, returns error if occured
 func (dlrs *DevlinkResources) parseAttributes(attrs map[uint16]syscall.NetlinkRouteAttr) error {
 	var attr syscall.NetlinkRouteAttr
@@ -252,22 +146,6 @@ func (dlrs *DevlinkResources) parseAttributes(attrs map[uint16]syscall.NetlinkRo
 	}
 
 	return nil
-}
-
-// DevlinkParam represents parameter of the device
-type DevlinkParam struct {
-	Name      string
-	IsGeneric bool
-	Type      uint8 // possible values are in nl.DEVLINK_PARAM_TYPE_* constants
-	Values    []DevlinkParamValue
-}
-
-// DevlinkParamValue contains values of the parameter
-// Data field contains specific type which can be casted by unsing info from the DevlinkParam.Type field
-type DevlinkParamValue struct {
-	rawData []byte
-	Data    interface{}
-	CMODE   uint8 // possible values are in nl.DEVLINK_PARAM_CMODE_* constants
 }
 
 // parseAttributes parses provided Netlink Attributes and populates DevlinkParam, returns error if occured
@@ -858,7 +736,7 @@ func (h *Handle) DevlinkSplitPort(port *DevlinkPort, count uint32) error {
 }
 
 func DevlinkSplitPort(port *DevlinkPort, count uint32) error {
-	return pkgHandle.DevlinkSplitPort(port, count);
+	return pkgHandle.DevlinkSplitPort(port, count)
 }
 
 // DevlinkUnsplitPort: unsplit devlink port
@@ -876,7 +754,7 @@ func (h *Handle) DevlinkUnsplitPort(port *DevlinkPort) error {
 }
 
 func DevlinkUnsplitPort(port *DevlinkPort) error {
-	return pkgHandle.DevlinkUnsplitPort(port);
+	return pkgHandle.DevlinkUnsplitPort(port)
 }
 
 // DevlinkSetDeviceParam set specific parameter for devlink device

--- a/devlink_unspecified.go
+++ b/devlink_unspecified.go
@@ -1,0 +1,68 @@
+//go:build !linux
+// +build !linux
+
+package netlink
+
+func DevLinkGetDeviceList() ([]*DevlinkDevice, error) {
+	return nil, ErrNotImplemented
+}
+
+func DevLinkGetDeviceByName(Bus string, Device string) (*DevlinkDevice, error) {
+	return nil, ErrNotImplemented
+}
+
+func DevLinkSetEswitchMode(Dev *DevlinkDevice, NewMode string) error {
+	return ErrNotImplemented
+}
+
+func DevLinkGetAllPortList() ([]*DevlinkPort, error) {
+	return nil, ErrNotImplemented
+}
+
+func DevlinkGetDeviceResources(bus string, device string) (*DevlinkResources, error) {
+	return nil, ErrNotImplemented
+}
+
+func DevlinkGetDeviceParams(bus string, device string) ([]*DevlinkParam, error) {
+	return nil, ErrNotImplemented
+}
+
+func DevlinkGetDeviceParamByName(bus string, device string, param string) (*DevlinkParam, error) {
+	return nil, ErrNotImplemented
+}
+
+func DevlinkSplitPort(port *DevlinkPort, count uint32) error {
+	return ErrNotImplemented
+}
+
+func DevlinkUnsplitPort(port *DevlinkPort) error {
+	return ErrNotImplemented
+}
+
+func DevlinkSetDeviceParam(bus string, device string, param string, cmode uint8, value interface{}) error {
+	return ErrNotImplemented
+}
+
+func DevLinkGetPortByIndex(Bus string, Device string, PortIndex uint32) (*DevlinkPort, error) {
+	return nil, ErrNotImplemented
+}
+
+func DevLinkPortAdd(Bus string, Device string, Flavour uint16, Attrs DevLinkPortAddAttrs) (*DevlinkPort, error) {
+	return nil, ErrNotImplemented
+}
+
+func DevLinkPortDel(Bus string, Device string, PortIndex uint32) error {
+	return ErrNotImplemented
+}
+
+func DevlinkPortFnSet(Bus string, Device string, PortIndex uint32, FnAttrs DevlinkPortFnSetAttrs) error {
+	return ErrNotImplemented
+}
+
+func DevlinkGetDeviceInfoByName(Bus string, Device string) (*DevlinkDeviceInfo, error) {
+	return nil, ErrNotImplemented
+}
+
+func DevlinkGetDeviceInfoByNameAsMap(Bus string, Device string) (map[string]string, error) {
+	return nil, ErrNotImplemented
+}


### PR DESCRIPTION
the structs and methods for managing devlink are
all under the `devlink_linux.go` file, and when
trying to write code in a non linux system (mac),
the editor doesn't recognize any of it.

this commit moves struct definitions from the
devlink_linux.go file and creates a
devlink_unspecified.go with the devlink funcs.
this is similar to what we have in netlink_unspecified.go

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive Devlink support: device listing, port management (add/del/split/unsplit), resource queries, and parameter/configuration APIs.
* **Compatibility**
  * Standardized Devlink public API naming; non-Linux builds provide clear "not implemented" responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->