### PR TITLE
filter: fix TCA_FLOWER_FLAGS decode using wrong constants

### DIFF
--- a/filter_linux.go
+++ b/filter_linux.go
@@ -257,8 +257,8 @@ func (filter *Flower) decode(data []syscall.NetlinkRouteAttr) error {
 			}
 		case nl.TCA_FLOWER_FLAGS:
 			attr := nl.DeserializeUint32Bitfield(datum.Value)
-			skipSw := attr.Value & nl.TCA_CLS_FLAGS_SKIP_HW
-			skipHw := attr.Value & nl.TCA_CLS_FLAGS_SKIP_SW
+			skipSw := attr.Value & nl.TCA_CLS_FLAGS_SKIP_SW
+			skipHw := attr.Value & nl.TCA_CLS_FLAGS_SKIP_HW
 			if skipSw != 0 {
 				filter.SkipSw = true
 			}


### PR DESCRIPTION
The decode function was using swapped constants for SkipSw and SkipHw:
- skipSw was using TCA_CLS_FLAGS_SKIP_HW (wrong)
- skipHw was using TCA_CLS_FLAGS_SKIP_SW (wrong)

This caused SkipSw and SkipHw to have incorrect values when reading flower filters from kernel, breaking hardware offload detection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed flower filter flag decoding to correctly interpret skip settings, ensuring packet filtering behavior matches configured directives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->