### PR TITLE
netlink: skip VLAN proto byte swap on s390x (big-endian)

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -699,7 +699,7 @@ func (h *Handle) LinkSetVfVlanQosProto(link Link, vf, vlan, qos, proto int) erro
 			Vlan: uint32(vlan),
 			Qos:  uint32(qos),
 		},
-		VlanProto: (uint16(proto)>>8)&0xFF | (uint16(proto)&0xFF)<<8,
+		VlanProto: nl.Swap16(uint16(proto)),
 	}
 
 	vfVlanList.AddRtAttr(nl.IFLA_VF_VLAN_INFO, vfmsg.Serialize())


### PR DESCRIPTION
s390x is a big-endian architecture, so VLAN protocol values are already in network byte order. The existing unconditional byte swap performed when setting IFLA_VF_VLAN_INFO corrupts the VLAN protocol field on s390x, causing drivers to reject the request with protocol not supported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved handling of VLAN protocol endianness to ensure correct behavior across CPU architectures, reducing protocol misinterpretation and improving cross-platform reliability.
  * No changes to public APIs or method signatures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->