### PR TITLE
openvswitch: add OpenvSwitch and OpenvSwitchSlave link models

### DIFF
--- a/link.go
+++ b/link.go
@@ -289,6 +289,21 @@ func (bridge *Bridge) Type() string {
 	return "bridge"
 }
 
+// OpenvSwitch links are Open vSwitch bridge devices.
+// Note: their lifecycle is typically managed by OVS (OVSDB/ovs-vsctl),
+// while netlink is used to query/link them.
+type OpenvSwitch struct {
+	LinkAttrs
+}
+
+func (ovs *OpenvSwitch) Attrs() *LinkAttrs {
+	return &ovs.LinkAttrs
+}
+
+func (ovs *OpenvSwitch) Type() string {
+	return "openvswitch"
+}
+
 // Vlan links have ParentIndex set in their Attrs()
 type Vlan struct {
 	LinkAttrs
@@ -1064,6 +1079,12 @@ type VrfSlave struct {
 
 func (v *VrfSlave) SlaveType() string {
 	return "vrf"
+}
+
+type OpenvSwitchSlave struct{}
+
+func (o *OpenvSwitchSlave) SlaveType() string {
+	return "openvswitch"
 }
 
 // Geneve devices must specify RemoteIP and ID (VNI) on create

--- a/link_linux.go
+++ b/link_linux.go
@@ -2188,6 +2188,8 @@ func LinkDeserialize(hdr *unix.NlMsghdr, m []byte) (Link, error) {
 						link = &Ifb{}
 					case "bridge":
 						link = &Bridge{}
+					case "openvswitch":
+						link = &OpenvSwitch{}
 					case "vlan":
 						link = &Vlan{}
 					case "netkit":
@@ -2308,6 +2310,8 @@ func LinkDeserialize(hdr *unix.NlMsghdr, m []byte) (Link, error) {
 						linkSlave = &BondSlave{}
 					case "vrf":
 						linkSlave = &VrfSlave{}
+					case "openvswitch":
+						linkSlave = &OpenvSwitchSlave{}
 					}
 
 				case nl.IFLA_INFO_SLAVE_DATA:


### PR DESCRIPTION
Hello!

We proposal to add base Open vSwitch support to netlink. The goal is to correctly recognize `openvswitch` interfaces and their slave relationships when reading state through the netlink API.

Example of configuration and reads by `ovs-vsctl` and `iproute2` utils show below:

```
root@node1:~# ovs-vsctl add-br br0
root@node1:~# ovs-vsctl add-port br0 port0 -- set Interface port0 type=internal
root@node1:~# ovs-vsctl add-port br0 eth0

root@node1:~# ovs-vsctl show
36d616df-f303-48fc-982a-eded492f18f9
    Bridge br0
        Port br0
            Interface br0
                type: internal
        Port port0
            Interface port0
                type: internal

root@node1:~# ip -d link show eth0
1: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 16384 qdisc htb master ovs-system state UP mode DEFAULT group default qlen 1000
    link/ether 52:54:00:3e:bb:57 brd ff:ff:ff:ff:ff:ff promiscuity 1 allmulti 0 minmtu 68 maxmtu 65535 
    openvswitch_slave addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536 gso_ipv4_max_size 65536 gro_ipv4_max_size 65536 parentbus virtio parentdev virtio7 

root@node1:~# ip -d link show ovs-system
2: ovs-system: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN mode DEFAULT group default qlen 1000
    link/ether a2:be:9c:66:07:fa brd ff:ff:ff:ff:ff:ff promiscuity 1 allmulti 0 minmtu 68 maxmtu 65535 
    openvswitch addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536 gso_ipv4_max_size 65536 gro_ipv4_max_size 65536 

root@node1:~# ip -d link show br0
3: br0: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN mode DEFAULT group default qlen 1000
    link/ether aa:46:3d:22:88:4d brd ff:ff:ff:ff:ff:ff promiscuity 1 allmulti 0 minmtu 68 maxmtu 65535 
    openvswitch addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536 gso_ipv4_max_size 65536 gro_ipv4_max_size 65536 

root@node1:~# ip -d link show port0
4: port0: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN mode DEFAULT group default qlen 1000
    link/ether 8a:d7:bf:52:ea:98 brd ff:ff:ff:ff:ff:ff promiscuity 1 allmulti 0 minmtu 68 maxmtu 65535 
    openvswitch addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536 gso_ipv4_max_size 65536 gro_ipv4_max_size 65536 

```

From the output, we see a mention of interface kind. This can be `openvswitch` - in case of interface created and managed by Open vSwitch, or `openvswitch_slave` - if we just attach system interface to ovs bridge.

So, we're just adding support for this `IFLA_INFO_KIND` and `IFLA_INFO_SLAVE_KIND` to the library, making it possible to query.

I would like to note separately that these interfaces are created and deleted via Open vSwitch. Therefore, you should not expect updates and tests in the LinkAdd/Del part. 

As for the test, I added the need to load the kernel module before start. The test itself starts and runs (not skipped) if the ovs bridges have been pre-configured in the environment, as in the example above. I don't see the point or need to add an appropriate os.Exec's to the environment preparation code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Open vSwitch bridge devices with complete type identification and attribute management
  * Extended link management to properly recognize and configure Open vSwitch slave devices

* **Tests**
  * Added comprehensive validation tests for Open vSwitch device handling, including type identification and master-slave relationship verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->