### PR TITLE
Use binary.NativeEndian

### DIFF
--- a/conntrack_test.go
+++ b/conntrack_test.go
@@ -5,7 +5,6 @@ package netlink
 
 import (
 	"bytes"
-	"encoding/binary"
 	"fmt"
 	"net"
 	"os"
@@ -16,6 +15,7 @@ import (
 
 	"github.com/vishvananda/netlink/nl"
 	"github.com/vishvananda/netns"
+	"golang.org/x/sys/cpu"
 	"golang.org/x/sys/unix"
 )
 
@@ -841,7 +841,7 @@ func TestConntrackFilter(t *testing.T) {
 }
 
 func TestParseRawData(t *testing.T) {
-	if nl.NativeEndian() == binary.BigEndian {
+	if cpu.IsBigEndian {
 		t.Skip("testdata expect little-endian test executor")
 	}
 	os.Setenv("TZ", "") // print timestamps in UTC

--- a/nl/nl_linux.go
+++ b/nl/nl_linux.go
@@ -16,6 +16,7 @@ import (
 	"unsafe"
 
 	"github.com/vishvananda/netns"
+	"golang.org/x/sys/cpu"
 	"golang.org/x/sys/unix"
 )
 
@@ -78,24 +79,14 @@ func GetIPFamily(ip net.IP) int {
 	return FAMILY_V6
 }
 
-var nativeEndian binary.ByteOrder
-
 // NativeEndian gets native endianness for the system
 func NativeEndian() binary.ByteOrder {
-	if nativeEndian == nil {
-		var x uint32 = 0x01020304
-		if *(*byte)(unsafe.Pointer(&x)) == 0x01 {
-			nativeEndian = binary.BigEndian
-		} else {
-			nativeEndian = binary.LittleEndian
-		}
-	}
-	return nativeEndian
+	return binary.NativeEndian
 }
 
 // Byte swap a 16 bit value if we aren't big endian
 func Swap16(i uint16) uint16 {
-	if NativeEndian() == binary.BigEndian {
+	if cpu.IsBigEndian {
 		return i
 	}
 	return (i&0xff00)>>8 | (i&0xff)<<8
@@ -103,7 +94,7 @@ func Swap16(i uint16) uint16 {
 
 // Byte swap a 32 bit value if aren't big endian
 func Swap32(i uint32) uint32 {
-	if NativeEndian() == binary.BigEndian {
+	if cpu.IsBigEndian {
 		return i
 	}
 	return (i&0xff000000)>>24 | (i&0xff0000)>>8 | (i&0xff00)<<8 | (i&0xff)<<24


### PR DESCRIPTION
Use the NativeEndian native-endian var provided by the Go standard library encoding/binary package since Go 1.21.

Comparing binary.NativeEndian to binary.{Bit,Little}Endian doesn't work though, so instead use golang.org/x/sys/cpu.IsBigEndian as suggested by https://github.com/golang/go/issues/57237.

/cc @vishvananda @aboch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified endianness detection mechanism by replacing internal caching and detection logic with a direct runtime check.
  * Removed unsafe code paths previously used for endianness computation.
  * Updated internal imports to use standard platform detection utilities.

* **Tests**
  * Updated test endianness checks to use standard platform detection method.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->