### PR TITLE
handle: enable VF info collection by default for pkgHandle

### DIFF
--- a/handle_linux.go
+++ b/handle_linux.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Empty handle used by the netlink package methods
-var pkgHandle = &Handle{}
+var pkgHandle = &Handle{options: HandleOptions{collectVFInfo: true}}
 
 type HandleOptions struct {
 	lookupByDump  bool


### PR DESCRIPTION
The package-level handle (pkgHandle) was initialized without collectVFInfo, causing package-level functions like LinkByName to no longer collect Virtual Function information. This restores the previous default behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Virtual Function (VF) information collection is now enabled by default, providing enhanced visibility into network interface details. The existing option to disable this collection remains available if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->