### PR TITLE
addr: add IFA_PROTO support for address protocol/origin

### DIFF
--- a/addr.go
+++ b/addr.go
@@ -18,6 +18,7 @@ type Addr struct {
 	PreferedLft int
 	ValidLft    int
 	LinkIndex   int
+	Protocol    int // IFA_PROTO: address protocol/origin (kernel 5.18+)
 }
 
 // String returns $ip/$netmask $label


### PR DESCRIPTION
Add support for the `IFA_PROTO` netlink attribute (kernel 5.18+) which indicates the protocol or origin of an IP address.
This is similar to `RTPROT_*` for routes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added address protocol/origin support. New `Protocol` field enables setting and reading address protocol information (kernel 5.18+).
  * New constants available for address protocol values: `IFAPROT_UNSPEC`, `IFAPROT_KERNEL_LO`, `IFAPROT_KERNEL_RA`, `IFAPROT_KERNEL_LL`.

* **Tests**
  * Added test coverage for the new address protocol functionality with kernel version compatibility handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->