### PR TITLE
Add support for getting links in different namespaces

### DIFF
--- a/link_test.go
+++ b/link_test.go
@@ -2220,6 +2220,38 @@ func TestLinkByIndex(t *testing.T) {
 	}
 }
 
+func TestLinkByIndexAndNsid(t *testing.T) {
+	minKernelRequired(t, 4, 15)
+	t.Cleanup(setUpNetlinkTest(t))
+	nsId, linkIdx, linkName, cleanup := setUpNamespaceWithLink(t)
+	t.Cleanup(cleanup)
+
+	link, err := LinkByIndexAndNsid(linkIdx, nsId)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if link.Attrs().Name != linkName {
+		t.Fatal("did not get the correct link")
+	}
+}
+
+func TestLinkByNameAndNsid(t *testing.T) {
+	minKernelRequired(t, 4, 15)
+	t.Cleanup(setUpNetlinkTest(t))
+	nsId, linkIdx, linkName, cleanup := setUpNamespaceWithLink(t)
+	t.Cleanup(cleanup)
+
+	link, err := LinkByNameAndNsid(linkName, nsId)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if link.Attrs().Index != linkIdx {
+		t.Fatal("did not get the correct link")
+	}
+}
+
 func TestLinkSet(t *testing.T) {
 	t.Cleanup(setUpNetlinkTest(t))
 


### PR DESCRIPTION
Rtnetlink supports getting links from different namespaces by sending `IFLA_TARGET_NETNSID` with a `RTM_GETLINK` request. 
This is particularly useful for getting the peer of a veth, as the kernel tells us the netnsid of the peer but opening a netlink socket in that namespace requires a file descriptor into the namespace, and getting such a file descriptor from a netnsid requires enumerating all namespaces.

This PR adds two functions: `LinkByNameAndNsid` and `LinkByIndexAndNsid`. These functions are duplicates of `LinkByName` and `LinkByIndex`, but specify the `IFLA_TARGET_NETNSID` property in the request. The function `LinkByNameAndNsid` does not support the fallback functionality of getting the link from a dump, as the dump only includes links in the current namespace.

I am writing the nsid with `nl.Uint32Attr()`, but it is actually a signed 32 bit int. I can't find any function to write signed int attributes, I'm not sure if it makes a difference since go's cast should keep the bits the same (I think).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Query network interfaces by index within a specific network namespace
  * Query network interfaces by name within a specific network namespace

* **Bug Fixes**
  * Missing-interface handling now returns a clear “not found” result instead of a raw error

* **Tests**
  * Added tests and a test helper to validate namespace-targeted lookups and teardown routines

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->