### PR TITLE
Migrate to net/netip

### DIFF
--- a/addr.go
+++ b/addr.go
@@ -2,19 +2,19 @@ package netlink
 
 import (
 	"fmt"
-	"net"
+	"net/netip"
 	"strings"
 )
 
 // Addr represents an IP address from netlink. Netlink ip addresses
-// include a mask, so it stores the address as a net.IPNet.
+// include a mask, so it stores the address as a netip.Prefix.
 type Addr struct {
-	*net.IPNet
+	netip.Prefix
 	Label       string
 	Flags       int
 	Scope       int
-	Peer        *net.IPNet
-	Broadcast   net.IP
+	Peer        netip.Prefix
+	Broadcast   netip.Addr
 	PreferedLft int
 	ValidLft    int
 	LinkIndex   int
@@ -23,7 +23,7 @@ type Addr struct {
 
 // String returns $ip/$netmask $label
 func (a Addr) String() string {
-	return strings.TrimSpace(fmt.Sprintf("%s %s", a.IPNet, a.Label))
+	return strings.TrimSpace(fmt.Sprintf("%s %s", a.Prefix, a.Label))
 }
 
 // ParseAddr parses the string representation of an address in the
@@ -39,20 +39,14 @@ func ParseAddr(s string) (*Addr, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Addr{IPNet: m, Label: label}, nil
+	return &Addr{Prefix: m, Label: label}, nil
 }
 
-// Equal returns true if both Addrs have the same net.IPNet value.
+// Equal returns true if both Addrs have the same netip.Prefix value.
 func (a Addr) Equal(x Addr) bool {
-	sizea, _ := a.Mask.Size()
-	sizeb, _ := x.Mask.Size()
-	// ignore label for comparison
-	return a.IP.Equal(x.IP) && sizea == sizeb
+	return a.Prefix == x.Prefix
 }
 
 func (a Addr) PeerEqual(x Addr) bool {
-	sizea, _ := a.Peer.Mask.Size()
-	sizeb, _ := x.Peer.Mask.Size()
-	// ignore label for comparison
-	return a.Peer.IP.Equal(x.Peer.IP) && sizea == sizeb
+	return a.Peer == x.Peer
 }

--- a/addr.go
+++ b/addr.go
@@ -35,7 +35,7 @@ func ParseAddr(s string) (*Addr, error) {
 		s = parts[0]
 		label = parts[1]
 	}
-	m, err := ParseIPNet(s)
+	m, err := ParsePrefix(s)
 	if err != nil {
 		return nil, err
 	}

--- a/addr_linux.go
+++ b/addr_linux.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"syscall"
 
 	"github.com/vishvananda/netlink/nl"
@@ -29,7 +30,7 @@ const (
 //
 // If `addr` is an IPv4 address and the broadcast address is not given, it
 // will be automatically computed based on the IP mask if /30 or larger.
-// If `net.IPv4zero` is given as the broadcast address, broadcast is disabled.
+// If `0.0.0.0` is given as the broadcast address, broadcast is disabled.
 func AddrAdd(link Link, addr *Addr) error {
 	return pkgHandle.AddrAdd(link, addr)
 }
@@ -40,7 +41,7 @@ func AddrAdd(link Link, addr *Addr) error {
 //
 // If `addr` is an IPv4 address and the broadcast address is not given, it
 // will be automatically computed based on the IP mask if /30 or larger.
-// If `net.IPv4zero` is given as the broadcast address, broadcast is disabled.
+// If `0.0.0.0` is given as the broadcast address, broadcast is disabled.
 func (h *Handle) AddrAdd(link Link, addr *Addr) error {
 	req := h.newNetlinkRequest(unix.RTM_NEWADDR, unix.NLM_F_CREATE|unix.NLM_F_EXCL|unix.NLM_F_ACK)
 	return h.addrHandle(link, addr, req)
@@ -52,7 +53,7 @@ func (h *Handle) AddrAdd(link Link, addr *Addr) error {
 //
 // If `addr` is an IPv4 address and the broadcast address is not given, it
 // will be automatically computed based on the IP mask if /30 or larger.
-// If `net.IPv4zero` is given as the broadcast address, broadcast is disabled.
+// If `0.0.0.0` is given as the broadcast address, broadcast is disabled.
 func AddrReplace(link Link, addr *Addr) error {
 	return pkgHandle.AddrReplace(link, addr)
 }
@@ -63,7 +64,7 @@ func AddrReplace(link Link, addr *Addr) error {
 //
 // If `addr` is an IPv4 address and the broadcast address is not given, it
 // will be automatically computed based on the IP mask if /30 or larger.
-// If `net.IPv4zero` is given as the broadcast address, broadcast is disabled.
+// If `0.0.0.0` is given as the broadcast address, broadcast is disabled.
 func (h *Handle) AddrReplace(link Link, addr *Addr) error {
 	req := h.newNetlinkRequest(unix.RTM_NEWADDR, unix.NLM_F_CREATE|unix.NLM_F_REPLACE|unix.NLM_F_ACK)
 	return h.addrHandle(link, addr, req)
@@ -85,7 +86,7 @@ func (h *Handle) AddrDel(link Link, addr *Addr) error {
 }
 
 func (h *Handle) addrHandle(link Link, addr *Addr, req *nl.NetlinkRequest) error {
-	family := nl.GetIPFamily(addr.IP)
+	family := nl.GetIPFamily(addr.Addr())
 	msg := nl.NewIfAddrmsg(family)
 	msg.Scope = uint8(addr.Scope)
 	if link == nil {
@@ -95,30 +96,22 @@ func (h *Handle) addrHandle(link Link, addr *Addr, req *nl.NetlinkRequest) error
 		h.ensureIndex(base)
 		msg.Index = uint32(base.Index)
 	}
-	mask := addr.Mask
-	if addr.Peer != nil {
-		mask = addr.Peer.Mask
+
+	prefixlen := addr.Bits()
+	if addr.Peer.IsValid() {
+		prefixlen = addr.Peer.Bits()
 	}
-	prefixlen, masklen := mask.Size()
+
 	msg.Prefixlen = uint8(prefixlen)
 	req.AddData(msg)
 
-	var localAddrData []byte
-	if family == FAMILY_V4 {
-		localAddrData = addr.IP.To4()
-	} else {
-		localAddrData = addr.IP.To16()
-	}
+	localAddrData := addr.Addr().AsSlice()
 
 	localData := nl.NewRtAttr(unix.IFA_LOCAL, localAddrData)
 	req.AddData(localData)
 	var peerAddrData []byte
-	if addr.Peer != nil {
-		if family == FAMILY_V4 {
-			peerAddrData = addr.Peer.IP.To4()
-		} else {
-			peerAddrData = addr.Peer.IP.To16()
-		}
+	if addr.Peer.IsValid() {
+		peerAddrData = addr.Peer.Addr().AsSlice()
 	} else {
 		peerAddrData = localAddrData
 	}
@@ -141,20 +134,17 @@ func (h *Handle) addrHandle(link Link, addr *Addr, req *nl.NetlinkRequest) error
 		// Automatically set the broadcast address if it is unset and the
 		// subnet is large enough to sensibly have one (/30 or larger).
 		// See: RFC 3021
-		if addr.Broadcast == nil && prefixlen < 31 {
-			calcBroadcast := make(net.IP, masklen/8)
+		if !addr.Broadcast.IsValid() && prefixlen < 31 {
+			mask := net.CIDRMask(prefixlen, 32)
+			calcBroadcast := [4]byte{}
 			for i := range localAddrData {
 				calcBroadcast[i] = localAddrData[i] | ^mask[i]
 			}
-			addr.Broadcast = calcBroadcast
+			addr.Broadcast = netip.AddrFrom4(calcBroadcast)
 		}
 
-		if net.IPv4zero.Equal(addr.Broadcast) {
-			addr.Broadcast = nil
-		}
-
-		if addr.Broadcast != nil {
-			req.AddData(nl.NewRtAttr(unix.IFA_BROADCAST, addr.Broadcast))
+		if addr.Broadcast.IsValid() {
+			req.AddData(nl.NewRtAttr(unix.IFA_BROADCAST, addr.Broadcast.AsSlice()))
 		}
 
 		if addr.Label != "" {
@@ -256,27 +246,37 @@ func parseAddr(m []byte) (addr Addr, family int, err error) {
 	family = int(msg.Family)
 	addr.LinkIndex = int(msg.Index)
 
-	var local, dst *net.IPNet
+	var local, dst netip.Prefix
 	for _, attr := range attrs {
 		switch attr.Attr.Type {
 		case unix.IFA_ADDRESS:
-			dst = &net.IPNet{
-				IP:   attr.Value,
-				Mask: net.CIDRMask(int(msg.Prefixlen), 8*len(attr.Value)),
+			a, ok := netip.AddrFromSlice(attr.Value)
+			if !ok {
+				return Addr{}, 0, fmt.Errorf("IFA_ADDRESS: invalid address")
+			}
+			dst, err = a.Prefix(int(msg.Prefixlen))
+			if err != nil {
+				return Addr{}, 0, fmt.Errorf("IFA_ADDRESS: %w", err)
 			}
 		case unix.IFA_LOCAL:
+			a, ok := netip.AddrFromSlice(attr.Value)
+			if !ok {
+				return Addr{}, 0, fmt.Errorf("IFA_LOCAL: invalid address")
+			}
+
 			// iproute2 manual:
 			// If a peer address is specified, the local address
 			// cannot have a prefix length. The network prefix is
 			// associated with the peer rather than with the local
 			// address.
-			n := 8 * len(attr.Value)
-			local = &net.IPNet{
-				IP:   attr.Value,
-				Mask: net.CIDRMask(n, n),
-			}
+			local, _ = a.Prefix(a.BitLen())
 		case unix.IFA_BROADCAST:
-			addr.Broadcast = attr.Value
+			a, ok := netip.AddrFromSlice(attr.Value)
+			if !ok {
+				return Addr{}, 0, fmt.Errorf("IFA_BROADCAST: invalid address")
+			}
+
+			addr.Broadcast = a
 		case unix.IFA_LABEL:
 			addr.Label = string(attr.Value[:len(attr.Value)-1])
 		case unix.IFA_FLAGS:
@@ -299,15 +299,15 @@ func parseAddr(m []byte) (addr Addr, family int, err error) {
 	//
 	// But obviously, as there are IPv6 PtP addresses, too,
 	// IFA_LOCAL should also be handled for IPv6.
-	if local != nil {
-		if family == FAMILY_V4 && dst != nil && local.IP.Equal(dst.IP) {
-			addr.IPNet = dst
+	if local.IsValid() {
+		if family == FAMILY_V4 && dst.IsValid() && local.Addr() == dst.Addr() {
+			addr.Prefix = dst
 		} else {
-			addr.IPNet = local
+			addr.Prefix = local
 			addr.Peer = dst
 		}
 	} else {
-		addr.IPNet = dst
+		addr.Prefix = dst
 	}
 
 	addr.Scope = int(msg.Scope)
@@ -316,7 +316,7 @@ func parseAddr(m []byte) (addr Addr, family int, err error) {
 }
 
 type AddrUpdate struct {
-	LinkAddress net.IPNet
+	LinkAddress netip.Prefix
 	LinkIndex   int
 	Flags       int
 	Scope       int
@@ -440,7 +440,7 @@ func addrSubscribeAt(newNs, curNs netns.NsHandle, ch chan<- AddrUpdate, done <-c
 					continue
 				}
 
-				ch <- AddrUpdate{LinkAddress: *addr.IPNet,
+				ch <- AddrUpdate{LinkAddress: addr.Prefix,
 					LinkIndex:   addr.LinkIndex,
 					NewAddr:     msgType == unix.RTM_NEWADDR,
 					Flags:       addr.Flags,

--- a/addr_test.go
+++ b/addr_test.go
@@ -335,9 +335,9 @@ func TestAddrProtocol(t *testing.T) {
 	}
 
 	const testProtocol = 99
-	address := &net.IPNet{IP: net.IPv4(127, 0, 0, 2), Mask: net.CIDRMask(32, 32)}
+	prefix := netip.PrefixFrom(netip.MustParseAddr("127.0.0.2"), 32)
 	addr := &Addr{
-		IPNet:    address,
+		Prefix:   prefix,
 		Protocol: testProtocol,
 	}
 

--- a/bridge_linux_test.go
+++ b/bridge_linux_test.go
@@ -310,7 +310,7 @@ func setupBridgeWithTwoVxlans(t *testing.T) (*Bridge, *Vxlan, *Vxlan) {
 	// ip link add vxlan0 type vxlan dstport 4789 nolearning external local 10.0.1.1
 	vxlan0 := &Vxlan{
 		LinkAttrs: LinkAttrs{Name: "vxlan0"},
-		SrcAddr:   []byte("10.0.1.1"),
+		SrcAddr:   netip.MustParseAddr("10.0.1.1"),
 		Learning:  false,
 		FlowBased: true,
 		Port:      4789,
@@ -322,7 +322,7 @@ func setupBridgeWithTwoVxlans(t *testing.T) (*Bridge, *Vxlan, *Vxlan) {
 	// ip link add vxlan1 type vxlan dstport 4790 nolearning external local 10.0.1.1
 	vxlan1 := &Vxlan{
 		LinkAttrs: LinkAttrs{Name: "vxlan1"},
-		SrcAddr:   []byte("10.0.1.1"),
+		SrcAddr:   netip.MustParseAddr("10.0.1.1"),
 		Learning:  false,
 		FlowBased: true,
 		Port:      4790,

--- a/bridge_linux_test.go
+++ b/bridge_linux_test.go
@@ -3,6 +3,7 @@ package netlink
 import (
 	"fmt"
 	"io/ioutil"
+	"net/netip"
 	"testing"
 
 	"github.com/vishvananda/netlink/nl"
@@ -99,7 +100,7 @@ func TestBridgeVlanTunnelInfo(t *testing.T) {
 	// ip link add vxlan0 type vxlan dstport 4789 nolearning external local 10.0.1.1
 	vxlan := &Vxlan{
 		// local
-		SrcAddr:  []byte("10.0.1.1"),
+		SrcAddr:  netip.MustParseAddr("10.0.1.1"),
 		Learning: false,
 		// external
 		FlowBased: true,

--- a/cmd/ipset-test/main.go
+++ b/cmd/ipset-test/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"net/netip"
 	"os"
 	"sort"
 
@@ -145,7 +146,8 @@ func cmdAddDel(f func(string, *netlink.IPSetEntry) error) func([]string) {
 func cmdTest(args []string) {
 	setName := args[0]
 	element := args[1]
-	ip := net.ParseIP(element)
+	ip, err := netip.ParseAddr(element)
+	check(err)
 	entry := &netlink.IPSetEntry{
 		Timeout: timeoutVal,
 		IP:      ip,

--- a/conntrack_linux.go
+++ b/conntrack_linux.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"net"
+	"net/netip"
 	"time"
 
 	"github.com/vishvananda/netlink/nl"
@@ -278,11 +278,11 @@ func (*ProtoInfoDCCP) Protocol() string { return "dccp" }
 // For the time being, the structure below allows to parse and extract the base information of a flow
 type IPTuple struct {
 	Bytes    uint64
-	DstIP    net.IP
+	DstIP    netip.Addr
 	DstPort  uint16
 	Packets  uint64
 	Protocol uint8
-	SrcIP    net.IP
+	SrcIP    netip.Addr
 	SrcPort  uint16
 }
 
@@ -302,9 +302,9 @@ func (t *IPTuple) toNlData(family uint8) ([]*nl.RtAttr, error) {
 	}
 
 	ctTupleIP := nl.NewRtAttr(unix.NLA_F_NESTED|nl.CTA_TUPLE_IP, nil)
-	ctTupleIPSrc := nl.NewRtAttr(srcIPsFlag, t.SrcIP)
+	ctTupleIPSrc := nl.NewRtAttr(srcIPsFlag, t.SrcIP.AsSlice())
 	ctTupleIP.AddChild(ctTupleIPSrc)
-	ctTupleIPDst := nl.NewRtAttr(dstIPsFlag, t.DstIP)
+	ctTupleIPDst := nl.NewRtAttr(dstIPsFlag, t.DstIP.AsSlice())
 	ctTupleIP.AddChild(ctTupleIPDst)
 
 	ctTupleProto := nl.NewRtAttr(unix.NLA_F_NESTED|nl.CTA_TUPLE_PROTO, nil)
@@ -461,9 +461,9 @@ func parseIpTuple(reader *bytes.Reader, tpl *IPTuple) uint8 {
 		_, t, _, v := parseNfAttrTLV(reader)
 		switch t {
 		case nl.CTA_IP_V4_SRC, nl.CTA_IP_V6_SRC:
-			tpl.SrcIP = v
+			tpl.SrcIP, _ = netip.AddrFromSlice(v)
 		case nl.CTA_IP_V4_DST, nl.CTA_IP_V6_DST:
-			tpl.DstIP = v
+			tpl.DstIP, _ = netip.AddrFromSlice(v)
 		}
 	}
 	// Get total length of nested protocol-specific info.
@@ -782,7 +782,7 @@ type CustomConntrackFilter interface {
 }
 
 type ConntrackFilter struct {
-	ipNetFilter map[ConntrackFilterType]*net.IPNet
+	ipNetFilter map[ConntrackFilterType]netip.Prefix
 	portFilter  map[ConntrackFilterType]uint16
 	protoFilter uint8
 	labelFilter map[ConntrackFilterType][][]byte
@@ -790,12 +790,12 @@ type ConntrackFilter struct {
 }
 
 // AddIPNet adds a IP subnet to the conntrack filter
-func (f *ConntrackFilter) AddIPNet(tp ConntrackFilterType, ipNet *net.IPNet) error {
-	if ipNet == nil {
+func (f *ConntrackFilter) AddIPNet(tp ConntrackFilterType, ipNet netip.Prefix) error {
+	if !ipNet.IsValid() {
 		return fmt.Errorf("Filter attribute empty")
 	}
 	if f.ipNetFilter == nil {
-		f.ipNetFilter = make(map[ConntrackFilterType]*net.IPNet)
+		f.ipNetFilter = make(map[ConntrackFilterType]netip.Prefix)
 	}
 	if _, ok := f.ipNetFilter[tp]; ok {
 		return errors.New("Filter attribute already present")
@@ -805,8 +805,8 @@ func (f *ConntrackFilter) AddIPNet(tp ConntrackFilterType, ipNet *net.IPNet) err
 }
 
 // AddIP adds an IP to the conntrack filter
-func (f *ConntrackFilter) AddIP(tp ConntrackFilterType, ip net.IP) error {
-	if ip == nil {
+func (f *ConntrackFilter) AddIP(tp ConntrackFilterType, ip netip.Addr) error {
+	if !ip.IsValid() {
 		return fmt.Errorf("Filter attribute empty")
 	}
 	return f.AddIPNet(tp, NewIPNet(ip))

--- a/conntrack_linux.go
+++ b/conntrack_linux.go
@@ -809,7 +809,7 @@ func (f *ConntrackFilter) AddIP(tp ConntrackFilterType, ip netip.Addr) error {
 	if !ip.IsValid() {
 		return fmt.Errorf("Filter attribute empty")
 	}
-	return f.AddIPNet(tp, NewIPNet(ip))
+	return f.AddIPNet(tp, NewPrefix(ip))
 }
 
 // AddPort adds a Port to the conntrack filter if the Layer 4 protocol allows it

--- a/conntrack_test.go
+++ b/conntrack_test.go
@@ -629,7 +629,7 @@ func TestConntrackFilter(t *testing.T) {
 
 	// SrcIPNet filter
 	filterV4 = &ConntrackFilter{}
-	ipNet, err := ParseIPNet("10.0.0.0/12")
+	ipNet, err := ParsePrefix("10.0.0.0/12")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -639,7 +639,7 @@ func TestConntrackFilter(t *testing.T) {
 	}
 
 	filterV6 = &ConntrackFilter{}
-	ipNet, err = ParseIPNet("eeee:eeee:eeee:eeee::/64")
+	ipNet, err = ParsePrefix("eeee:eeee:eeee:eeee::/64")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -655,7 +655,7 @@ func TestConntrackFilter(t *testing.T) {
 
 	// DstIpNet filter
 	filterV4 = &ConntrackFilter{}
-	ipNet, err = ParseIPNet("20.0.0.0/12")
+	ipNet, err = ParsePrefix("20.0.0.0/12")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -665,7 +665,7 @@ func TestConntrackFilter(t *testing.T) {
 	}
 
 	filterV6 = &ConntrackFilter{}
-	ipNet, err = ParseIPNet("dddd:dddd:dddd:dddd::/64")
+	ipNet, err = ParsePrefix("dddd:dddd:dddd:dddd::/64")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -681,7 +681,7 @@ func TestConntrackFilter(t *testing.T) {
 
 	// SrcIPNet for NAT
 	filterV4 = &ConntrackFilter{}
-	ipNet, err = ParseIPNet("20.0.0.0/12")
+	ipNet, err = ParsePrefix("20.0.0.0/12")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -691,7 +691,7 @@ func TestConntrackFilter(t *testing.T) {
 	}
 
 	filterV6 = &ConntrackFilter{}
-	ipNet, err = ParseIPNet("dddd:dddd:dddd:dddd::/64")
+	ipNet, err = ParsePrefix("dddd:dddd:dddd:dddd::/64")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -707,7 +707,7 @@ func TestConntrackFilter(t *testing.T) {
 
 	// DstIPNet for NAT
 	filterV4 = &ConntrackFilter{}
-	ipNet, err = ParseIPNet("192.168.0.0/12")
+	ipNet, err = ParsePrefix("192.168.0.0/12")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -717,7 +717,7 @@ func TestConntrackFilter(t *testing.T) {
 	}
 
 	filterV6 = &ConntrackFilter{}
-	ipNet, err = ParseIPNet("dddd:dddd:dddd:dddd::/64")
+	ipNet, err = ParsePrefix("dddd:dddd:dddd:dddd::/64")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -733,7 +733,7 @@ func TestConntrackFilter(t *testing.T) {
 
 	// AnyIpNet for Nat
 	filterV4 = &ConntrackFilter{}
-	ipNet, err = ParseIPNet("192.168.0.0/12")
+	ipNet, err = ParsePrefix("192.168.0.0/12")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -743,7 +743,7 @@ func TestConntrackFilter(t *testing.T) {
 	}
 
 	filterV6 = &ConntrackFilter{}
-	ipNet, err = ParseIPNet("eeee:eeee:eeee:eeee::/64")
+	ipNet, err = ParsePrefix("eeee:eeee:eeee:eeee::/64")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -1124,10 +1124,10 @@ func TestConntrackUpdateV4(t *testing.T) {
 
 	filter := ConntrackFilter{
 		ipNetFilter: map[ConntrackFilterType]netip.Prefix{
-			ConntrackOrigSrcIP:  NewIPNet(flow.Forward.SrcIP),
-			ConntrackOrigDstIP:  NewIPNet(flow.Forward.DstIP),
-			ConntrackReplySrcIP: NewIPNet(flow.Reverse.SrcIP),
-			ConntrackReplyDstIP: NewIPNet(flow.Reverse.DstIP),
+			ConntrackOrigSrcIP:  NewPrefix(flow.Forward.SrcIP),
+			ConntrackOrigDstIP:  NewPrefix(flow.Forward.DstIP),
+			ConntrackReplySrcIP: NewPrefix(flow.Reverse.SrcIP),
+			ConntrackReplyDstIP: NewPrefix(flow.Reverse.DstIP),
 		},
 		portFilter: map[ConntrackFilterType]uint16{
 			ConntrackOrigSrcPort: flow.Forward.SrcPort,
@@ -1257,10 +1257,10 @@ func TestConntrackUpdateV6(t *testing.T) {
 
 	filter := ConntrackFilter{
 		ipNetFilter: map[ConntrackFilterType]netip.Prefix{
-			ConntrackOrigSrcIP:  NewIPNet(flow.Forward.SrcIP),
-			ConntrackOrigDstIP:  NewIPNet(flow.Forward.DstIP),
-			ConntrackReplySrcIP: NewIPNet(flow.Reverse.SrcIP),
-			ConntrackReplyDstIP: NewIPNet(flow.Reverse.DstIP),
+			ConntrackOrigSrcIP:  NewPrefix(flow.Forward.SrcIP),
+			ConntrackOrigDstIP:  NewPrefix(flow.Forward.DstIP),
+			ConntrackReplySrcIP: NewPrefix(flow.Reverse.SrcIP),
+			ConntrackReplyDstIP: NewPrefix(flow.Reverse.DstIP),
 		},
 		portFilter: map[ConntrackFilterType]uint16{
 			ConntrackOrigSrcPort: flow.Forward.SrcPort,
@@ -1383,10 +1383,10 @@ func TestConntrackCreateV4(t *testing.T) {
 
 	filter := ConntrackFilter{
 		ipNetFilter: map[ConntrackFilterType]netip.Prefix{
-			ConntrackOrigSrcIP:  NewIPNet(flow.Forward.SrcIP),
-			ConntrackOrigDstIP:  NewIPNet(flow.Forward.DstIP),
-			ConntrackReplySrcIP: NewIPNet(flow.Reverse.SrcIP),
-			ConntrackReplyDstIP: NewIPNet(flow.Reverse.DstIP),
+			ConntrackOrigSrcIP:  NewPrefix(flow.Forward.SrcIP),
+			ConntrackOrigDstIP:  NewPrefix(flow.Forward.DstIP),
+			ConntrackReplySrcIP: NewPrefix(flow.Reverse.SrcIP),
+			ConntrackReplyDstIP: NewPrefix(flow.Reverse.DstIP),
 		},
 		portFilter: map[ConntrackFilterType]uint16{
 			ConntrackOrigSrcPort: flow.Forward.SrcPort,
@@ -1478,10 +1478,10 @@ func TestConntrackCreateV6(t *testing.T) {
 
 	filter := ConntrackFilter{
 		ipNetFilter: map[ConntrackFilterType]netip.Prefix{
-			ConntrackOrigSrcIP:  NewIPNet(flow.Forward.SrcIP),
-			ConntrackOrigDstIP:  NewIPNet(flow.Forward.DstIP),
-			ConntrackReplySrcIP: NewIPNet(flow.Reverse.SrcIP),
-			ConntrackReplyDstIP: NewIPNet(flow.Reverse.DstIP),
+			ConntrackOrigSrcIP:  NewPrefix(flow.Forward.SrcIP),
+			ConntrackOrigDstIP:  NewPrefix(flow.Forward.DstIP),
+			ConntrackReplySrcIP: NewPrefix(flow.Reverse.SrcIP),
+			ConntrackReplyDstIP: NewPrefix(flow.Reverse.DstIP),
 		},
 		portFilter: map[ConntrackFilterType]uint16{
 			ConntrackOrigSrcPort: flow.Forward.SrcPort,
@@ -1547,15 +1547,15 @@ func TestConntrackDeleteV4(t *testing.T) {
 	flow := ConntrackFlow{
 		FamilyType: FAMILY_V4,
 		Forward: IPTuple{
-			SrcIP:    net.IP{234, 234, 234, 234},
-			DstIP:    net.IP{123, 123, 123, 123},
+			SrcIP:    netip.MustParseAddr("234.234.234.234"),
+			DstIP:    netip.MustParseAddr("123.123.123.123"),
 			SrcPort:  48385,
 			DstPort:  53,
 			Protocol: unix.IPPROTO_TCP,
 		},
 		Reverse: IPTuple{
-			SrcIP:    net.IP{123, 123, 123, 123},
-			DstIP:    net.IP{234, 234, 234, 234},
+			SrcIP:    netip.MustParseAddr("123.123.123.123"),
+			DstIP:    netip.MustParseAddr("234.234.234.234"),
 			SrcPort:  53,
 			DstPort:  48385,
 			Protocol: unix.IPPROTO_TCP,
@@ -1579,11 +1579,11 @@ func TestConntrackDeleteV4(t *testing.T) {
 		t.Fatalf("failed to list conntracks following successful insert: %s", err)
 	}
 	filter := ConntrackFilter{
-		ipNetFilter: map[ConntrackFilterType]*net.IPNet{
-			ConntrackOrigSrcIP:  NewIPNet(flow.Forward.SrcIP),
-			ConntrackOrigDstIP:  NewIPNet(flow.Forward.DstIP),
-			ConntrackReplySrcIP: NewIPNet(flow.Reverse.SrcIP),
-			ConntrackReplyDstIP: NewIPNet(flow.Reverse.DstIP),
+		ipNetFilter: map[ConntrackFilterType]netip.Prefix{
+			ConntrackOrigSrcIP:  NewPrefix(flow.Forward.SrcIP),
+			ConntrackOrigDstIP:  NewPrefix(flow.Forward.DstIP),
+			ConntrackReplySrcIP: NewPrefix(flow.Reverse.SrcIP),
+			ConntrackReplyDstIP: NewPrefix(flow.Reverse.DstIP),
 		},
 		portFilter: map[ConntrackFilterType]uint16{
 			ConntrackOrigSrcPort: flow.Forward.SrcPort,
@@ -1655,15 +1655,15 @@ func TestConntrackDeleteV6(t *testing.T) {
 	flow := ConntrackFlow{
 		FamilyType: FAMILY_V6,
 		Forward: IPTuple{
-			SrcIP:    net.ParseIP("2001:db8::68"),
-			DstIP:    net.ParseIP("2001:db9::32"),
+			SrcIP:    netip.MustParseAddr("2001:db8::68"),
+			DstIP:    netip.MustParseAddr("2001:db9::32"),
 			SrcPort:  48385,
 			DstPort:  53,
 			Protocol: unix.IPPROTO_TCP,
 		},
 		Reverse: IPTuple{
-			SrcIP:    net.ParseIP("2001:db9::32"),
-			DstIP:    net.ParseIP("2001:db8::68"),
+			SrcIP:    netip.MustParseAddr("2001:db9::32"),
+			DstIP:    netip.MustParseAddr("2001:db8::68"),
 			SrcPort:  53,
 			DstPort:  48385,
 			Protocol: unix.IPPROTO_TCP,
@@ -1687,11 +1687,11 @@ func TestConntrackDeleteV6(t *testing.T) {
 		t.Fatalf("failed to list conntracks following successful insert: %s", err)
 	}
 	filter := ConntrackFilter{
-		ipNetFilter: map[ConntrackFilterType]*net.IPNet{
-			ConntrackOrigSrcIP:  NewIPNet(flow.Forward.SrcIP),
-			ConntrackOrigDstIP:  NewIPNet(flow.Forward.DstIP),
-			ConntrackReplySrcIP: NewIPNet(flow.Reverse.SrcIP),
-			ConntrackReplyDstIP: NewIPNet(flow.Reverse.DstIP),
+		ipNetFilter: map[ConntrackFilterType]netip.Prefix{
+			ConntrackOrigSrcIP:  NewPrefix(flow.Forward.SrcIP),
+			ConntrackOrigDstIP:  NewPrefix(flow.Forward.DstIP),
+			ConntrackReplySrcIP: NewPrefix(flow.Reverse.SrcIP),
+			ConntrackReplyDstIP: NewPrefix(flow.Reverse.DstIP),
 		},
 		portFilter: map[ConntrackFilterType]uint16{
 			ConntrackOrigSrcPort: flow.Forward.SrcPort,
@@ -1753,15 +1753,15 @@ func TestConntrackLabels(t *testing.T) {
 	flow := ConntrackFlow{
 		FamilyType: FAMILY_V4,
 		Forward: IPTuple{
-			SrcIP:    net.IP{234, 234, 234, 234},
-			DstIP:    net.IP{123, 123, 123, 123},
+			SrcIP:    netip.MustParseAddr("234.234.234.234"),
+			DstIP:    netip.MustParseAddr("123.123.123.123"),
 			SrcPort:  48385,
 			DstPort:  53,
 			Protocol: unix.IPPROTO_TCP,
 		},
 		Reverse: IPTuple{
-			SrcIP:    net.IP{123, 123, 123, 123},
-			DstIP:    net.IP{234, 234, 234, 234},
+			SrcIP:    netip.MustParseAddr("123.123.123.123"),
+			DstIP:    netip.MustParseAddr("234.234.234.234"),
 			SrcPort:  53,
 			DstPort:  48385,
 			Protocol: unix.IPPROTO_TCP,
@@ -1792,11 +1792,11 @@ func TestConntrackLabels(t *testing.T) {
 	}
 
 	filter := ConntrackFilter{
-		ipNetFilter: map[ConntrackFilterType]*net.IPNet{
-			ConntrackOrigSrcIP:  NewIPNet(flow.Forward.SrcIP),
-			ConntrackOrigDstIP:  NewIPNet(flow.Forward.DstIP),
-			ConntrackReplySrcIP: NewIPNet(flow.Reverse.SrcIP),
-			ConntrackReplyDstIP: NewIPNet(flow.Reverse.DstIP),
+		ipNetFilter: map[ConntrackFilterType]netip.Prefix{
+			ConntrackOrigSrcIP:  NewPrefix(flow.Forward.SrcIP),
+			ConntrackOrigDstIP:  NewPrefix(flow.Forward.DstIP),
+			ConntrackReplySrcIP: NewPrefix(flow.Reverse.SrcIP),
+			ConntrackReplyDstIP: NewPrefix(flow.Reverse.DstIP),
 		},
 		portFilter: map[ConntrackFilterType]uint16{
 			ConntrackOrigSrcPort: flow.Forward.SrcPort,

--- a/conntrack_test.go
+++ b/conntrack_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"fmt"
 	"net"
+	"net/netip"
 	"os"
 	"os/exec"
 	"runtime"
@@ -215,7 +216,7 @@ func TestConntrackTableList(t *testing.T) {
 	var found int
 	for _, flow := range flows {
 		if flow.Forward.Protocol == 17 &&
-			flow.Forward.DstIP.Equal(net.ParseIP("127.0.0.10")) &&
+			flow.Forward.DstIP == netip.MustParseAddr("127.0.0.10") &&
 			flow.Forward.DstPort == 3000 &&
 			(flow.Forward.SrcPort >= 2000 && flow.Forward.SrcPort <= 2005) {
 			found++
@@ -282,7 +283,7 @@ func TestConntrackTableFlush(t *testing.T) {
 	var found int
 	for _, flow := range flows {
 		if flow.Forward.Protocol == 17 &&
-			flow.Forward.DstIP.Equal(net.ParseIP("127.0.0.10")) &&
+			flow.Forward.DstIP == netip.MustParseAddr("127.0.0.10") &&
 			flow.Forward.DstPort == 4000 &&
 			(flow.Forward.SrcPort >= 3000 && flow.Forward.SrcPort <= 3005) {
 			found++
@@ -304,7 +305,7 @@ func TestConntrackTableFlush(t *testing.T) {
 	found = 0
 	for _, flow := range flows {
 		if flow.Forward.Protocol == 17 &&
-			flow.Forward.DstIP.Equal(net.ParseIP("127.0.0.10")) &&
+			flow.Forward.DstIP == netip.MustParseAddr("127.0.0.10") &&
 			flow.Forward.DstPort == 4000 &&
 			(flow.Forward.SrcPort >= 3000 && flow.Forward.SrcPort <= 3005) {
 			found++
@@ -356,13 +357,13 @@ func TestConntrackTableDelete(t *testing.T) {
 	var groupB int
 	for _, flow := range flows {
 		if flow.Forward.Protocol == 17 &&
-			flow.Forward.DstIP.Equal(net.ParseIP("127.0.0.10")) &&
+			flow.Forward.DstIP == netip.MustParseAddr("127.0.0.10") &&
 			flow.Forward.DstPort == 6000 &&
 			(flow.Forward.SrcPort >= 5000 && flow.Forward.SrcPort <= 5005) {
 			groupA++
 		}
 		if flow.Forward.Protocol == 17 &&
-			flow.Forward.DstIP.Equal(net.ParseIP("127.0.0.20")) &&
+			flow.Forward.DstIP == netip.MustParseAddr("127.0.0.20") &&
 			flow.Forward.DstPort == 8000 &&
 			(flow.Forward.SrcPort >= 7000 && flow.Forward.SrcPort <= 7005) {
 			groupB++
@@ -374,7 +375,7 @@ func TestConntrackTableDelete(t *testing.T) {
 
 	// Create a filter to erase groupB flows
 	filter := &ConntrackFilter{}
-	filter.AddIP(ConntrackOrigDstIP, net.ParseIP("127.0.0.20"))
+	filter.AddIP(ConntrackOrigDstIP, netip.MustParseAddr("127.0.0.20"))
 	filter.AddProtocol(17)
 	filter.AddPort(ConntrackOrigDstPort, 8000)
 
@@ -396,13 +397,13 @@ func TestConntrackTableDelete(t *testing.T) {
 	groupB = 0
 	for _, flow := range flows {
 		if flow.Forward.Protocol == 17 &&
-			flow.Forward.DstIP.Equal(net.ParseIP("127.0.0.10")) &&
+			flow.Forward.DstIP == netip.MustParseAddr("127.0.0.10") &&
 			flow.Forward.DstPort == 6000 &&
 			(flow.Forward.SrcPort >= 5000 && flow.Forward.SrcPort <= 5005) {
 			groupA++
 		}
 		if flow.Forward.Protocol == 17 &&
-			flow.Forward.DstIP.Equal(net.ParseIP("127.0.0.20")) &&
+			flow.Forward.DstIP == netip.MustParseAddr("127.0.0.20") &&
 			flow.Forward.DstPort == 8000 &&
 			(flow.Forward.SrcPort >= 7000 && flow.Forward.SrcPort <= 7005) {
 			groupB++
@@ -421,15 +422,15 @@ func TestConntrackFilter(t *testing.T) {
 	flowList = append(flowList, ConntrackFlow{
 		FamilyType: unix.AF_INET,
 		Forward: IPTuple{
-			SrcIP:    net.ParseIP("10.0.0.1"),
-			DstIP:    net.ParseIP("20.0.0.1"),
+			SrcIP:    netip.MustParseAddr("10.0.0.1"),
+			DstIP:    netip.MustParseAddr("20.0.0.1"),
 			SrcPort:  1000,
 			DstPort:  2000,
 			Protocol: 17,
 		},
 		Reverse: IPTuple{
-			SrcIP:    net.ParseIP("20.0.0.1"),
-			DstIP:    net.ParseIP("192.168.1.1"),
+			SrcIP:    netip.MustParseAddr("20.0.0.1"),
+			DstIP:    netip.MustParseAddr("192.168.1.1"),
 			SrcPort:  2000,
 			DstPort:  1000,
 			Protocol: 17,
@@ -438,15 +439,15 @@ func TestConntrackFilter(t *testing.T) {
 		ConntrackFlow{
 			FamilyType: unix.AF_INET,
 			Forward: IPTuple{
-				SrcIP:    net.ParseIP("10.0.0.2"),
-				DstIP:    net.ParseIP("20.0.0.2"),
+				SrcIP:    netip.MustParseAddr("10.0.0.2"),
+				DstIP:    netip.MustParseAddr("20.0.0.2"),
 				SrcPort:  5000,
 				DstPort:  6000,
 				Protocol: 6,
 			},
 			Reverse: IPTuple{
-				SrcIP:    net.ParseIP("20.0.0.2"),
-				DstIP:    net.ParseIP("192.168.1.1"),
+				SrcIP:    netip.MustParseAddr("20.0.0.2"),
+				DstIP:    netip.MustParseAddr("192.168.1.1"),
 				SrcPort:  6000,
 				DstPort:  5000,
 				Protocol: 6,
@@ -457,15 +458,15 @@ func TestConntrackFilter(t *testing.T) {
 		ConntrackFlow{
 			FamilyType: unix.AF_INET6,
 			Forward: IPTuple{
-				SrcIP:    net.ParseIP("eeee:eeee:eeee:eeee:eeee:eeee:eeee:eeee"),
-				DstIP:    net.ParseIP("dddd:dddd:dddd:dddd:dddd:dddd:dddd:dddd"),
+				SrcIP:    netip.MustParseAddr("eeee:eeee:eeee:eeee:eeee:eeee:eeee:eeee"),
+				DstIP:    netip.MustParseAddr("dddd:dddd:dddd:dddd:dddd:dddd:dddd:dddd"),
 				SrcPort:  1000,
 				DstPort:  2000,
 				Protocol: 132,
 			},
 			Reverse: IPTuple{
-				SrcIP:    net.ParseIP("dddd:dddd:dddd:dddd:dddd:dddd:dddd:dddd"),
-				DstIP:    net.ParseIP("eeee:eeee:eeee:eeee:eeee:eeee:eeee:eeee"),
+				SrcIP:    netip.MustParseAddr("dddd:dddd:dddd:dddd:dddd:dddd:dddd:dddd"),
+				DstIP:    netip.MustParseAddr("eeee:eeee:eeee:eeee:eeee:eeee:eeee:eeee"),
 				SrcPort:  2000,
 				DstPort:  1000,
 				Protocol: 132,
@@ -483,11 +484,11 @@ func TestConntrackFilter(t *testing.T) {
 
 	// Adding same attribute should fail
 	filter := &ConntrackFilter{}
-	err := filter.AddIP(ConntrackOrigSrcIP, net.ParseIP("10.0.0.1"))
+	err := filter.AddIP(ConntrackOrigSrcIP, netip.MustParseAddr("10.0.0.1"))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if err := filter.AddIP(ConntrackOrigSrcIP, net.ParseIP("10.0.0.1")); err == nil {
+	if err := filter.AddIP(ConntrackOrigSrcIP, netip.MustParseAddr("10.0.0.1")); err == nil {
 		t.Fatalf("Error, it should fail adding same attribute to the filter")
 	}
 	err = filter.AddProtocol(6)
@@ -538,13 +539,13 @@ func TestConntrackFilter(t *testing.T) {
 
 	// SrcIP filter
 	filterV4 = &ConntrackFilter{}
-	err = filterV4.AddIP(ConntrackOrigSrcIP, net.ParseIP("10.0.0.1"))
+	err = filterV4.AddIP(ConntrackOrigSrcIP, netip.MustParseAddr("10.0.0.1"))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
 	filterV6 = &ConntrackFilter{}
-	err = filterV6.AddIP(ConntrackOrigSrcIP, net.ParseIP("eeee:eeee:eeee:eeee:eeee:eeee:eeee:eeee"))
+	err = filterV6.AddIP(ConntrackOrigSrcIP, netip.MustParseAddr("eeee:eeee:eeee:eeee:eeee:eeee:eeee:eeee"))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -556,13 +557,13 @@ func TestConntrackFilter(t *testing.T) {
 
 	// DstIp filter
 	filterV4 = &ConntrackFilter{}
-	err = filterV4.AddIP(ConntrackOrigDstIP, net.ParseIP("20.0.0.1"))
+	err = filterV4.AddIP(ConntrackOrigDstIP, netip.MustParseAddr("20.0.0.1"))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
 	filterV6 = &ConntrackFilter{}
-	err = filterV6.AddIP(ConntrackOrigDstIP, net.ParseIP("dddd:dddd:dddd:dddd:dddd:dddd:dddd:dddd"))
+	err = filterV6.AddIP(ConntrackOrigDstIP, netip.MustParseAddr("dddd:dddd:dddd:dddd:dddd:dddd:dddd:dddd"))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -574,13 +575,13 @@ func TestConntrackFilter(t *testing.T) {
 
 	// SrcIP for NAT
 	filterV4 = &ConntrackFilter{}
-	err = filterV4.AddIP(ConntrackReplySrcIP, net.ParseIP("20.0.0.1"))
+	err = filterV4.AddIP(ConntrackReplySrcIP, netip.MustParseAddr("20.0.0.1"))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
 	filterV6 = &ConntrackFilter{}
-	err = filterV6.AddIP(ConntrackReplySrcIP, net.ParseIP("dddd:dddd:dddd:dddd:dddd:dddd:dddd:dddd"))
+	err = filterV6.AddIP(ConntrackReplySrcIP, netip.MustParseAddr("dddd:dddd:dddd:dddd:dddd:dddd:dddd:dddd"))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -592,13 +593,13 @@ func TestConntrackFilter(t *testing.T) {
 
 	// DstIP for NAT
 	filterV4 = &ConntrackFilter{}
-	err = filterV4.AddIP(ConntrackReplyDstIP, net.ParseIP("192.168.1.1"))
+	err = filterV4.AddIP(ConntrackReplyDstIP, netip.MustParseAddr("192.168.1.1"))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
 	filterV6 = &ConntrackFilter{}
-	err = filterV6.AddIP(ConntrackReplyDstIP, net.ParseIP("dddd:dddd:dddd:dddd:dddd:dddd:dddd:dddd"))
+	err = filterV6.AddIP(ConntrackReplyDstIP, netip.MustParseAddr("dddd:dddd:dddd:dddd:dddd:dddd:dddd:dddd"))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -610,13 +611,13 @@ func TestConntrackFilter(t *testing.T) {
 
 	// AnyIp for Nat
 	filterV4 = &ConntrackFilter{}
-	err = filterV4.AddIP(ConntrackReplyAnyIP, net.ParseIP("192.168.1.1"))
+	err = filterV4.AddIP(ConntrackReplyAnyIP, netip.MustParseAddr("192.168.1.1"))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
 	filterV6 = &ConntrackFilter{}
-	err = filterV6.AddIP(ConntrackReplyAnyIP, net.ParseIP("eeee:eeee:eeee:eeee:eeee:eeee:eeee:eeee"))
+	err = filterV6.AddIP(ConntrackReplyAnyIP, netip.MustParseAddr("eeee:eeee:eeee:eeee:eeee:eeee:eeee:eeee"))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -1084,15 +1085,15 @@ func TestConntrackUpdateV4(t *testing.T) {
 	flow := ConntrackFlow{
 		FamilyType: FAMILY_V4,
 		Forward: IPTuple{
-			SrcIP:    net.IP{234, 234, 234, 234},
-			DstIP:    net.IP{123, 123, 123, 123},
+			SrcIP:    netip.MustParseAddr("234.234.234.234"),
+			DstIP:    netip.MustParseAddr("123.123.123.123"),
 			SrcPort:  48385,
 			DstPort:  53,
 			Protocol: unix.IPPROTO_TCP,
 		},
 		Reverse: IPTuple{
-			SrcIP:    net.IP{123, 123, 123, 123},
-			DstIP:    net.IP{234, 234, 234, 234},
+			SrcIP:    netip.MustParseAddr("123.123.123.123"),
+			DstIP:    netip.MustParseAddr("234.234.234.234"),
 			SrcPort:  53,
 			DstPort:  48385,
 			Protocol: unix.IPPROTO_TCP,
@@ -1122,7 +1123,7 @@ func TestConntrackUpdateV4(t *testing.T) {
 	}
 
 	filter := ConntrackFilter{
-		ipNetFilter: map[ConntrackFilterType]*net.IPNet{
+		ipNetFilter: map[ConntrackFilterType]netip.Prefix{
 			ConntrackOrigSrcIP:  NewIPNet(flow.Forward.SrcIP),
 			ConntrackOrigDstIP:  NewIPNet(flow.Forward.DstIP),
 			ConntrackReplySrcIP: NewIPNet(flow.Reverse.SrcIP),
@@ -1217,15 +1218,15 @@ func TestConntrackUpdateV6(t *testing.T) {
 	flow := ConntrackFlow{
 		FamilyType: FAMILY_V6,
 		Forward: IPTuple{
-			SrcIP:    net.ParseIP("2001:db8::68"),
-			DstIP:    net.ParseIP("2001:db9::32"),
+			SrcIP:    netip.MustParseAddr("2001:db8::68"),
+			DstIP:    netip.MustParseAddr("2001:db9::32"),
 			SrcPort:  48385,
 			DstPort:  53,
 			Protocol: unix.IPPROTO_TCP,
 		},
 		Reverse: IPTuple{
-			SrcIP:    net.ParseIP("2001:db9::32"),
-			DstIP:    net.ParseIP("2001:db8::68"),
+			SrcIP:    netip.MustParseAddr("2001:db9::32"),
+			DstIP:    netip.MustParseAddr("2001:db8::68"),
 			SrcPort:  53,
 			DstPort:  48385,
 			Protocol: unix.IPPROTO_TCP,
@@ -1255,7 +1256,7 @@ func TestConntrackUpdateV6(t *testing.T) {
 	}
 
 	filter := ConntrackFilter{
-		ipNetFilter: map[ConntrackFilterType]*net.IPNet{
+		ipNetFilter: map[ConntrackFilterType]netip.Prefix{
 			ConntrackOrigSrcIP:  NewIPNet(flow.Forward.SrcIP),
 			ConntrackOrigDstIP:  NewIPNet(flow.Forward.DstIP),
 			ConntrackReplySrcIP: NewIPNet(flow.Reverse.SrcIP),
@@ -1348,15 +1349,15 @@ func TestConntrackCreateV4(t *testing.T) {
 	flow := ConntrackFlow{
 		FamilyType: FAMILY_V4,
 		Forward: IPTuple{
-			SrcIP:    net.IP{234, 234, 234, 234},
-			DstIP:    net.IP{123, 123, 123, 123},
+			SrcIP:    netip.MustParseAddr("234.234.234.234"),
+			DstIP:    netip.MustParseAddr("123.123.123.123"),
 			SrcPort:  48385,
 			DstPort:  53,
 			Protocol: unix.IPPROTO_TCP,
 		},
 		Reverse: IPTuple{
-			SrcIP:    net.IP{123, 123, 123, 123},
-			DstIP:    net.IP{234, 234, 234, 234},
+			SrcIP:    netip.MustParseAddr("123.123.123.123"),
+			DstIP:    netip.MustParseAddr("234.234.234.234"),
 			SrcPort:  53,
 			DstPort:  48385,
 			Protocol: unix.IPPROTO_TCP,
@@ -1381,7 +1382,7 @@ func TestConntrackCreateV4(t *testing.T) {
 	}
 
 	filter := ConntrackFilter{
-		ipNetFilter: map[ConntrackFilterType]*net.IPNet{
+		ipNetFilter: map[ConntrackFilterType]netip.Prefix{
 			ConntrackOrigSrcIP:  NewIPNet(flow.Forward.SrcIP),
 			ConntrackOrigDstIP:  NewIPNet(flow.Forward.DstIP),
 			ConntrackReplySrcIP: NewIPNet(flow.Reverse.SrcIP),
@@ -1443,15 +1444,15 @@ func TestConntrackCreateV6(t *testing.T) {
 	flow := ConntrackFlow{
 		FamilyType: FAMILY_V6,
 		Forward: IPTuple{
-			SrcIP:    net.ParseIP("2001:db8::68"),
-			DstIP:    net.ParseIP("2001:db9::32"),
+			SrcIP:    netip.MustParseAddr("2001:db8::68"),
+			DstIP:    netip.MustParseAddr("2001:db9::32"),
 			SrcPort:  48385,
 			DstPort:  53,
 			Protocol: unix.IPPROTO_TCP,
 		},
 		Reverse: IPTuple{
-			SrcIP:    net.ParseIP("2001:db9::32"),
-			DstIP:    net.ParseIP("2001:db8::68"),
+			SrcIP:    netip.MustParseAddr("2001:db9::32"),
+			DstIP:    netip.MustParseAddr("2001:db8::68"),
 			SrcPort:  53,
 			DstPort:  48385,
 			Protocol: unix.IPPROTO_TCP,
@@ -1476,7 +1477,7 @@ func TestConntrackCreateV6(t *testing.T) {
 	}
 
 	filter := ConntrackFilter{
-		ipNetFilter: map[ConntrackFilterType]*net.IPNet{
+		ipNetFilter: map[ConntrackFilterType]netip.Prefix{
 			ConntrackOrigSrcIP:  NewIPNet(flow.Forward.SrcIP),
 			ConntrackOrigDstIP:  NewIPNet(flow.Forward.DstIP),
 			ConntrackReplySrcIP: NewIPNet(flow.Reverse.SrcIP),
@@ -1865,15 +1866,15 @@ func TestConntrackFlowToNlData(t *testing.T) {
 	flowV4 := ConntrackFlow{
 		FamilyType: FAMILY_V4,
 		Forward: IPTuple{
-			SrcIP:    net.IP{234, 234, 234, 234},
-			DstIP:    net.IP{123, 123, 123, 123},
+			SrcIP:    netip.MustParseAddr("234.234.234.234"),
+			DstIP:    netip.MustParseAddr("123.123.123.123"),
 			SrcPort:  48385,
 			DstPort:  53,
 			Protocol: unix.IPPROTO_TCP,
 		},
 		Reverse: IPTuple{
-			SrcIP:    net.IP{123, 123, 123, 123},
-			DstIP:    net.IP{234, 234, 234, 234},
+			SrcIP:    netip.MustParseAddr("123.123.123.123"),
+			DstIP:    netip.MustParseAddr("234.234.234.234"),
 			SrcPort:  53,
 			DstPort:  48385,
 			Protocol: unix.IPPROTO_TCP,
@@ -1888,15 +1889,15 @@ func TestConntrackFlowToNlData(t *testing.T) {
 	flowV6 := ConntrackFlow{
 		FamilyType: FAMILY_V6,
 		Forward: IPTuple{
-			SrcIP:    net.ParseIP("2001:db8::68"),
-			DstIP:    net.ParseIP("2001:db9::32"),
+			SrcIP:    netip.MustParseAddr("2001:db8::68"),
+			DstIP:    netip.MustParseAddr("2001:db9::32"),
 			SrcPort:  48385,
 			DstPort:  53,
 			Protocol: unix.IPPROTO_TCP,
 		},
 		Reverse: IPTuple{
-			SrcIP:    net.ParseIP("2001:db9::32"),
-			DstIP:    net.ParseIP("2001:db8::68"),
+			SrcIP:    netip.MustParseAddr("2001:db9::32"),
+			DstIP:    netip.MustParseAddr("2001:db8::68"),
 			SrcPort:  53,
 			DstPort:  48385,
 			Protocol: unix.IPPROTO_TCP,
@@ -1989,11 +1990,11 @@ func tuplesEqual(t1, t2 IPTuple) bool {
 		return false
 	}
 
-	if !t1.DstIP.Equal(t2.DstIP) {
+	if t1.DstIP != t2.DstIP {
 		return false
 	}
 
-	if !t1.SrcIP.Equal(t2.SrcIP) {
+	if t1.SrcIP != t2.SrcIP {
 		return false
 	}
 

--- a/filter.go
+++ b/filter.go
@@ -3,6 +3,7 @@ package netlink
 import (
 	"fmt"
 	"net"
+	"net/netip"
 )
 
 type Filter interface {
@@ -317,8 +318,8 @@ const (
 type TunnelKeyAction struct {
 	ActionAttrs
 	Action   TunnelKeyAct
-	SrcAddr  net.IP
-	DstAddr  net.IP
+	SrcAddr  netip.Addr
+	DstAddr  netip.Addr
 	KeyID    uint32
 	DestPort uint16
 }
@@ -491,8 +492,8 @@ type PeditAction struct {
 	Proto      uint8
 	SrcMacAddr net.HardwareAddr
 	DstMacAddr net.HardwareAddr
-	SrcIP      net.IP
-	DstIP      net.IP
+	SrcIP      netip.Addr
+	DstIP      netip.Addr
 	SrcPort    uint16
 	DstPort    uint16
 }

--- a/filter_linux.go
+++ b/filter_linux.go
@@ -99,7 +99,7 @@ func (filter *Flower) encodeIP(parent *nl.RtAttr, ip netip.Prefix, v4Type, v6Typ
 		maskType = v6MaskType
 	}
 
-	parent.AddRtAttr(ipType, ip.Addr().AsSlice())
+	parent.AddRtAttr(ipType, ip.Masked().Addr().AsSlice())
 	parent.AddRtAttr(maskType, encodeMask)
 }
 
@@ -913,19 +913,19 @@ func parsePeditExtendedKeys(pedit *nl.TcPedit, action *PeditAction) {
 
 		case nl.TCA_PEDIT_KEY_EX_HDR_TYPE_IP4:
 			srcIP, dstIP := nl.ParsePeditIP4Keys(keys)
-			if srcIP != nil {
+			if srcIP.IsValid() {
 				action.SrcIP = srcIP
 			}
-			if dstIP != nil {
+			if dstIP.IsValid() {
 				action.DstIP = dstIP
 			}
 
 		case nl.TCA_PEDIT_KEY_EX_HDR_TYPE_IP6:
 			srcIP, dstIP := nl.ParsePeditIP6Keys(keys)
-			if srcIP != nil {
+			if srcIP.IsValid() {
 				action.SrcIP = srcIP
 			}
-			if dstIP != nil {
+			if dstIP.IsValid() {
 				action.DstIP = dstIP
 			}
 

--- a/filter_test.go
+++ b/filter_test.go
@@ -1829,17 +1829,17 @@ func TestFilterFlowerAddDel(t *testing.T) {
 	if filter.EthType != flower.EthType {
 		t.Fatalf("Flower EthType doesn't match")
 	}
-	if filter.Dest != flower.Dest {
+	if filter.Dest.Masked() != flower.Dest.Masked() {
 		t.Fatalf("Flower DestIP doesn't match")
 	}
-	if filter.Src != flower.Src {
+	if filter.Src.Masked() != flower.Src.Masked() {
 		t.Fatalf("Flower SrcIP doesn't match")
 	}
 
-	if filter.EncDest != flower.EncDest {
+	if filter.EncDest.Masked() != flower.EncDest.Masked() {
 		t.Fatalf("Flower EncDestIP doesn't match")
 	}
-	if filter.EncSrc != flower.EncSrc {
+	if filter.EncSrc.Masked() != flower.EncSrc.Masked() {
 		t.Fatalf("Flower EncSrcIP doesn't match")
 	}
 	if filter.EncKeyId != flower.EncKeyId {
@@ -2186,7 +2186,7 @@ func TestFilterIPv6FlowerPedit(t *testing.T) {
 	if filter.EthType != flower.EthType {
 		t.Fatalf("Flower EthType doesn't match")
 	}
-	if filter.Dest != flower.Dest {
+	if filter.Dest.Masked() != flower.Dest.Masked() {
 		t.Fatalf("Flower DestIP doesn't match")
 	}
 

--- a/fou.go
+++ b/fou.go
@@ -1,16 +1,14 @@
 package netlink
 
-import (
-	"net"
-)
+import "net/netip"
 
 type Fou struct {
 	Family    int
 	Port      int
 	Protocol  int
 	EncapType int
-	Local     net.IP
-	Peer      net.IP
+	Local     netip.Addr
+	Peer      netip.Addr
 	PeerPort  int
 	IfIndex   int
 }

--- a/fou_linux.go
+++ b/fou_linux.go
@@ -6,7 +6,7 @@ package netlink
 import (
 	"encoding/binary"
 	"errors"
-	"net"
+	"net/netip"
 
 	"github.com/vishvananda/netlink/nl"
 	"golang.org/x/sys/unix"
@@ -189,9 +189,9 @@ func deserializeFouMsg(msg []byte) Fou {
 		case FOU_ATTR_TYPE:
 			fou.EncapType = int(attr.Value[0])
 		case FOU_ATTR_LOCAL_V4, FOU_ATTR_LOCAL_V6:
-			fou.Local = net.IP(attr.Value)
+			fou.Local, _ = netip.AddrFromSlice(attr.Value)
 		case FOU_ATTR_PEER_V4, FOU_ATTR_PEER_V6:
-			fou.Peer = net.IP(attr.Value)
+			fou.Peer, _ = netip.AddrFromSlice(attr.Value)
 		case FOU_ATTR_PEER_PORT:
 			fou.PeerPort = int(networkOrder.Uint16(attr.Value))
 		case FOU_ATTR_IFINDEX:

--- a/fou_test.go
+++ b/fou_test.go
@@ -4,7 +4,7 @@
 package netlink
 
 import (
-	"net"
+	"net/netip"
 	"testing"
 )
 
@@ -54,11 +54,11 @@ func TestFouDeserializeMsg(t *testing.T) {
 		t.Errorf("expected encap type %d, got %d", FOU_ENCAP_GUE, fou.EncapType)
 	}
 
-	if expected := net.IPv4(1, 2, 3, 4); !fou.Local.Equal(expected) {
+	if expected := netip.MustParseAddr("1.2.3.4"); fou.Local != expected {
 		t.Errorf("expected local %v, got %v", expected, fou.Local)
 	}
 
-	if expected := net.IPv4(5, 6, 7, 8); !fou.Peer.Equal(expected) {
+	if expected := netip.MustParseAddr("5.6.7.8"); fou.Peer != expected {
 		t.Errorf("expected peer %v, got %v", expected, fou.Peer)
 	}
 

--- a/gtp_linux.go
+++ b/gtp_linux.go
@@ -183,7 +183,11 @@ func (h *Handle) GTPPDPByMSAddress(link Link, addr netip.Addr) (*PDP, error) {
 	req.AddData(msg)
 	req.AddData(nl.NewRtAttr(nl.GENL_GTP_ATTR_VERSION, nl.Uint32Attr(0)))
 	req.AddData(nl.NewRtAttr(nl.GENL_GTP_ATTR_LINK, nl.Uint32Attr(uint32(link.Attrs().Index))))
-	req.AddData(nl.NewRtAttr(nl.GENL_GTP_ATTR_MS_ADDRESS, addr.AsSlice()))
+	addr4 := addr.Unmap()
+	if !addr4.Is4() {
+		return nil, fmt.Errorf("GTP MS address must be IPv4: %s", addr)
+	}
+	req.AddData(nl.NewRtAttr(nl.GENL_GTP_ATTR_MS_ADDRESS, addr4.AsSlice()))
 	return gtpPDPGet(req)
 }
 
@@ -204,8 +208,16 @@ func (h *Handle) GTPPDPAdd(link Link, pdp *PDP) error {
 	req.AddData(msg)
 	req.AddData(nl.NewRtAttr(nl.GENL_GTP_ATTR_VERSION, nl.Uint32Attr(pdp.Version)))
 	req.AddData(nl.NewRtAttr(nl.GENL_GTP_ATTR_LINK, nl.Uint32Attr(uint32(link.Attrs().Index))))
-	req.AddData(nl.NewRtAttr(nl.GENL_GTP_ATTR_PEER_ADDRESS, pdp.PeerAddress.AsSlice()))
-	req.AddData(nl.NewRtAttr(nl.GENL_GTP_ATTR_MS_ADDRESS, pdp.MSAddress.AsSlice()))
+	peerAddr := pdp.PeerAddress.Unmap()
+	if !peerAddr.Is4() {
+		return fmt.Errorf("GTP peer address must be IPv4: %s", pdp.PeerAddress)
+	}
+	msAddr := pdp.MSAddress.Unmap()
+	if !msAddr.Is4() {
+		return fmt.Errorf("GTP MS address must be IPv4: %s", pdp.MSAddress)
+	}
+	req.AddData(nl.NewRtAttr(nl.GENL_GTP_ATTR_PEER_ADDRESS, peerAddr.AsSlice()))
+	req.AddData(nl.NewRtAttr(nl.GENL_GTP_ATTR_MS_ADDRESS, msAddr.AsSlice()))
 
 	switch pdp.Version {
 	case 0:

--- a/gtp_test.go
+++ b/gtp_test.go
@@ -4,7 +4,7 @@
 package netlink
 
 import (
-	"net"
+	"net/netip"
 	"testing"
 )
 
@@ -19,8 +19,8 @@ func TestPDPv0AddDel(t *testing.T) {
 		t.Fatal(err)
 	}
 	err = GTPPDPAdd(link, &PDP{
-		PeerAddress: net.ParseIP("1.1.1.1"),
-		MSAddress:   net.ParseIP("2.2.2.2"),
+		PeerAddress: netip.MustParseAddr("1.1.1.1"),
+		MSAddress:   netip.MustParseAddr("2.2.2.2"),
 		TID:         10,
 	})
 	if err != nil {
@@ -33,7 +33,7 @@ func TestPDPv0AddDel(t *testing.T) {
 	if len(list) != 1 {
 		t.Fatal("Failed to add v0 PDP")
 	}
-	pdp, err := GTPPDPByMSAddress(link, net.ParseIP("2.2.2.2"))
+	pdp, err := GTPPDPByMSAddress(link, netip.MustParseAddr("2.2.2.2"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,8 +71,8 @@ func TestPDPv1AddDel(t *testing.T) {
 		t.Fatal(err)
 	}
 	err = GTPPDPAdd(link, &PDP{
-		PeerAddress: net.ParseIP("1.1.1.1"),
-		MSAddress:   net.ParseIP("2.2.2.2"),
+		PeerAddress: netip.MustParseAddr("1.1.1.1"),
+		MSAddress:   netip.MustParseAddr("2.2.2.2"),
 		Version:     1,
 		ITEI:        10,
 		OTEI:        10,
@@ -87,7 +87,7 @@ func TestPDPv1AddDel(t *testing.T) {
 	if len(list) != 1 {
 		t.Fatal("Failed to add v1 PDP")
 	}
-	pdp, err := GTPPDPByMSAddress(link, net.ParseIP("2.2.2.2"))
+	pdp, err := GTPPDPByMSAddress(link, netip.MustParseAddr("2.2.2.2"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/handle_test.go
+++ b/handle_test.go
@@ -8,7 +8,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"net"
+	"net/netip"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -180,8 +180,8 @@ var (
 
 func getXfrmState(thread int) *XfrmState {
 	return &XfrmState{
-		Src:   net.IPv4(byte(192), byte(168), 1, byte(1+thread)),
-		Dst:   net.IPv4(byte(192), byte(168), 2, byte(1+thread)),
+		Src:   netip.AddrFrom4([4]byte{192, 168, 1, byte(1 + thread)}),
+		Dst:   netip.AddrFrom4([4]byte{192, 168, 2, byte(1 + thread)}),
 		Proto: XFRM_PROTO_AH,
 		Mode:  XFRM_MODE_TUNNEL,
 		Spi:   thread,
@@ -193,17 +193,19 @@ func getXfrmState(thread int) *XfrmState {
 }
 
 func getXfrmPolicy(thread int) *XfrmPolicy {
+	subnet, _ := netip.AddrFrom4([4]byte{10, 10, byte(thread), 0}).Prefix(24)
+
 	return &XfrmPolicy{
-		Src:     &net.IPNet{IP: net.IPv4(byte(10), byte(10), byte(thread), 0), Mask: []byte{255, 255, 255, 0}},
-		Dst:     &net.IPNet{IP: net.IPv4(byte(10), byte(10), byte(thread), 0), Mask: []byte{255, 255, 255, 0}},
+		Src:     subnet,
+		Dst:     subnet,
 		Proto:   17,
 		DstPort: 1234,
 		SrcPort: 5678,
 		Dir:     XFRM_DIR_OUT,
 		Tmpls: []XfrmPolicyTmpl{
 			{
-				Src:   net.IPv4(byte(192), byte(168), 1, byte(thread)),
-				Dst:   net.IPv4(byte(192), byte(168), 2, byte(thread)),
+				Src:   netip.AddrFrom4([4]byte{192, 168, 1, byte(thread)}),
+				Dst:   netip.AddrFrom4([4]byte{192, 168, 2, byte(thread)}),
 				Proto: XFRM_PROTO_ESP,
 				Mode:  XFRM_MODE_TUNNEL,
 			},

--- a/handle_unspecified.go
+++ b/handle_unspecified.go
@@ -5,6 +5,7 @@ package netlink
 
 import (
 	"net"
+	"net/netip"
 	"time"
 
 	"github.com/vishvananda/netns"
@@ -276,7 +277,7 @@ func (h *Handle) RouteDel(route *Route) error {
 	return ErrNotImplemented
 }
 
-func (h *Handle) RouteGet(destination net.IP) ([]Route, error) {
+func (h *Handle) RouteGet(destination netip.Addr) ([]Route, error) {
 	return nil, ErrNotImplemented
 }
 

--- a/ipset_linux.go
+++ b/ipset_linux.go
@@ -3,6 +3,7 @@ package netlink
 import (
 	"encoding/binary"
 	"net"
+	"net/netip"
 	"syscall"
 
 	"github.com/vishvananda/netlink/nl"
@@ -13,14 +14,14 @@ import (
 type IPSetEntry struct {
 	Comment  string
 	MAC      net.HardwareAddr
-	IP       net.IP
+	IP       netip.Addr
 	CIDR     uint8
 	Timeout  *uint32
 	Packets  *uint64
 	Bytes    *uint64
 	Protocol *uint8
 	Port     *uint16
-	IP2      net.IP
+	IP2      netip.Addr
 	CIDR2    uint8
 	IFace    string
 	Mark     *uint32
@@ -41,8 +42,8 @@ type IPSetResult struct {
 	Comment            string
 	MarkMask           uint32
 
-	IPFrom   net.IP
-	IPTo     net.IP
+	IPFrom   netip.Addr
+	IPTo     netip.Addr
 	PortFrom uint16
 	PortTo   uint16
 
@@ -68,8 +69,8 @@ type IpsetCreateOptions struct {
 
 	Family      uint8
 	Revision    uint8
-	IPFrom      net.IP
-	IPTo        net.IP
+	IPFrom      netip.Addr
+	IPTo        netip.Addr
 	PortFrom    uint16
 	PortTo      uint16
 	MaxElements uint32
@@ -252,16 +253,15 @@ func (h *Handle) IpsetDel(setname string, entry *IPSetEntry) error {
 	return h.ipsetAddDel(nl.IPSET_CMD_DEL, setname, entry)
 }
 
-func encodeIP(ip net.IP) (*nl.RtAttr, error) {
+func encodeIP(ip netip.Addr) (*nl.RtAttr, error) {
 	typ := int(nl.NLA_F_NET_BYTEORDER)
-	if ip4 := ip.To4(); ip4 != nil {
+	if ip.Is4() {
 		typ |= nl.IPSET_ATTR_IPADDR_IPV4
-		ip = ip4
 	} else {
 		typ |= nl.IPSET_ATTR_IPADDR_IPV6
 	}
 
-	return nl.NewRtAttr(typ, ip), nil
+	return nl.NewRtAttr(typ, ip.AsSlice()), nil
 }
 
 func buildEntryData(entry *IPSetEntry) (*nl.RtAttr, error) {
@@ -275,7 +275,7 @@ func buildEntryData(entry *IPSetEntry) (*nl.RtAttr, error) {
 		data.AddChild(&nl.Uint32Attribute{Type: nl.IPSET_ATTR_TIMEOUT | nl.NLA_F_NET_BYTEORDER, Value: *entry.Timeout})
 	}
 
-	if entry.IP != nil {
+	if entry.IP.IsValid() {
 		nestedData, err := encodeIP(entry.IP)
 		if err != nil {
 			return nil, err
@@ -291,7 +291,7 @@ func buildEntryData(entry *IPSetEntry) (*nl.RtAttr, error) {
 		data.AddChild(nl.NewRtAttr(nl.IPSET_ATTR_CIDR, nl.Uint8Attr(entry.CIDR)))
 	}
 
-	if entry.IP2 != nil {
+	if entry.IP2.IsValid() {
 		nestedData, err := encodeIP(entry.IP2)
 		if err != nil {
 			return nil, err
@@ -539,16 +539,18 @@ func (result *IPSetResult) parseAttrData(data []byte) {
 			for nested := range nl.ParseAttributes(attr.Value) {
 				switch nested.Type {
 				case nl.IPSET_ATTR_IP | nl.NLA_F_NET_BYTEORDER:
-					result.Entries = append(result.Entries, IPSetEntry{IP: nested.Value})
+					addr, _ := netip.AddrFromSlice(nested.Value)
+					result.Entries = append(result.Entries, IPSetEntry{IP: addr})
 				case nl.IPSET_ATTR_IP:
-					result.IPFrom = nested.Value
+					addr, _ := netip.AddrFromSlice(nested.Value)
+					result.IPFrom = addr
 				}
 			}
 		case nl.IPSET_ATTR_IP_TO | nl.NLA_F_NESTED:
 			for nested := range nl.ParseAttributes(attr.Value) {
 				switch nested.Type {
 				case nl.IPSET_ATTR_IP:
-					result.IPTo = nested.Value
+					result.IPTo, _ = netip.AddrFromSlice(nested.Value)
 				}
 			}
 		case nl.IPSET_ATTR_PORT_FROM | nl.NLA_F_NET_BYTEORDER:
@@ -589,21 +591,21 @@ func parseIPSetEntry(data []byte) (entry IPSetEntry) {
 		case nl.IPSET_ATTR_ETHER:
 			entry.MAC = net.HardwareAddr(attr.Value)
 		case nl.IPSET_ATTR_IP:
-			entry.IP = net.IP(attr.Value)
+			entry.IP, _ = netip.AddrFromSlice(attr.Value)
 		case nl.IPSET_ATTR_COMMENT:
 			entry.Comment = nl.BytesToString(attr.Value)
 		case nl.IPSET_ATTR_IP | nl.NLA_F_NESTED:
 			for attr := range nl.ParseAttributes(attr.Value) {
 				switch attr.Type {
 				case nl.IPSET_ATTR_IPADDR_IPV4, nl.IPSET_ATTR_IPADDR_IPV6:
-					entry.IP = net.IP(attr.Value)
+					entry.IP, _ = netip.AddrFromSlice(attr.Value)
 				}
 			}
 		case nl.IPSET_ATTR_IP2 | nl.NLA_F_NESTED:
 			for attr := range nl.ParseAttributes(attr.Value) {
 				switch attr.Type {
 				case nl.IPSET_ATTR_IPADDR_IPV4, nl.IPSET_ATTR_IPADDR_IPV6:
-					entry.IP2 = net.IP(attr.Value)
+					entry.IP2, _ = netip.AddrFromSlice(attr.Value)
 				}
 			}
 		case nl.IPSET_ATTR_CIDR:

--- a/ipset_linux_test.go
+++ b/ipset_linux_test.go
@@ -3,6 +3,7 @@ package netlink
 import (
 	"bytes"
 	"net"
+	"net/netip"
 	"os"
 	"testing"
 
@@ -142,7 +143,7 @@ func TestIpsetCreateListAddDelDestroy(t *testing.T) {
 		t.Errorf("expected timeout to be 3, but got '%d'", *results[0].Timeout)
 	}
 
-	ip := net.ParseIP("10.99.99.99")
+	ip := netip.MustParseAddr("10.99.99.99")
 	exist, err := IpsetTest("my-test-ipset-1", &IPSetEntry{
 		IP: ip,
 	})
@@ -193,7 +194,7 @@ func TestIpsetCreateListAddDelDestroy(t *testing.T) {
 
 	err = IpsetDel("my-test-ipset-1", &IPSetEntry{
 		Comment: "test comment",
-		IP:      net.ParseIP("10.99.99.99"),
+		IP:      netip.MustParseAddr("10.99.99.99"),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -244,7 +245,7 @@ func TestIpsetCreateListAddDelDestroyWithTestCases(t *testing.T) {
 			},
 			entry: &IPSetEntry{
 				Comment: "test comment",
-				IP:      net.ParseIP("10.99.99.99"),
+				IP:      netip.MustParseAddr("10.99.99.99"),
 				Replace: false,
 			},
 		},
@@ -261,7 +262,7 @@ func TestIpsetCreateListAddDelDestroyWithTestCases(t *testing.T) {
 			},
 			entry: &IPSetEntry{
 				Comment: "test comment",
-				IP:      net.ParseIP("10.99.99.0"),
+				IP:      netip.MustParseAddr("10.99.99.0"),
 				CIDR:    24,
 				Replace: false,
 			},
@@ -279,9 +280,9 @@ func TestIpsetCreateListAddDelDestroyWithTestCases(t *testing.T) {
 			},
 			entry: &IPSetEntry{
 				Comment: "test comment",
-				IP:      net.ParseIP("10.99.99.0"),
+				IP:      netip.MustParseAddr("10.99.99.0"),
 				CIDR:    24,
-				IP2:     net.ParseIP("10.99.0.0"),
+				IP2:     netip.MustParseAddr("10.99.0.0"),
 				CIDR2:   24,
 				Replace: false,
 			},
@@ -299,8 +300,8 @@ func TestIpsetCreateListAddDelDestroyWithTestCases(t *testing.T) {
 			},
 			entry: &IPSetEntry{
 				Comment: "test comment",
-				IP:      net.ParseIP("10.99.99.0"),
-				IP2:     net.ParseIP("10.99.0.0"),
+				IP:      netip.MustParseAddr("10.99.99.0"),
+				IP2:     netip.MustParseAddr("10.99.0.0"),
 				Replace: false,
 			},
 		},
@@ -317,7 +318,7 @@ func TestIpsetCreateListAddDelDestroyWithTestCases(t *testing.T) {
 			},
 			entry: &IPSetEntry{
 				Comment:  "test comment",
-				IP:       net.ParseIP("10.99.99.1"),
+				IP:       netip.MustParseAddr("10.99.99.1"),
 				Protocol: &protocalTCP,
 				Port:     &port,
 				Replace:  false,
@@ -336,9 +337,9 @@ func TestIpsetCreateListAddDelDestroyWithTestCases(t *testing.T) {
 			},
 			entry: &IPSetEntry{
 				Comment:  "test comment",
-				IP:       net.ParseIP("10.99.99.0"),
+				IP:       netip.MustParseAddr("10.99.99.0"),
 				CIDR:     24,
-				IP2:      net.ParseIP("10.99.0.0"),
+				IP2:      netip.MustParseAddr("10.99.0.0"),
 				CIDR2:    24,
 				Protocol: &protocalTCP,
 				Port:     &port,
@@ -375,7 +376,7 @@ func TestIpsetCreateListAddDelDestroyWithTestCases(t *testing.T) {
 			},
 			entry: &IPSetEntry{
 				Comment: "test comment",
-				IP:      net.ParseIP("10.99.99.0"),
+				IP:      netip.MustParseAddr("10.99.99.0"),
 				CIDR:    24,
 				IFace:   "eth0",
 				Replace: false,
@@ -394,7 +395,7 @@ func TestIpsetCreateListAddDelDestroyWithTestCases(t *testing.T) {
 			},
 			entry: &IPSetEntry{
 				Comment: "test comment",
-				IP:      net.ParseIP("10.99.99.0"),
+				IP:      netip.MustParseAddr("10.99.99.0"),
 				Mark:    &timeout,
 				Replace: false,
 			},
@@ -413,7 +414,7 @@ func TestIpsetCreateListAddDelDestroyWithTestCases(t *testing.T) {
 			},
 			entry: &IPSetEntry{
 				Comment: "test comment",
-				IP:      net.ParseIP("::1"),
+				IP:      netip.MustParseAddr("::1"),
 				CIDR:    128,
 				Replace: false,
 			},
@@ -432,9 +433,9 @@ func TestIpsetCreateListAddDelDestroyWithTestCases(t *testing.T) {
 			},
 			entry: &IPSetEntry{
 				Comment: "test comment",
-				IP:      net.ParseIP("::1"),
+				IP:      netip.MustParseAddr("::1"),
 				CIDR:    128,
-				IP2:     net.ParseIP("::2"),
+				IP2:     netip.MustParseAddr("::2"),
 				CIDR2:   128,
 				Replace: false,
 			},
@@ -507,8 +508,8 @@ func TestIpsetCreateListAddDelDestroyWithTestCases(t *testing.T) {
 				t.Fatalf("expected 1 entry be created, got '%d'", len(result.Entries))
 			}
 
-			if tC.entry.IP != nil {
-				if !tC.entry.IP.Equal(result.Entries[0].IP) {
+			if tC.entry.IP.IsValid() {
+				if tC.entry.IP != result.Entries[0].IP {
 					t.Fatalf("expected entry to be '%v', got '%v'", tC.entry.IP, result.Entries[0].IP)
 				}
 			}
@@ -519,8 +520,8 @@ func TestIpsetCreateListAddDelDestroyWithTestCases(t *testing.T) {
 				}
 			}
 
-			if tC.entry.IP2 != nil {
-				if !tC.entry.IP2.Equal(result.Entries[0].IP2) {
+			if tC.entry.IP2.IsValid() {
+				if tC.entry.IP2 != result.Entries[0].IP2 {
 					t.Fatalf("expected entry.ip2 to be '%v', got '%v'", tC.entry.IP2, result.Entries[0].IP2)
 				}
 			}
@@ -621,7 +622,7 @@ func TestIpsetBitmapCreateListWithTestCases(t *testing.T) {
 			},
 			entry: &IPSetEntry{
 				Comment: "test comment",
-				IP:      net.ParseIP("10.99.99.0"),
+				IP:      netip.MustParseAddr("10.99.99.0"),
 				CIDR:    26,
 				Mark:    &timeout,
 				Replace: false,
@@ -648,7 +649,7 @@ func TestIpsetBitmapCreateListWithTestCases(t *testing.T) {
 					t.Fatalf("expected port range %d-%d, got %d-%d", tC.options.PortFrom, tC.options.PortTo, result.PortFrom, result.PortTo)
 				}
 			} else if tC.typename == "bitmap:ip" {
-				if result.IPFrom == nil || result.IPTo == nil || result.IPFrom.Equal(tC.options.IPFrom) || result.IPTo.Equal(tC.options.IPTo) {
+				if !result.IPFrom.IsValid() || !result.IPTo.IsValid() || result.IPFrom == tC.options.IPFrom || result.IPTo == tC.options.IPTo {
 					t.Fatalf("expected ip range %v-%v, got %v-%v", tC.options.IPFrom, tC.options.IPTo, result.IPFrom, result.IPTo)
 				}
 			}
@@ -684,7 +685,7 @@ func TestIpsetSwap(t *testing.T) {
 	}()
 
 	err = IpsetAdd(ipset1, &IPSetEntry{
-		IP: net.ParseIP("10.99.99.99"),
+		IP: netip.MustParseAddr("10.99.99.99"),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -725,15 +726,6 @@ func TestIpsetSwap(t *testing.T) {
 	assertHasOneEntry(ipset2)
 }
 
-func nextIP(ip net.IP) {
-	for j := len(ip) - 1; j >= 0; j-- {
-		ip[j]++
-		if ip[j] > 0 {
-			break
-		}
-	}
-}
-
 // TestIpsetMaxElements tests that we can create an ipset containing
 // 128k elements, which is double the default size (64k elements).
 func TestIpsetMaxElements(t *testing.T) {
@@ -753,7 +745,7 @@ func TestIpsetMaxElements(t *testing.T) {
 		_ = IpsetDestroy(ipsetName)
 	}()
 
-	ip := net.ParseIP("10.0.0.0")
+	ip := netip.MustParseAddr("10.0.0.0")
 	for i := uint32(0); i < maxElements; i++ {
 		err = IpsetAdd(ipsetName, &IPSetEntry{
 			IP: ip,
@@ -761,7 +753,7 @@ func TestIpsetMaxElements(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		nextIP(ip)
+		ip = ip.Next()
 	}
 
 	result, err := IpsetList(ipsetName)

--- a/link.go
+++ b/link.go
@@ -3,6 +3,7 @@ package netlink
 import (
 	"fmt"
 	"net"
+	"net/netip"
 	"os"
 	"strconv"
 )
@@ -505,8 +506,8 @@ type Vxlan struct {
 	LinkAttrs
 	VxlanId        int
 	VtepDevIndex   int
-	SrcAddr        net.IP
-	Group          net.IP
+	SrcAddr        netip.Addr
+	Group          netip.Addr
 	TTL            int
 	TOS            int
 	Learning       bool
@@ -916,7 +917,7 @@ type Bond struct {
 	DownDelay       int
 	UseCarrier      int
 	ArpInterval     int
-	ArpIpTargets    []net.IP
+	ArpIpTargets    []netip.Addr
 	ArpValidate     BondArpValidate
 	ArpAllTargets   BondArpAllTargets
 	Primary         int
@@ -1092,7 +1093,7 @@ func (o *OpenvSwitchSlave) SlaveType() string {
 type Geneve struct {
 	LinkAttrs
 	ID                uint32 // vni
-	Remote            net.IP
+	Remote            netip.Addr
 	Ttl               uint8
 	Tos               uint8
 	Dport             uint16
@@ -1131,8 +1132,8 @@ type Gretap struct {
 	OKey       uint32
 	EncapSport uint16
 	EncapDport uint16
-	Local      net.IP
-	Remote     net.IP
+	Local      netip.Addr
+	Remote     netip.Addr
 	IFlags     uint16
 	OFlags     uint16
 	PMtuDisc   uint8
@@ -1157,7 +1158,7 @@ func (gretap *Gretap) Attrs() *LinkAttrs {
 }
 
 func (gretap *Gretap) Type() string {
-	if gretap.Local.To4() == nil {
+	if gretap.Local.Is6() {
 		return "ip6gretap"
 	}
 	return "gretap"
@@ -1169,8 +1170,8 @@ type Iptun struct {
 	Tos        uint8
 	PMtuDisc   uint8
 	Link       uint32
-	Local      net.IP
-	Remote     net.IP
+	Local      netip.Addr
+	Remote     netip.Addr
 	EncapSport uint16
 	EncapDport uint16
 	EncapType  uint16
@@ -1190,8 +1191,8 @@ func (iptun *Iptun) Type() string {
 type Ip6tnl struct {
 	LinkAttrs
 	Link       uint32
-	Local      net.IP
-	Remote     net.IP
+	Local      netip.Addr
+	Remote     netip.Addr
 	Ttl        uint8
 	Tos        uint8
 	Flags      uint32
@@ -1251,8 +1252,8 @@ type Sittun struct {
 	Tos        uint8
 	PMtuDisc   uint8
 	Proto      uint8
-	Local      net.IP
-	Remote     net.IP
+	Local      netip.Addr
+	Remote     netip.Addr
 	EncapLimit uint8
 	EncapType  uint16
 	EncapFlags uint16
@@ -1273,8 +1274,8 @@ type Vti struct {
 	IKey   uint32
 	OKey   uint32
 	Link   uint32
-	Local  net.IP
-	Remote net.IP
+	Local  netip.Addr
+	Remote netip.Addr
 }
 
 func (vti *Vti) Attrs() *LinkAttrs {
@@ -1282,7 +1283,7 @@ func (vti *Vti) Attrs() *LinkAttrs {
 }
 
 func (vti *Vti) Type() string {
-	if vti.Local.To4() == nil {
+	if vti.Local.Is6() {
 		return "vti6"
 	}
 	return "vti"
@@ -1295,8 +1296,8 @@ type Gretun struct {
 	OFlags     uint16
 	IKey       uint32
 	OKey       uint32
-	Local      net.IP
-	Remote     net.IP
+	Local      netip.Addr
+	Remote     netip.Addr
 	Ttl        uint8
 	Tos        uint8
 	PMtuDisc   uint8
@@ -1312,7 +1313,7 @@ func (gretun *Gretun) Attrs() *LinkAttrs {
 }
 
 func (gretun *Gretun) Type() string {
-	if gretun.Local.To4() == nil {
+	if gretun.Local.Is6() {
 		return "ip6gre"
 	}
 	return "gre"

--- a/link.go
+++ b/link.go
@@ -1158,7 +1158,7 @@ func (gretap *Gretap) Attrs() *LinkAttrs {
 }
 
 func (gretap *Gretap) Type() string {
-	if gretap.Local.Is6() {
+	if !gretap.Local.Is4() {
 		return "ip6gretap"
 	}
 	return "gretap"
@@ -1313,7 +1313,7 @@ func (gretun *Gretun) Attrs() *LinkAttrs {
 }
 
 func (gretun *Gretun) Type() string {
-	if gretun.Local.Is6() {
+	if !gretun.Local.Is4() {
 		return "ip6gre"
 	}
 	return "gre"

--- a/link_linux.go
+++ b/link_linux.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"net/netip"
 	"os"
 	"strconv"
 	"strings"
@@ -1289,26 +1290,18 @@ func addVxlanAttrs(vxlan *Vxlan, linkInfo *nl.RtAttr) {
 	if vxlan.VtepDevIndex != 0 {
 		data.AddRtAttr(nl.IFLA_VXLAN_LINK, nl.Uint32Attr(uint32(vxlan.VtepDevIndex)))
 	}
-	if vxlan.SrcAddr != nil {
-		ip := vxlan.SrcAddr.To4()
-		if ip != nil {
-			data.AddRtAttr(nl.IFLA_VXLAN_LOCAL, []byte(ip))
+	if vxlan.SrcAddr.IsValid() {
+		if vxlan.SrcAddr.Is4() {
+			data.AddRtAttr(nl.IFLA_VXLAN_LOCAL, vxlan.SrcAddr.AsSlice())
 		} else {
-			ip = vxlan.SrcAddr.To16()
-			if ip != nil {
-				data.AddRtAttr(nl.IFLA_VXLAN_LOCAL6, []byte(ip))
-			}
+			data.AddRtAttr(nl.IFLA_VXLAN_LOCAL6, vxlan.SrcAddr.AsSlice())
 		}
 	}
-	if vxlan.Group != nil {
-		group := vxlan.Group.To4()
-		if group != nil {
-			data.AddRtAttr(nl.IFLA_VXLAN_GROUP, []byte(group))
+	if vxlan.Group.IsValid() {
+		if vxlan.Group.Is4() {
+			data.AddRtAttr(nl.IFLA_VXLAN_GROUP, vxlan.Group.AsSlice())
 		} else {
-			group = vxlan.Group.To16()
-			if group != nil {
-				data.AddRtAttr(nl.IFLA_VXLAN_GROUP6, []byte(group))
-			}
+			data.AddRtAttr(nl.IFLA_VXLAN_GROUP6, vxlan.Group.AsSlice())
 		}
 	}
 
@@ -1381,15 +1374,8 @@ func addBondAttrs(bond *Bond, linkInfo *nl.RtAttr) {
 	if bond.ArpIpTargets != nil {
 		msg := data.AddRtAttr(nl.IFLA_BOND_ARP_IP_TARGET, nil)
 		for i := range bond.ArpIpTargets {
-			ip := bond.ArpIpTargets[i].To4()
-			if ip != nil {
-				msg.AddRtAttr(i, []byte(ip))
-				continue
-			}
-			ip = bond.ArpIpTargets[i].To16()
-			if ip != nil {
-				msg.AddRtAttr(i, []byte(ip))
-			}
+			ip := bond.ArpIpTargets[i]
+			msg.AddRtAttr(i, ip.AsSlice())
 		}
 	}
 	if bond.ArpValidate >= 0 {
@@ -3063,13 +3049,13 @@ func parseVxlanData(link Link, data []syscall.NetlinkRouteAttr) {
 		case nl.IFLA_VXLAN_LINK:
 			vxlan.VtepDevIndex = int(native.Uint32(datum.Value[0:4]))
 		case nl.IFLA_VXLAN_LOCAL:
-			vxlan.SrcAddr = net.IP(datum.Value[0:4])
+			vxlan.SrcAddr, _ = netip.AddrFromSlice(datum.Value[0:4])
 		case nl.IFLA_VXLAN_LOCAL6:
-			vxlan.SrcAddr = net.IP(datum.Value[0:16])
+			vxlan.SrcAddr, _ = netip.AddrFromSlice(datum.Value[0:16])
 		case nl.IFLA_VXLAN_GROUP:
-			vxlan.Group = net.IP(datum.Value[0:4])
+			vxlan.Group, _ = netip.AddrFromSlice(datum.Value[0:4])
 		case nl.IFLA_VXLAN_GROUP6:
-			vxlan.Group = net.IP(datum.Value[0:16])
+			vxlan.Group, _ = netip.AddrFromSlice(datum.Value[0:16])
 		case nl.IFLA_VXLAN_TTL:
 			vxlan.TTL = int(datum.Value[0])
 		case nl.IFLA_VXLAN_TOS:
@@ -3176,21 +3162,17 @@ func parseBondData(link Link, data []syscall.NetlinkRouteAttr) {
 	}
 }
 
-func parseBondArpIpTargets(value []byte) []net.IP {
+func parseBondArpIpTargets(value []byte) []netip.Addr {
 	data, err := nl.ParseRouteAttr(value)
 	if err != nil {
 		return nil
 	}
 
-	targets := []net.IP{}
+	targets := []netip.Addr{}
 	for i := range data {
-		target := net.IP(data[i].Value)
-		if ip := target.To4(); ip != nil {
-			targets = append(targets, ip)
-			continue
-		}
-		if ip := target.To16(); ip != nil {
-			targets = append(targets, ip)
+		addr, ok := netip.AddrFromSlice(data[i].Value)
+		if ok {
+			targets = append(targets, addr)
 		}
 	}
 
@@ -3369,11 +3351,11 @@ func addGeneveAttrs(geneve *Geneve, linkInfo *nl.RtAttr) {
 		data.AddRtAttr(nl.IFLA_GENEVE_COLLECT_METADATA, []byte{})
 	}
 
-	if ip := geneve.Remote; ip != nil {
-		if ip4 := ip.To4(); ip4 != nil {
-			data.AddRtAttr(nl.IFLA_GENEVE_REMOTE, ip.To4())
+	if ip := geneve.Remote; ip.IsValid() {
+		if ip.Is4() {
+			data.AddRtAttr(nl.IFLA_GENEVE_REMOTE, ip.AsSlice())
 		} else {
-			data.AddRtAttr(nl.IFLA_GENEVE_REMOTE6, []byte(ip))
+			data.AddRtAttr(nl.IFLA_GENEVE_REMOTE6, ip.AsSlice())
 		}
 	}
 
@@ -3412,7 +3394,7 @@ func parseGeneveData(link Link, data []syscall.NetlinkRouteAttr) {
 		case nl.IFLA_GENEVE_ID:
 			geneve.ID = native.Uint32(datum.Value[0:4])
 		case nl.IFLA_GENEVE_REMOTE, nl.IFLA_GENEVE_REMOTE6:
-			geneve.Remote = datum.Value
+			geneve.Remote, _ = netip.AddrFromSlice(datum.Value)
 		case nl.IFLA_GENEVE_PORT:
 			geneve.Dport = ntohs(datum.Value[0:2])
 		case nl.IFLA_GENEVE_TTL:
@@ -3443,18 +3425,12 @@ func addGretapAttrs(gretap *Gretap, linkInfo *nl.RtAttr) {
 		return
 	}
 
-	if ip := gretap.Local; ip != nil {
-		if ip.To4() != nil {
-			ip = ip.To4()
-		}
-		data.AddRtAttr(nl.IFLA_GRE_LOCAL, []byte(ip))
+	if ip := gretap.Local; ip.IsValid() {
+		data.AddRtAttr(nl.IFLA_GRE_LOCAL, ip.AsSlice())
 	}
 
-	if ip := gretap.Remote; ip != nil {
-		if ip.To4() != nil {
-			ip = ip.To4()
-		}
-		data.AddRtAttr(nl.IFLA_GRE_REMOTE, []byte(ip))
+	if ip := gretap.Remote; ip.IsValid() {
+		data.AddRtAttr(nl.IFLA_GRE_REMOTE, ip.AsSlice())
 	}
 
 	if gretap.IKey != 0 {
@@ -3495,9 +3471,9 @@ func parseGretapData(link Link, data []syscall.NetlinkRouteAttr) {
 		case nl.IFLA_GRE_IKEY:
 			gre.OKey = ntohl(datum.Value[0:4])
 		case nl.IFLA_GRE_LOCAL:
-			gre.Local = net.IP(datum.Value)
+			gre.Local, _ = netip.AddrFromSlice(datum.Value)
 		case nl.IFLA_GRE_REMOTE:
-			gre.Remote = net.IP(datum.Value)
+			gre.Remote, _ = netip.AddrFromSlice(datum.Value)
 		case nl.IFLA_GRE_ENCAP_SPORT:
 			gre.EncapSport = ntohs(datum.Value[0:2])
 		case nl.IFLA_GRE_ENCAP_DPORT:
@@ -3531,18 +3507,12 @@ func addGretunAttrs(gre *Gretun, linkInfo *nl.RtAttr) {
 		return
 	}
 
-	if ip := gre.Local; ip != nil {
-		if ip.To4() != nil {
-			ip = ip.To4()
-		}
-		data.AddRtAttr(nl.IFLA_GRE_LOCAL, []byte(ip))
+	if ip := gre.Local; ip.IsValid() {
+		data.AddRtAttr(nl.IFLA_GRE_LOCAL, ip.AsSlice())
 	}
 
-	if ip := gre.Remote; ip != nil {
-		if ip.To4() != nil {
-			ip = ip.To4()
-		}
-		data.AddRtAttr(nl.IFLA_GRE_REMOTE, []byte(ip))
+	if ip := gre.Remote; ip.IsValid() {
+		data.AddRtAttr(nl.IFLA_GRE_REMOTE, ip.AsSlice())
 	}
 
 	if gre.IKey != 0 {
@@ -3580,9 +3550,9 @@ func parseGretunData(link Link, data []syscall.NetlinkRouteAttr) {
 		case nl.IFLA_GRE_OKEY:
 			gre.OKey = ntohl(datum.Value[0:4])
 		case nl.IFLA_GRE_LOCAL:
-			gre.Local = net.IP(datum.Value)
+			gre.Local, _ = netip.AddrFromSlice(datum.Value)
 		case nl.IFLA_GRE_REMOTE:
-			gre.Remote = net.IP(datum.Value)
+			gre.Remote, _ = netip.AddrFromSlice(datum.Value)
 		case nl.IFLA_GRE_IFLAGS:
 			gre.IFlags = ntohs(datum.Value[0:2])
 		case nl.IFLA_GRE_OFLAGS:
@@ -3651,14 +3621,12 @@ func addIptunAttrs(iptun *Iptun, linkInfo *nl.RtAttr) {
 		return
 	}
 
-	ip := iptun.Local.To4()
-	if ip != nil {
-		data.AddRtAttr(nl.IFLA_IPTUN_LOCAL, []byte(ip))
+	if iptun.Local.Is4() {
+		data.AddRtAttr(nl.IFLA_IPTUN_LOCAL, iptun.Local.AsSlice())
 	}
 
-	ip = iptun.Remote.To4()
-	if ip != nil {
-		data.AddRtAttr(nl.IFLA_IPTUN_REMOTE, []byte(ip))
+	if iptun.Remote.Is4() {
+		data.AddRtAttr(nl.IFLA_IPTUN_REMOTE, iptun.Remote.AsSlice())
 	}
 
 	if iptun.Link != 0 {
@@ -3679,9 +3647,9 @@ func parseIptunData(link Link, data []syscall.NetlinkRouteAttr) {
 	for _, datum := range data {
 		switch datum.Attr.Type {
 		case nl.IFLA_IPTUN_LOCAL:
-			iptun.Local = net.IP(datum.Value[0:4])
+			iptun.Local, _ = netip.AddrFromSlice(datum.Value[0:4])
 		case nl.IFLA_IPTUN_REMOTE:
-			iptun.Remote = net.IP(datum.Value[0:4])
+			iptun.Remote, _ = netip.AddrFromSlice(datum.Value[0:4])
 		case nl.IFLA_IPTUN_TTL:
 			iptun.Ttl = uint8(datum.Value[0])
 		case nl.IFLA_IPTUN_TOS:
@@ -3717,14 +3685,12 @@ func addIp6tnlAttrs(ip6tnl *Ip6tnl, linkInfo *nl.RtAttr) {
 		data.AddRtAttr(nl.IFLA_IPTUN_LINK, nl.Uint32Attr(ip6tnl.Link))
 	}
 
-	ip := ip6tnl.Local.To16()
-	if ip != nil {
-		data.AddRtAttr(nl.IFLA_IPTUN_LOCAL, []byte(ip))
+	if ip6tnl.Local.Is6() {
+		data.AddRtAttr(nl.IFLA_IPTUN_LOCAL, ip6tnl.Local.AsSlice())
 	}
 
-	ip = ip6tnl.Remote.To16()
-	if ip != nil {
-		data.AddRtAttr(nl.IFLA_IPTUN_REMOTE, []byte(ip))
+	if ip6tnl.Remote.Is6() {
+		data.AddRtAttr(nl.IFLA_IPTUN_REMOTE, ip6tnl.Remote.AsSlice())
 	}
 
 	data.AddRtAttr(nl.IFLA_IPTUN_TTL, nl.Uint8Attr(ip6tnl.Ttl))
@@ -3744,9 +3710,9 @@ func parseIp6tnlData(link Link, data []syscall.NetlinkRouteAttr) {
 	for _, datum := range data {
 		switch datum.Attr.Type {
 		case nl.IFLA_IPTUN_LOCAL:
-			ip6tnl.Local = net.IP(datum.Value[:16])
+			ip6tnl.Local, _ = netip.AddrFromSlice(datum.Value[:16])
 		case nl.IFLA_IPTUN_REMOTE:
-			ip6tnl.Remote = net.IP(datum.Value[:16])
+			ip6tnl.Remote, _ = netip.AddrFromSlice(datum.Value[:16])
 		case nl.IFLA_IPTUN_TTL:
 			ip6tnl.Ttl = datum.Value[0]
 		case nl.IFLA_IPTUN_TOS:
@@ -3780,14 +3746,12 @@ func addSittunAttrs(sittun *Sittun, linkInfo *nl.RtAttr) {
 		data.AddRtAttr(nl.IFLA_IPTUN_LINK, nl.Uint32Attr(sittun.Link))
 	}
 
-	ip := sittun.Local.To4()
-	if ip != nil {
-		data.AddRtAttr(nl.IFLA_IPTUN_LOCAL, []byte(ip))
+	if sittun.Local.Is4() {
+		data.AddRtAttr(nl.IFLA_IPTUN_LOCAL, sittun.Local.AsSlice())
 	}
 
-	ip = sittun.Remote.To4()
-	if ip != nil {
-		data.AddRtAttr(nl.IFLA_IPTUN_REMOTE, []byte(ip))
+	if sittun.Remote.Is4() {
+		data.AddRtAttr(nl.IFLA_IPTUN_REMOTE, sittun.Remote.AsSlice())
 	}
 
 	if sittun.Ttl > 0 {
@@ -3810,9 +3774,9 @@ func parseSittunData(link Link, data []syscall.NetlinkRouteAttr) {
 	for _, datum := range data {
 		switch datum.Attr.Type {
 		case nl.IFLA_IPTUN_LOCAL:
-			sittun.Local = net.IP(datum.Value[0:4])
+			sittun.Local, _ = netip.AddrFromSlice(datum.Value[0:4])
 		case nl.IFLA_IPTUN_REMOTE:
-			sittun.Remote = net.IP(datum.Value[0:4])
+			sittun.Remote, _ = netip.AddrFromSlice(datum.Value[0:4])
 		case nl.IFLA_IPTUN_TTL:
 			sittun.Ttl = datum.Value[0]
 		case nl.IFLA_IPTUN_TOS:
@@ -3836,29 +3800,12 @@ func parseSittunData(link Link, data []syscall.NetlinkRouteAttr) {
 func addVtiAttrs(vti *Vti, linkInfo *nl.RtAttr) {
 	data := linkInfo.AddRtAttr(nl.IFLA_INFO_DATA, nil)
 
-	family := FAMILY_V4
-	if vti.Local.To4() == nil {
-		family = FAMILY_V6
+	if vti.Local.IsValid() {
+		data.AddRtAttr(nl.IFLA_VTI_LOCAL, vti.Local.AsSlice())
 	}
 
-	var ip net.IP
-
-	if family == FAMILY_V4 {
-		ip = vti.Local.To4()
-	} else {
-		ip = vti.Local
-	}
-	if ip != nil {
-		data.AddRtAttr(nl.IFLA_VTI_LOCAL, []byte(ip))
-	}
-
-	if family == FAMILY_V4 {
-		ip = vti.Remote.To4()
-	} else {
-		ip = vti.Remote
-	}
-	if ip != nil {
-		data.AddRtAttr(nl.IFLA_VTI_REMOTE, []byte(ip))
+	if vti.Remote.IsValid() {
+		data.AddRtAttr(nl.IFLA_VTI_REMOTE, vti.Remote.AsSlice())
 	}
 
 	if vti.Link != 0 {
@@ -3874,9 +3821,9 @@ func parseVtiData(link Link, data []syscall.NetlinkRouteAttr) {
 	for _, datum := range data {
 		switch datum.Attr.Type {
 		case nl.IFLA_VTI_LOCAL:
-			vti.Local = net.IP(datum.Value)
+			vti.Local, _ = netip.AddrFromSlice(datum.Value)
 		case nl.IFLA_VTI_REMOTE:
-			vti.Remote = net.IP(datum.Value)
+			vti.Remote, _ = netip.AddrFromSlice(datum.Value)
 		case nl.IFLA_VTI_IKEY:
 			vti.IKey = ntohl(datum.Value[0:4])
 		case nl.IFLA_VTI_OKEY:

--- a/link_linux.go
+++ b/link_linux.go
@@ -1241,7 +1241,7 @@ func LinkSetVXLANVtepDevIndex(link *Vxlan, ifIndex int) error {
 // LinkSetVXLANVtepDevIndex sets the VTEP device index of a VXLAN link device.
 // Equivalent to: `ip link set $link type [ dev $dev ]`
 func (h *Handle) LinkSetVXLANVtepDevIndex(link *Vxlan, ifIndex int) error {
-	if link.Group != nil && ifIndex == 0 {
+	if link.Group.IsValid() && ifIndex == 0 {
 		return fmt.Errorf("VTEP device index must be set when group address is set")
 	}
 

--- a/link_test.go
+++ b/link_test.go
@@ -17,6 +17,8 @@ import (
 	"testing"
 	"time"
 
+	"net/netip"
+
 	"github.com/vishvananda/netlink/nl"
 	"github.com/vishvananda/netns"
 	"golang.org/x/sys/unix"
@@ -299,7 +301,7 @@ func testLinkAddDel(t *testing.T, link Link) {
 			}
 
 			for i := range bond.ArpIpTargets {
-				if !bond.ArpIpTargets[i].Equal(other.ArpIpTargets[i]) {
+				if bond.ArpIpTargets[i] != other.ArpIpTargets[i] {
 					t.Fatalf("Got unexpected ArpIpTargets: %s, expected: %s",
 						other.ArpIpTargets[i], bond.ArpIpTargets[i])
 				}
@@ -441,7 +443,7 @@ func compareGeneve(t *testing.T, expected, actual *Geneve) {
 		t.Fatal("Geneve.Tos doesn't match")
 	}
 
-	if !actual.Remote.Equal(expected.Remote) {
+	if actual.Remote != expected.Remote {
 		t.Fatalf("Geneve.Remote is not equal: %s!=%s", actual.Remote, expected.Remote)
 	}
 
@@ -482,11 +484,11 @@ func compareGretap(t *testing.T, expected, actual *Gretap) {
 		t.Fatal("Gretap.EncapDport doesn't match")
 	}
 
-	if expected.Local != nil && !actual.Local.Equal(expected.Local) {
+	if expected.Local.IsValid() && actual.Local != expected.Local {
 		t.Fatal("Gretap.Local doesn't match")
 	}
 
-	if expected.Remote != nil && !actual.Remote.Equal(expected.Remote) {
+	if expected.Remote.IsValid() && actual.Remote != expected.Remote {
 		t.Fatal("Gretap.Remote doesn't match")
 	}
 
@@ -548,11 +550,11 @@ func compareGretun(t *testing.T, expected, actual *Gretun) {
 		t.Fatal("Gretun.OKey doesn't match")
 	}
 
-	if expected.Local != nil && !actual.Local.Equal(expected.Local) {
+	if expected.Local.IsValid() && actual.Local != expected.Local {
 		t.Fatal("Gretun.Local doesn't match")
 	}
 
-	if expected.Remote != nil && !actual.Remote.Equal(expected.Remote) {
+	if expected.Remote.IsValid() && actual.Remote != expected.Remote {
 		t.Fatal("Gretun.Remote doesn't match")
 	}
 
@@ -593,10 +595,10 @@ func compareVxlan(t *testing.T, expected, actual *Vxlan) {
 	if actual.VxlanId != expected.VxlanId {
 		t.Fatal("Vxlan.VxlanId doesn't match")
 	}
-	if expected.SrcAddr != nil && !actual.SrcAddr.Equal(expected.SrcAddr) {
+	if expected.SrcAddr.IsValid() && actual.SrcAddr != expected.SrcAddr {
 		t.Fatal("Vxlan.SrcAddr doesn't match")
 	}
-	if expected.Group != nil && !actual.Group.Equal(expected.Group) {
+	if expected.Group.IsValid() && actual.Group != expected.Group {
 		t.Fatal("Vxlan.Group doesn't match")
 	}
 	if expected.TTL != -1 && actual.TTL != expected.TTL {
@@ -790,12 +792,12 @@ func TestLinkAddDelGeneve(t *testing.T) {
 	testLinkAddDel(t, &Geneve{
 		LinkAttrs: LinkAttrs{Name: "foo4", EncapType: "geneve"},
 		ID:        0x1000,
-		Remote:    net.IPv4(127, 0, 0, 1)})
+		Remote:    netip.MustParseAddr("127.0.0.1")})
 
 	testLinkAddDel(t, &Geneve{
 		LinkAttrs: LinkAttrs{Name: "foo6", EncapType: "geneve"},
 		ID:        0x1000,
-		Remote:    net.ParseIP("2001:db8:ef33::2")})
+		Remote:    netip.MustParseAddr("2001:db8:ef33::2")})
 }
 
 func TestLinkAddDelGeneveFlowBased(t *testing.T) {
@@ -813,7 +815,7 @@ func TestGeneveCompareToIP(t *testing.T) {
 
 	expected := &Geneve{
 		ID:     0x764332, // 23 bits
-		Remote: net.ParseIP("1.2.3.4"),
+		Remote: netip.MustParseAddr("1.2.3.4"),
 		Dport:  6081,
 	}
 
@@ -854,15 +856,15 @@ func TestLinkAddDelGretap(t *testing.T) {
 		IKey:      0x101,
 		OKey:      0x101,
 		PMtuDisc:  1,
-		Local:     net.IPv4(127, 0, 0, 1),
-		Remote:    net.IPv4(127, 0, 0, 1)})
+		Local:     netip.MustParseAddr("127.0.0.1"),
+		Remote:    netip.MustParseAddr("127.0.0.1")})
 
 	testLinkAddDel(t, &Gretap{
 		LinkAttrs: LinkAttrs{Name: "foo6"},
 		IKey:      0x101,
 		OKey:      0x101,
-		Local:     net.ParseIP("2001:db8:abcd::1"),
-		Remote:    net.ParseIP("2001:db8:ef33::2")})
+		Local:     netip.MustParseAddr("2001:db8:abcd::1"),
+		Remote:    netip.MustParseAddr("2001:db8:ef33::2")})
 }
 
 func TestLinkAddDelGretun(t *testing.T) {
@@ -870,13 +872,13 @@ func TestLinkAddDelGretun(t *testing.T) {
 
 	testLinkAddDel(t, &Gretun{
 		LinkAttrs: LinkAttrs{Name: "foo4"},
-		Local:     net.IPv4(127, 0, 0, 1),
-		Remote:    net.IPv4(127, 0, 0, 1)})
+		Local:     netip.MustParseAddr("127.0.0.1"),
+		Remote:    netip.MustParseAddr("127.0.0.1")})
 
 	testLinkAddDel(t, &Gretun{
 		LinkAttrs: LinkAttrs{Name: "foo6"},
-		Local:     net.ParseIP("2001:db8:abcd::1"),
-		Remote:    net.ParseIP("2001:db8:ef33::2")})
+		Local:     netip.MustParseAddr("2001:db8:abcd::1"),
+		Remote:    netip.MustParseAddr("2001:db8:ef33::2")})
 }
 
 func TestLinkAddDelGretunPointToMultiPoint(t *testing.T) {
@@ -884,13 +886,13 @@ func TestLinkAddDelGretunPointToMultiPoint(t *testing.T) {
 
 	testLinkAddDel(t, &Gretun{
 		LinkAttrs: LinkAttrs{Name: "foo"},
-		Local:     net.IPv4(127, 0, 0, 1),
+		Local:     netip.MustParseAddr("127.0.0.1"),
 		IKey:      1234,
 		OKey:      1234})
 
 	testLinkAddDel(t, &Gretun{
 		LinkAttrs: LinkAttrs{Name: "foo6"},
-		Local:     net.ParseIP("2001:db8:1234::4"),
+		Local:     netip.MustParseAddr("2001:db8:1234::4"),
 		IKey:      5678,
 		OKey:      7890})
 }
@@ -1387,10 +1389,10 @@ func TestLinkAddDelBond(t *testing.T) {
 			bond.AdActorSysPrio = 1
 			bond.AdUserPortKey = 1
 			bond.AdActorSystem, _ = net.ParseMAC("06:aa:bb:cc:dd:ee")
-			bond.ArpIpTargets = []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("1.1.1.2")}
+			bond.ArpIpTargets = []netip.Addr{netip.MustParseAddr("1.1.1.1"), netip.MustParseAddr("1.1.1.2")}
 		case "balance-tlb":
 			bond.TlbDynamicLb = 1
-			bond.ArpIpTargets = []net.IP{net.ParseIP("1.1.1.2"), net.ParseIP("1.1.1.1")}
+			bond.ArpIpTargets = []netip.Addr{netip.MustParseAddr("1.1.1.2"), netip.MustParseAddr("1.1.1.1")}
 		}
 		testLinkAddDel(t, bond)
 	}
@@ -2780,8 +2782,8 @@ func TestLinkAddDelIptun(t *testing.T) {
 	testLinkAddDel(t, &Iptun{
 		LinkAttrs: LinkAttrs{Name: "iptunfoo"},
 		PMtuDisc:  1,
-		Local:     net.IPv4(127, 0, 0, 1),
-		Remote:    net.IPv4(127, 0, 0, 1)})
+		Local:     netip.MustParseAddr("127.0.0.1"),
+		Remote:    netip.MustParseAddr("127.0.0.1")})
 }
 
 func TestLinkAddDelIptunFlowBased(t *testing.T) {
@@ -2799,8 +2801,8 @@ func TestLinkAddDelIp6tnl(t *testing.T) {
 
 	testLinkAddDel(t, &Ip6tnl{
 		LinkAttrs: LinkAttrs{Name: "ip6tnltest"},
-		Local:     net.ParseIP("2001:db8::100"),
-		Remote:    net.ParseIP("2001:db8::200"),
+		Local:     netip.MustParseAddr("2001:db8::100"),
+		Remote:    netip.MustParseAddr("2001:db8::200"),
 	})
 }
 
@@ -2819,8 +2821,8 @@ func TestLinkAddDelSittun(t *testing.T) {
 	testLinkAddDel(t, &Sittun{
 		LinkAttrs: LinkAttrs{Name: "sittunfoo"},
 		PMtuDisc:  1,
-		Local:     net.IPv4(127, 0, 0, 1),
-		Remote:    net.IPv4(127, 0, 0, 1)})
+		Local:     netip.MustParseAddr("127.0.0.1"),
+		Remote:    netip.MustParseAddr("127.0.0.1")})
 }
 
 func TestLinkAddDelVti(t *testing.T) {
@@ -2830,15 +2832,15 @@ func TestLinkAddDelVti(t *testing.T) {
 		LinkAttrs: LinkAttrs{Name: "vtifoo"},
 		IKey:      0x101,
 		OKey:      0x101,
-		Local:     net.IPv4(127, 0, 0, 1),
-		Remote:    net.IPv4(127, 0, 0, 1)})
+		Local:     netip.MustParseAddr("127.0.0.1"),
+		Remote:    netip.MustParseAddr("127.0.0.1")})
 
 	testLinkAddDel(t, &Vti{
 		LinkAttrs: LinkAttrs{Name: "vtibar"},
 		IKey:      0x101,
 		OKey:      0x101,
-		Local:     net.IPv6loopback,
-		Remote:    net.IPv6loopback})
+		Local:     netip.MustParseAddr("::1"),
+		Remote:    netip.MustParseAddr("::1")})
 }
 
 func TestLinkSetGSOMaxSize(t *testing.T) {

--- a/neigh.go
+++ b/neigh.go
@@ -3,6 +3,7 @@ package netlink
 import (
 	"fmt"
 	"net"
+	"net/netip"
 )
 
 // Neigh represents a link layer neighbor from netlink.
@@ -13,9 +14,9 @@ type Neigh struct {
 	Type         int
 	Flags        int
 	FlagsExt     int
-	IP           net.IP
+	IP           netip.Addr
 	HardwareAddr net.HardwareAddr
-	LLIPAddr     net.IP //Used in the case of NHRP
+	LLIPAddr     netip.Addr //Used in the case of NHRP
 	Vlan         int
 	VNI          int
 	MasterIndex  int

--- a/netlink.go
+++ b/netlink.go
@@ -10,7 +10,7 @@ package netlink
 
 import (
 	"errors"
-	"net"
+	"net/netip"
 )
 
 var (
@@ -18,23 +18,20 @@ var (
 	ErrNotImplemented = errors.New("not implemented")
 )
 
-// ParseIPNet parses a string in ip/net format and returns a net.IPNet.
+// ParseIPNet parses a string in ip/net format and returns a netip.Prefix.
 // This is valuable because addresses in netlink are often IPNets and
 // ParseCIDR returns an IPNet with the IP part set to the base IP of the
 // range.
-func ParseIPNet(s string) (*net.IPNet, error) {
-	ip, ipNet, err := net.ParseCIDR(s)
-	if err != nil {
-		return nil, err
-	}
-	ipNet.IP = ip
-	return ipNet, nil
+func ParseIPNet(s string) (netip.Prefix, error) {
+	return netip.ParsePrefix(s)
 }
 
 // NewIPNet generates an IPNet from an ip address using a netmask of 32 or 128.
-func NewIPNet(ip net.IP) *net.IPNet {
-	if ip.To4() != nil {
-		return &net.IPNet{IP: ip, Mask: net.CIDRMask(32, 32)}
-	}
-	return &net.IPNet{IP: ip, Mask: net.CIDRMask(128, 128)}
+func NewIPNet(ip netip.Addr) netip.Prefix {
+	return netip.PrefixFrom(ip, ip.BitLen())
 }
+
+var (
+	v4zero = netip.MustParseAddr("0.0.0.0")
+	v6zero = netip.MustParseAddr("::0")
+)

--- a/netlink.go
+++ b/netlink.go
@@ -18,16 +18,16 @@ var (
 	ErrNotImplemented = errors.New("not implemented")
 )
 
-// ParseIPNet parses a string in ip/net format and returns a netip.Prefix.
+// ParsePrefix parses a string in ip/net format and returns a netip.Prefix.
 // This is valuable because addresses in netlink are often IPNets and
 // ParseCIDR returns an IPNet with the IP part set to the base IP of the
 // range.
-func ParseIPNet(s string) (netip.Prefix, error) {
+func ParsePrefix(s string) (netip.Prefix, error) {
 	return netip.ParsePrefix(s)
 }
 
-// NewIPNet generates an IPNet from an ip address using a netmask of 32 or 128.
-func NewIPNet(ip netip.Addr) netip.Prefix {
+// NewPrefix generates a Prefix from an ip address using a netmask of 32 or 128.
+func NewPrefix(ip netip.Addr) netip.Prefix {
 	return netip.PrefixFrom(ip, ip.BitLen())
 }
 

--- a/netlink_unspecified.go
+++ b/netlink_unspecified.go
@@ -3,7 +3,10 @@
 
 package netlink
 
-import "net"
+import (
+	"net"
+	"net/netip"
+)
 
 func LinkSetUp(link Link) error {
 	return ErrNotImplemented
@@ -217,7 +220,7 @@ func RouteDel(route *Route) error {
 	return ErrNotImplemented
 }
 
-func RouteGet(destination net.IP) ([]Route, error) {
+func RouteGet(destination netip.Addr) ([]Route, error) {
 	return nil, ErrNotImplemented
 }
 

--- a/nexthop.go
+++ b/nexthop.go
@@ -2,7 +2,7 @@ package netlink
 
 import (
 	"fmt"
-	"net"
+	"net/netip"
 	"strconv"
 	"strings"
 )
@@ -11,7 +11,7 @@ type Nexthop struct {
 	ID        uint32
 	Blackhole bool
 	OIF       uint32
-	Gateway   net.IP
+	Gateway   netip.Addr
 	Protocol  RouteProtocol
 }
 

--- a/nexthop_linux.go
+++ b/nexthop_linux.go
@@ -2,7 +2,7 @@ package netlink
 
 import (
 	"errors"
-	"net"
+	"net/netip"
 
 	"github.com/vishvananda/netlink/nl"
 	"golang.org/x/sys/unix"
@@ -161,18 +161,18 @@ var nexthopAttrHandlers = map[uint16]struct {
 	},
 	unix.NHA_GATEWAY: {
 		encode: func(nh *Nexthop) *nl.RtAttr {
-			if nh.Gateway != nil {
-				if gw4 := nh.Gateway.To4(); gw4 != nil {
-					return nl.NewRtAttr(unix.NHA_GATEWAY, gw4)
-				}
-				return nl.NewRtAttr(unix.NHA_GATEWAY, nh.Gateway)
+			if nh.Gateway.IsValid() {
+				return nl.NewRtAttr(unix.NHA_GATEWAY, nh.Gateway.AsSlice())
 			}
 			return nil
 		},
 		decode: func(nh *Nexthop, attr *nl.RtAttr) {
 			if len(attr.Data) != 0 {
-				nh.Gateway = make(net.IP, len(attr.Data))
-				copy(nh.Gateway, attr.Data)
+				addr, ok := netip.AddrFromSlice(attr.Data)
+				if !ok {
+					return
+				}
+				nh.Gateway = addr
 			}
 		},
 	},
@@ -233,7 +233,7 @@ func parseNhmsg(m []byte) (*Nexthop, error) {
 }
 
 func deriveFamilyFromNexthop(nh *Nexthop) uint8 {
-	if nh.Gateway == nil || nh.Gateway.To4() != nil {
+	if nh.Gateway.Is4() {
 		return FAMILY_V4
 	}
 	return FAMILY_V6

--- a/nexthop_test.go
+++ b/nexthop_test.go
@@ -4,7 +4,7 @@
 package netlink
 
 import (
-	"net"
+	"net/netip"
 	"slices"
 	"testing"
 
@@ -42,10 +42,7 @@ func TestNexthopAddListDelReplace(t *testing.T) {
 	}
 
 	// Assign ip address to dummy interface
-	if err = AddrAdd(link0, &Addr{IPNet: &net.IPNet{
-		IP:   net.ParseIP("10.0.0.2"),
-		Mask: net.CIDRMask(24, 32),
-	}}); err != nil {
+	if err = AddrAdd(link0, &Addr{Prefix: netip.PrefixFrom(netip.MustParseAddr("10.0.0.2"), 24)}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -59,7 +56,7 @@ func TestNexthopAddListDelReplace(t *testing.T) {
 		// Auto assign ID
 		ID:       0,
 		OIF:      uint32(link0.Attrs().Index),
-		Gateway:  net.ParseIP("fe80::1234:5678:9abc:def0"),
+		Gateway:  netip.MustParseAddr("fe80::1234:5678:9abc:def0"),
 		Protocol: unix.RTPROT_BGP,
 	}
 
@@ -103,7 +100,7 @@ func TestNexthopAddListDelReplace(t *testing.T) {
 	if resNH1.OIF != nh1.OIF {
 		t.Fatalf("Nexthop OIF mismatch: expected %d, got %d", nh1.OIF, resNH1.OIF)
 	}
-	if !resNH1.Gateway.Equal(nh1.Gateway) {
+	if resNH1.Gateway != nh1.Gateway {
 		t.Fatalf("Nexthop Gateway mismatch: expected %s, got %s", nh1.Gateway, resNH1.Gateway)
 	}
 	if resNH1.Protocol != nh1.Protocol {
@@ -128,7 +125,7 @@ func TestNexthopAddListDelReplace(t *testing.T) {
 		ID:       resNH1.ID,
 		Protocol: unix.RTPROT_STATIC,
 		OIF:      uint32(link0.Attrs().Index),
-		Gateway:  net.ParseIP("10.0.0.1"),
+		Gateway:  netip.MustParseAddr("10.0.0.1"),
 	}
 	if err = NexthopReplace(nh2); err != nil {
 		t.Fatal(err)
@@ -149,7 +146,7 @@ func TestNexthopAddListDelReplace(t *testing.T) {
 	if resNH2.OIF != nh2.OIF {
 		t.Fatalf("Nexthop OIF mismatch: expected %d, got %d", nh2.OIF, resNH2.OIF)
 	}
-	if !resNH2.Gateway.Equal(nh2.Gateway) {
+	if resNH2.Gateway != nh2.Gateway {
 		t.Fatalf("Nexthop Gateway mismatch: expected %s, got %s", nh2.Gateway, resNH2.Gateway)
 	}
 }

--- a/nl/nl_linux.go
+++ b/nl/nl_linux.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"net"
 	"os"
 	"runtime"
 	"sync"
@@ -14,6 +13,8 @@ import (
 	"syscall"
 	"time"
 	"unsafe"
+
+	"net/netip"
 
 	"github.com/vishvananda/netns"
 	"golang.org/x/sys/cpu"
@@ -68,14 +69,12 @@ func (e errDumpInterrupted) Is(target error) bool {
 	return target == unix.EINTR
 }
 
-// GetIPFamily returns the family type of a net.IP.
-func GetIPFamily(ip net.IP) int {
-	if len(ip) <= net.IPv4len {
+// GetIPFamily returns the family type of a netip.Addr.
+func GetIPFamily(ip netip.Addr) int {
+	if ip.Is4() {
 		return FAMILY_V4
 	}
-	if ip.To4() != nil {
-		return FAMILY_V4
-	}
+
 	return FAMILY_V6
 }
 

--- a/nl/tc_linux.go
+++ b/nl/tc_linux.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
+	"net/netip"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -1487,8 +1488,10 @@ func (p *TcPedit) SetEthSrc(mac net.HardwareAddr) {
 	p.Sel.NKeys++
 }
 
-func (p *TcPedit) SetIPv6Src(ip6 net.IP) {
-	u32 := NativeEndian().Uint32(ip6[:4])
+func (p *TcPedit) SetIPv6Src(ip6 netip.Addr) {
+	ip6s := ip6.As16()
+
+	u32 := NativeEndian().Uint32(ip6s[:4])
 
 	tKey := TcPeditKey{}
 	tKeyEx := TcPeditKeyEx{}
@@ -1502,7 +1505,7 @@ func (p *TcPedit) SetIPv6Src(ip6 net.IP) {
 	p.KeysEx = append(p.KeysEx, tKeyEx)
 	p.Sel.NKeys++
 
-	u32 = NativeEndian().Uint32(ip6[4:8])
+	u32 = NativeEndian().Uint32(ip6s[4:8])
 	tKey = TcPeditKey{}
 	tKeyEx = TcPeditKeyEx{}
 
@@ -1516,7 +1519,7 @@ func (p *TcPedit) SetIPv6Src(ip6 net.IP) {
 
 	p.Sel.NKeys++
 
-	u32 = NativeEndian().Uint32(ip6[8:12])
+	u32 = NativeEndian().Uint32(ip6s[8:12])
 	tKey = TcPeditKey{}
 	tKeyEx = TcPeditKeyEx{}
 
@@ -1530,7 +1533,7 @@ func (p *TcPedit) SetIPv6Src(ip6 net.IP) {
 
 	p.Sel.NKeys++
 
-	u32 = NativeEndian().Uint32(ip6[12:16])
+	u32 = NativeEndian().Uint32(ip6s[12:16])
 	tKey = TcPeditKey{}
 	tKeyEx = TcPeditKeyEx{}
 
@@ -1545,24 +1548,25 @@ func (p *TcPedit) SetIPv6Src(ip6 net.IP) {
 	p.Sel.NKeys++
 }
 
-func (p *TcPedit) SetDstIP(ip net.IP) {
-	if ip.To4() != nil {
+func (p *TcPedit) SetDstIP(ip netip.Addr) {
+	if ip.Is4() {
 		p.SetIPv4Dst(ip)
 	} else {
 		p.SetIPv6Dst(ip)
 	}
 }
 
-func (p *TcPedit) SetSrcIP(ip net.IP) {
-	if ip.To4() != nil {
+func (p *TcPedit) SetSrcIP(ip netip.Addr) {
+	if ip.Is4() {
 		p.SetIPv4Src(ip)
 	} else {
 		p.SetIPv6Src(ip)
 	}
 }
 
-func (p *TcPedit) SetIPv6Dst(ip6 net.IP) {
-	u32 := NativeEndian().Uint32(ip6[:4])
+func (p *TcPedit) SetIPv6Dst(ip6 netip.Addr) {
+	ip6s := ip6.As16()
+	u32 := NativeEndian().Uint32(ip6s[:4])
 
 	tKey := TcPeditKey{}
 	tKeyEx := TcPeditKeyEx{}
@@ -1576,7 +1580,7 @@ func (p *TcPedit) SetIPv6Dst(ip6 net.IP) {
 	p.KeysEx = append(p.KeysEx, tKeyEx)
 	p.Sel.NKeys++
 
-	u32 = NativeEndian().Uint32(ip6[4:8])
+	u32 = NativeEndian().Uint32(ip6s[4:8])
 	tKey = TcPeditKey{}
 	tKeyEx = TcPeditKeyEx{}
 
@@ -1590,7 +1594,7 @@ func (p *TcPedit) SetIPv6Dst(ip6 net.IP) {
 
 	p.Sel.NKeys++
 
-	u32 = NativeEndian().Uint32(ip6[8:12])
+	u32 = NativeEndian().Uint32(ip6s[8:12])
 	tKey = TcPeditKey{}
 	tKeyEx = TcPeditKeyEx{}
 
@@ -1604,7 +1608,7 @@ func (p *TcPedit) SetIPv6Dst(ip6 net.IP) {
 
 	p.Sel.NKeys++
 
-	u32 = NativeEndian().Uint32(ip6[12:16])
+	u32 = NativeEndian().Uint32(ip6s[12:16])
 	tKey = TcPeditKey{}
 	tKeyEx = TcPeditKeyEx{}
 
@@ -1619,8 +1623,8 @@ func (p *TcPedit) SetIPv6Dst(ip6 net.IP) {
 	p.Sel.NKeys++
 }
 
-func (p *TcPedit) SetIPv4Src(ip net.IP) {
-	u32 := NativeEndian().Uint32(ip.To4())
+func (p *TcPedit) SetIPv4Src(ip netip.Addr) {
+	u32 := NativeEndian().Uint32(ip.AsSlice())
 
 	tKey := TcPeditKey{}
 	tKeyEx := TcPeditKeyEx{}
@@ -1635,8 +1639,8 @@ func (p *TcPedit) SetIPv4Src(ip net.IP) {
 	p.Sel.NKeys++
 }
 
-func (p *TcPedit) SetIPv4Dst(ip net.IP) {
-	u32 := NativeEndian().Uint32(ip.To4())
+func (p *TcPedit) SetIPv4Dst(ip netip.Addr) {
+	u32 := NativeEndian().Uint32(ip.AsSlice())
 
 	tKey := TcPeditKey{}
 	tKeyEx := TcPeditKeyEx{}

--- a/nl/tc_linux.go
+++ b/nl/tc_linux.go
@@ -1735,16 +1735,16 @@ func ParsePeditEthKeys(keys []TcPeditKey) (srcMac, dstMac net.HardwareAddr) {
 }
 
 // ParsePeditIP4Keys extracts IPv4 addresses from pedit keys
-func ParsePeditIP4Keys(keys []TcPeditKey) (srcIP, dstIP net.IP) {
+func ParsePeditIP4Keys(keys []TcPeditKey) (srcIP, dstIP netip.Addr) {
 	for _, key := range keys {
 		valBytes := make([]byte, 4)
 		NativeEndian().PutUint32(valBytes, key.Val)
 
 		switch key.Off {
 		case 12:
-			srcIP = net.IP(valBytes)
+			srcIP, _ = netip.AddrFromSlice(valBytes)
 		case 16:
-			dstIP = net.IP(valBytes)
+			dstIP, _ = netip.AddrFromSlice(valBytes)
 		}
 	}
 
@@ -1752,24 +1752,24 @@ func ParsePeditIP4Keys(keys []TcPeditKey) (srcIP, dstIP net.IP) {
 }
 
 // ParsePeditIP6Keys parses IPv6 header modifications
-func ParsePeditIP6Keys(keys []TcPeditKey) (srcIP, dstIP net.IP) {
+func ParsePeditIP6Keys(keys []TcPeditKey) (srcIP, dstIP netip.Addr) {
 	// Helper to parse 4 consecutive keys for a complete IPv6 address
-	parseIPv6Addr := func(startIdx int) net.IP {
+	parseIPv6Addr := func(startIdx int) netip.Addr {
 		if startIdx+3 >= len(keys) {
-			return nil
+			return netip.Addr{}
 		}
 
-		ip := make(net.IP, 16)
+		var raw [16]byte
 		baseOffset := keys[startIdx].Off
 
 		for j := 0; j < 4; j++ {
 			if keys[startIdx+j].Off != baseOffset+uint32(j*4) {
-				return nil
+				return netip.Addr{}
 			}
-			NativeEndian().PutUint32(ip[j*4:], keys[startIdx+j].Val)
+			NativeEndian().PutUint32(raw[j*4:], keys[startIdx+j].Val)
 		}
 
-		return ip
+		return netip.AddrFrom16(raw)
 	}
 
 	for idx, key := range keys {

--- a/nl/tc_linux_test.go
+++ b/nl/tc_linux_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"net"
+	"net/netip"
 	"testing"
 
 	"golang.org/x/sys/unix"
@@ -221,40 +222,40 @@ func TestParsePeditEthKeys(t *testing.T) {
 func TestParsePeditIP4Keys(t *testing.T) {
 	tests := []struct {
 		name  string
-		srcIP net.IP
-		dstIP net.IP
+		srcIP netip.Addr
+		dstIP netip.Addr
 	}{
 		{
 			name:  "Parse source IPv4",
-			srcIP: net.ParseIP("192.168.1.1"),
+			srcIP: netip.MustParseAddr("192.168.1.1"),
 		},
 		{
 			name:  "Parse destination IPv4",
-			dstIP: net.ParseIP("10.0.0.1"),
+			dstIP: netip.MustParseAddr("10.0.0.1"),
 		},
 		{
 			name:  "Parse both IPv4 addresses",
-			srcIP: net.ParseIP("192.168.1.1"),
-			dstIP: net.ParseIP("10.0.0.1"),
+			srcIP: netip.MustParseAddr("192.168.1.1"),
+			dstIP: netip.MustParseAddr("10.0.0.1"),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pedit := &TcPedit{}
-			if tt.srcIP != nil {
+			if tt.srcIP.IsValid() {
 				pedit.SetIPv4Src(tt.srcIP)
 			}
-			if tt.dstIP != nil {
+			if tt.dstIP.IsValid() {
 				pedit.SetIPv4Dst(tt.dstIP)
 			}
 
 			srcIP, dstIP := ParsePeditIP4Keys(pedit.Keys)
 
-			if !srcIP.Equal(tt.srcIP) {
+			if srcIP != tt.srcIP {
 				t.Errorf("ParsePeditIP4Keys() srcIP = %v, want %v", srcIP, tt.srcIP)
 			}
-			if !dstIP.Equal(tt.dstIP) {
+			if dstIP != tt.dstIP {
 				t.Errorf("ParsePeditIP4Keys() dstIP = %v, want %v", dstIP, tt.dstIP)
 			}
 		})
@@ -264,40 +265,40 @@ func TestParsePeditIP4Keys(t *testing.T) {
 func TestParsePeditIP6Keys(t *testing.T) {
 	tests := []struct {
 		name  string
-		srcIP net.IP
-		dstIP net.IP
+		srcIP netip.Addr
+		dstIP netip.Addr
 	}{
 		{
 			name:  "Parse source IPv6",
-			srcIP: net.ParseIP("2001:db8::1"),
+			srcIP: netip.MustParseAddr("2001:db8::1"),
 		},
 		{
 			name:  "Parse destination IPv6",
-			dstIP: net.ParseIP("fe80::1"),
+			dstIP: netip.MustParseAddr("fe80::1"),
 		},
 		{
 			name:  "Parse both IPv6 addresses",
-			srcIP: net.ParseIP("2001:db8::1"),
-			dstIP: net.ParseIP("fe80::1"),
+			srcIP: netip.MustParseAddr("2001:db8::1"),
+			dstIP: netip.MustParseAddr("fe80::1"),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pedit := &TcPedit{}
-			if tt.srcIP != nil {
+			if tt.srcIP.IsValid() {
 				pedit.SetIPv6Src(tt.srcIP)
 			}
-			if tt.dstIP != nil {
+			if tt.dstIP.IsValid() {
 				pedit.SetIPv6Dst(tt.dstIP)
 			}
 
 			srcIP, dstIP := ParsePeditIP6Keys(pedit.Keys)
 
-			if !srcIP.Equal(tt.srcIP) {
+			if srcIP != tt.srcIP {
 				t.Errorf("ParsePeditIP6Keys() srcIP = %v, want %v", srcIP, tt.srcIP)
 			}
-			if !dstIP.Equal(tt.dstIP) {
+			if dstIP != tt.dstIP {
 				t.Errorf("ParsePeditIP6Keys() dstIP = %v, want %v", dstIP, tt.dstIP)
 			}
 		})

--- a/nl/xfrm_linux.go
+++ b/nl/xfrm_linux.go
@@ -141,20 +141,19 @@ func (x *XfrmAddress) ToIP() netip.Addr {
 	return addr
 }
 
-// family is only used when x and prefixlen are both 0
-func (x *XfrmAddress) ToIPNet(prefixlen uint8, family uint16) netip.Prefix {
+func (x *XfrmAddress) ToPrefix(prefixlen uint8, family uint16) netip.Prefix {
 	empty := [SizeofXfrmAddress]byte{}
-	if bytes.Equal(x[:], empty[:]) && prefixlen == 0 {
-		if family == FAMILY_V6 {
-			return netip.PrefixFrom(v6zero, 128)
+	if bytes.Equal(x[:], empty[:]) {
+		switch family {
+		case FAMILY_V4:
+			return netip.PrefixFrom(v4zero, int(prefixlen))
+		case FAMILY_V6:
+			return netip.PrefixFrom(v6zero, int(prefixlen))
+		default:
+			return netip.Prefix{}
 		}
-		return netip.PrefixFrom(v4zero, 32)
 	}
-	ip := x.ToIP()
-	if ip.Is4() {
-		return netip.PrefixFrom(ip, 32)
-	}
-	return netip.PrefixFrom(ip, 128)
+	return netip.PrefixFrom(x.ToIP(), int(prefixlen))
 }
 
 func (x *XfrmAddress) FromIP(ip netip.Addr) {

--- a/route_linux.go
+++ b/route_linux.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"strconv"
 	"strings"
 	"syscall"
@@ -201,7 +202,7 @@ func (e *MPLSEncap) Equal(x Encap) bool {
 // SEG6 definitions
 type SEG6Encap struct {
 	Mode     int
-	Segments []net.IP
+	Segments []netip.Addr
 }
 
 func (e *SEG6Encap) Type() int {
@@ -263,7 +264,7 @@ func (e *SEG6Encap) Equal(x Encap) bool {
 		return false
 	}
 	for i := range e.Segments {
-		if !e.Segments[i].Equal(o.Segments[i]) {
+		if e.Segments[i] != o.Segments[i] {
 			return false
 		}
 	}
@@ -274,11 +275,11 @@ func (e *SEG6Encap) Equal(x Encap) bool {
 type SEG6LocalEncap struct {
 	Flags    [nl.SEG6_LOCAL_MAX]bool
 	Action   int
-	Segments []net.IP // from SRH in seg6_local_lwt
-	Table    int      // table id for End.T and End.DT6
-	VrfTable int      // vrftable id for END.DT4 and END.DT6
-	InAddr   net.IP
-	In6Addr  net.IP
+	Segments []netip.Addr // from SRH in seg6_local_lwt
+	Table    int          // table id for End.T and End.DT6
+	VrfTable int          // vrftable id for END.DT4 and END.DT6
+	InAddr   netip.Addr
+	In6Addr  netip.Addr
 	Iif      int
 	Oif      int
 	bpf      bpfObj
@@ -316,10 +317,10 @@ func (e *SEG6LocalEncap) Decode(buf []byte) error {
 			e.VrfTable = int(native.Uint32(attr.Value[0:4]))
 			e.Flags[nl.SEG6_LOCAL_VRFTABLE] = true
 		case nl.SEG6_LOCAL_NH4:
-			e.InAddr = net.IP(attr.Value[0:4])
+			e.InAddr, _ = netip.AddrFromSlice(attr.Value[0:4])
 			e.Flags[nl.SEG6_LOCAL_NH4] = true
 		case nl.SEG6_LOCAL_NH6:
-			e.In6Addr = net.IP(attr.Value[0:16])
+			e.In6Addr, _ = netip.AddrFromSlice(attr.Value[0:16])
 			e.Flags[nl.SEG6_LOCAL_NH6] = true
 		case nl.SEG6_LOCAL_IIF:
 			e.Iif = int(native.Uint32(attr.Value[0:4]))
@@ -384,19 +385,18 @@ func (e *SEG6LocalEncap) Encode() ([]byte, error) {
 		attr := make([]byte, 4)
 		native.PutUint16(attr, 8)
 		native.PutUint16(attr[2:], nl.SEG6_LOCAL_NH4)
-		ipv4 := e.InAddr.To4()
-		if ipv4 == nil {
+		if !e.InAddr.Is4() {
 			err = fmt.Errorf("SEG6_LOCAL_NH4 has invalid IPv4 address")
 			return nil, err
 		}
-		attr = append(attr, ipv4...)
+		attr = append(attr, e.InAddr.AsSlice()...)
 		res = append(res, attr...)
 	}
 	if e.Flags[nl.SEG6_LOCAL_NH6] {
 		attr := make([]byte, 4)
 		native.PutUint16(attr, 20)
 		native.PutUint16(attr[2:], nl.SEG6_LOCAL_NH6)
-		attr = append(attr, e.In6Addr...)
+		attr = append(attr, e.In6Addr.AsSlice()...)
 		res = append(res, attr...)
 	}
 	if e.Flags[nl.SEG6_LOCAL_IIF] {
@@ -493,12 +493,12 @@ func (e *SEG6LocalEncap) Equal(x Encap) bool {
 		return false
 	}
 	for i := range e.Segments {
-		if !e.Segments[i].Equal(o.Segments[i]) {
+		if e.Segments[i] != o.Segments[i] {
 			return false
 		}
 	}
 	// compare values
-	if !e.InAddr.Equal(o.InAddr) || !e.In6Addr.Equal(o.In6Addr) {
+	if e.InAddr != o.InAddr || e.In6Addr != o.In6Addr {
 		return false
 	}
 	if e.Action != o.Action || e.Table != o.Table || e.Iif != o.Iif || e.Oif != o.Oif || e.bpf != o.bpf || e.VrfTable != o.VrfTable {
@@ -656,8 +656,8 @@ func (e *BpfEncap) Equal(x Encap) bool {
 // IP6tnlEncap definition
 type IP6tnlEncap struct {
 	ID       uint64
-	Dst      net.IP
-	Src      net.IP
+	Dst      netip.Addr
+	Src      netip.Addr
 	Hoplimit uint8
 	TC       uint8
 	Flags    uint16
@@ -677,9 +677,9 @@ func (e *IP6tnlEncap) Decode(buf []byte) error {
 		case nl.LWTUNNEL_IP6_ID:
 			e.ID = uint64(binary.BigEndian.Uint64(attr.Value[0:8]))
 		case nl.LWTUNNEL_IP6_DST:
-			e.Dst = net.IP(attr.Value[:])
+			e.Dst, _ = netip.AddrFromSlice(attr.Value[:])
 		case nl.LWTUNNEL_IP6_SRC:
-			e.Src = net.IP(attr.Value[:])
+			e.Src, _ = netip.AddrFromSlice(attr.Value[:])
 		case nl.LWTUNNEL_IP6_HOPLIMIT:
 			e.Hoplimit = attr.Value[0]
 		case nl.LWTUNNEL_IP6_TC:
@@ -708,13 +708,13 @@ func (e *IP6tnlEncap) Encode() ([]byte, error) {
 	resDst := make([]byte, 4)
 	native.PutUint16(resDst, 20) //  2+2+16
 	native.PutUint16(resDst[2:], nl.LWTUNNEL_IP6_DST)
-	resDst = append(resDst, e.Dst...)
+	resDst = append(resDst, e.Dst.AsSlice()...)
 	final = append(final, resDst...)
 
 	resSrc := make([]byte, 4)
 	native.PutUint16(resSrc, 20)
 	native.PutUint16(resSrc[2:], nl.LWTUNNEL_IP6_SRC)
-	resSrc = append(resSrc, e.Src...)
+	resSrc = append(resSrc, e.Src.AsSlice()...)
 	final = append(final, resSrc...)
 
 	resTc := make([]byte, 5)
@@ -748,7 +748,7 @@ func (e *IP6tnlEncap) Equal(x Encap) bool {
 		return false
 	}
 
-	if e.ID != o.ID || e.Flags != o.Flags || e.Hoplimit != o.Hoplimit || e.Src.Equal(o.Src) || e.Dst.Equal(o.Dst) || e.TC != o.TC {
+	if e.ID != o.ID || e.Flags != o.Flags || e.Hoplimit != o.Hoplimit || e.Src != o.Src || e.Dst != o.Dst || e.TC != o.TC {
 		return false
 	}
 	return true
@@ -756,7 +756,7 @@ func (e *IP6tnlEncap) Equal(x Encap) bool {
 
 type Via struct {
 	AddrFamily int
-	Addr       net.IP
+	Addr       netip.Addr
 }
 
 func (v *Via) Equal(x Destination) bool {
@@ -764,7 +764,7 @@ func (v *Via) Equal(x Destination) bool {
 	if !ok {
 		return false
 	}
-	if v.AddrFamily == x.Family() && v.Addr.Equal(o.Addr) {
+	if v.AddrFamily == x.Family() && v.Addr == o.Addr {
 		return true
 	}
 	return false
@@ -797,13 +797,13 @@ func (v *Via) Decode(b []byte) error {
 	}
 	v.AddrFamily = int(native.Uint16(b[0:2]))
 	if v.AddrFamily == nl.FAMILY_V4 {
-		v.Addr = net.IP(b[2:6])
+		v.Addr, _ = netip.AddrFromSlice(b[2:6])
 		return nil
 	} else if v.AddrFamily == nl.FAMILY_V6 {
 		if len(b) < 18 {
 			return fmt.Errorf("decoding failed: buffer too small (%d bytes)", len(b))
 		}
-		v.Addr = net.IP(b[2:])
+		v.Addr, _ = netip.AddrFromSlice(b[2:])
 		return nil
 	}
 	return fmt.Errorf("decoding failed: address family %d unknown", v.AddrFamily)
@@ -911,24 +911,19 @@ func (h *Handle) routeHandleIter(route *Route, req *nl.NetlinkRequest, msg *nl.R
 }
 
 func (h *Handle) prepareRouteReq(route *Route, req *nl.NetlinkRequest, msg *nl.RtMsg) error {
-	if req.NlMsghdr.Type != unix.RTM_GETROUTE && (route.Dst == nil || route.Dst.IP == nil) && route.Src == nil && route.Gw == nil && route.MPLSDst == nil {
+	if req.NlMsghdr.Type != unix.RTM_GETROUTE && (!route.Dst.IsValid() || !route.Dst.IsValid()) && !route.Src.IsValid() && !route.Gw.IsValid() && route.MPLSDst == nil {
 		return fmt.Errorf("either Dst.IP, Src.IP or Gw must be set")
 	}
 
 	family := -1
 	var rtAttrs []*nl.RtAttr
 
-	if route.Dst != nil && route.Dst.IP != nil {
-		dstLen, _ := route.Dst.Mask.Size()
+	if route.Dst.IsValid() {
+		dstLen := route.Dst.Bits()
 		msg.Dst_len = uint8(dstLen)
-		dstFamily := nl.GetIPFamily(route.Dst.IP)
+		dstFamily := nl.GetIPFamily(route.Dst.Addr())
 		family = dstFamily
-		var dstData []byte
-		if dstFamily == FAMILY_V4 {
-			dstData = route.Dst.IP.To4()
-		} else {
-			dstData = route.Dst.IP.To16()
-		}
+		dstData := route.Dst.Addr().AsSlice()
 		rtAttrs = append(rtAttrs, nl.NewRtAttr(unix.RTA_DST, dstData))
 	} else if route.MPLSDst != nil {
 		family = nl.FAMILY_MPLS
@@ -965,34 +960,24 @@ func (h *Handle) prepareRouteReq(route *Route, req *nl.NetlinkRequest, msg *nl.R
 
 	}
 
-	if route.Src != nil {
+	if route.Src.IsValid() {
 		srcFamily := nl.GetIPFamily(route.Src)
 		if family != -1 && family != srcFamily {
 			return fmt.Errorf("source and destination ip are not the same IP family")
 		}
 		family = srcFamily
-		var srcData []byte
-		if srcFamily == FAMILY_V4 {
-			srcData = route.Src.To4()
-		} else {
-			srcData = route.Src.To16()
-		}
+		srcData := route.Src.AsSlice()
 		// The commonly used src ip for routes is actually PREFSRC
 		rtAttrs = append(rtAttrs, nl.NewRtAttr(unix.RTA_PREFSRC, srcData))
 	}
 
-	if route.Gw != nil {
+	if route.Gw.IsValid() {
 		gwFamily := nl.GetIPFamily(route.Gw)
 		if family != -1 && family != gwFamily {
 			return fmt.Errorf("gateway, source, and destination ip are not the same IP family")
 		}
 		family = gwFamily
-		var gwData []byte
-		if gwFamily == FAMILY_V4 {
-			gwData = route.Gw.To4()
-		} else {
-			gwData = route.Gw.To16()
-		}
+		gwData := route.Gw.AsSlice()
 		rtAttrs = append(rtAttrs, nl.NewRtAttr(unix.RTA_GATEWAY, gwData))
 	}
 
@@ -1015,16 +1000,12 @@ func (h *Handle) prepareRouteReq(route *Route, req *nl.NetlinkRequest, msg *nl.R
 				},
 			}
 			children := []nl.NetlinkRequestData{}
-			if nh.Gw != nil {
+			if nh.Gw.IsValid() {
 				gwFamily := nl.GetIPFamily(nh.Gw)
 				if family != -1 && family != gwFamily {
 					return fmt.Errorf("gateway, source, and destination ip are not the same IP family")
 				}
-				if gwFamily == FAMILY_V4 {
-					children = append(children, nl.NewRtAttr(unix.RTA_GATEWAY, []byte(nh.Gw.To4())))
-				} else {
-					children = append(children, nl.NewRtAttr(unix.RTA_GATEWAY, []byte(nh.Gw.To16())))
-				}
+				children = append(children, nl.NewRtAttr(unix.RTA_GATEWAY, nh.Gw.AsSlice()))
 			}
 			if nh.NewDst != nil {
 				if family != -1 && family != nh.NewDst.Family() {
@@ -1307,16 +1288,16 @@ func (h *Handle) RouteListFilteredIter(family int, filter *Route, filterMask uin
 				return true
 			case filterMask&RT_FILTER_IIF != 0 && route.ILinkIndex != filter.ILinkIndex:
 				return true
-			case filterMask&RT_FILTER_GW != 0 && !route.Gw.Equal(filter.Gw):
+			case filterMask&RT_FILTER_GW != 0 && route.Gw != filter.Gw:
 				return true
-			case filterMask&RT_FILTER_SRC != 0 && !route.Src.Equal(filter.Src):
+			case filterMask&RT_FILTER_SRC != 0 && route.Src != filter.Src:
 				return true
 			case filterMask&RT_FILTER_DST != 0:
 				if filter.MPLSDst == nil || route.MPLSDst == nil || (*filter.MPLSDst) != (*route.MPLSDst) {
-					if filter.Dst == nil {
+					if filter.Dst.IsValid() {
 						filter.Dst = genZeroIPNet(family)
 					}
-					if !ipNetEqual(route.Dst, filter.Dst) {
+					if route.Dst != filter.Dst {
 						return true
 					}
 				}
@@ -1375,9 +1356,9 @@ func deserializeRoute(m []byte) (Route, error) {
 	for _, attr := range attrs {
 		switch attr.Attr.Type {
 		case unix.RTA_GATEWAY:
-			route.Gw = net.IP(attr.Value)
+			route.Gw, _ = netip.AddrFromSlice(attr.Value)
 		case unix.RTA_PREFSRC:
-			route.Src = net.IP(attr.Value)
+			route.Src, _ = netip.AddrFromSlice(attr.Value)
 		case unix.RTA_DST:
 			if msg.Family == nl.FAMILY_MPLS {
 				stack := nl.DecodeMPLSStack(attr.Value)
@@ -1386,9 +1367,13 @@ func deserializeRoute(m []byte) (Route, error) {
 				}
 				route.MPLSDst = &stack[0]
 			} else {
-				route.Dst = &net.IPNet{
-					IP:   attr.Value,
-					Mask: net.CIDRMask(int(msg.Dst_len), 8*len(attr.Value)),
+				addr, ok := netip.AddrFromSlice(attr.Value)
+				if !ok {
+					return route, fmt.Errorf("RTA_DST: invalid address")
+				}
+				route.Dst, err = addr.Prefix(int(msg.Dst_len))
+				if err != nil {
+					return route, fmt.Errorf("RTA_DST: %w", err)
 				}
 			}
 		case unix.RTA_OIF:
@@ -1429,7 +1414,7 @@ func deserializeRoute(m []byte) (Route, error) {
 				for _, attr := range attrs {
 					switch attr.Attr.Type {
 					case unix.RTA_GATEWAY:
-						info.Gw = net.IP(attr.Value)
+						info.Gw, _ = netip.AddrFromSlice(attr.Value)
 					case unix.RTA_NEWDST:
 						var d Destination
 						switch msg.Family {
@@ -1547,22 +1532,22 @@ func deserializeRoute(m []byte) (Route, error) {
 	}
 
 	// Same logic to generate "default" dst with iproute2 implementation
-	if route.Dst == nil {
+	if !route.Dst.IsValid() {
 		var addLen int
-		var ip net.IP
+		var ip netip.Addr
 		switch msg.Family {
 		case FAMILY_V4:
 			addLen = net.IPv4len
-			ip = net.IPv4zero
+			ip = v4zero
 		case FAMILY_V6:
 			addLen = net.IPv6len
-			ip = net.IPv6zero
+			ip = v6zero
 		}
 
 		if addLen != 0 {
-			route.Dst = &net.IPNet{
-				IP:   ip,
-				Mask: net.CIDRMask(int(msg.Dst_len), 8*addLen),
+			route.Dst, err = ip.Prefix(int(msg.Dst_len))
+			if err != nil {
+				return route, fmt.Errorf("Dst: %w", err)
 			}
 		}
 	}
@@ -1611,7 +1596,7 @@ type RouteGetOptions struct {
 	Oif      string
 	OifIndex int
 	VrfName  string
-	SrcAddr  net.IP
+	SrcAddr  netip.Addr
 	UID      *uint32
 	Mark     uint32
 	FIBMatch bool
@@ -1619,35 +1604,28 @@ type RouteGetOptions struct {
 
 // RouteGetWithOptions gets a route to a specific destination from the host system.
 // Equivalent to: 'ip route get <> vrf <VrfName>'.
-func RouteGetWithOptions(destination net.IP, options *RouteGetOptions) ([]Route, error) {
+func RouteGetWithOptions(destination netip.Addr, options *RouteGetOptions) ([]Route, error) {
 	return pkgHandle.RouteGetWithOptions(destination, options)
 }
 
 // RouteGet gets a route to a specific destination from the host system.
 // Equivalent to: 'ip route get'.
-func RouteGet(destination net.IP) ([]Route, error) {
+func RouteGet(destination netip.Addr) ([]Route, error) {
 	return pkgHandle.RouteGet(destination)
 }
 
 // RouteGetWithOptions gets a route to a specific destination from the host system.
 // Equivalent to: 'ip route get <> vrf <VrfName>'.
-func (h *Handle) RouteGetWithOptions(destination net.IP, options *RouteGetOptions) ([]Route, error) {
+func (h *Handle) RouteGetWithOptions(destination netip.Addr, options *RouteGetOptions) ([]Route, error) {
 	req := h.newNetlinkRequest(unix.RTM_GETROUTE, unix.NLM_F_REQUEST)
 	family := nl.GetIPFamily(destination)
-	var destinationData []byte
-	var bitlen uint8
-	if family == FAMILY_V4 {
-		destinationData = destination.To4()
-		bitlen = 32
-	} else {
-		destinationData = destination.To16()
-		bitlen = 128
-	}
+	destinationData := destination.AsSlice()
+
 	msg := &nl.RtMsg{}
 	msg.Family = uint8(family)
-	msg.Dst_len = bitlen
-	if options != nil && options.SrcAddr != nil {
-		msg.Src_len = bitlen
+	msg.Dst_len = uint8(destination.BitLen())
+	if options != nil && options.SrcAddr.IsValid() {
+		msg.Src_len = uint8(destination.BitLen())
 	}
 	msg.Flags = unix.RTM_F_LOOKUP_TABLE
 	if options != nil && options.FIBMatch {
@@ -1707,15 +1685,8 @@ func (h *Handle) RouteGetWithOptions(destination net.IP, options *RouteGetOption
 			req.AddData(nl.NewRtAttr(unix.RTA_OIF, b))
 		}
 
-		if options.SrcAddr != nil {
-			var srcAddr []byte
-			if family == FAMILY_V4 {
-				srcAddr = options.SrcAddr.To4()
-			} else {
-				srcAddr = options.SrcAddr.To16()
-			}
-
-			req.AddData(nl.NewRtAttr(unix.RTA_SRC, srcAddr))
+		if options.SrcAddr.IsValid() {
+			req.AddData(nl.NewRtAttr(unix.RTA_SRC, options.SrcAddr.AsSlice()))
 		}
 
 		if options.UID != nil {
@@ -1752,7 +1723,7 @@ func (h *Handle) RouteGetWithOptions(destination net.IP, options *RouteGetOption
 
 // RouteGet gets a route to a specific destination from the host system.
 // Equivalent to: 'ip route get'.
-func (h *Handle) RouteGet(destination net.IP) ([]Route, error) {
+func (h *Handle) RouteGet(destination netip.Addr) ([]Route, error) {
 	return h.RouteGetWithOptions(destination, nil)
 }
 
@@ -1933,22 +1904,15 @@ func (p RouteProtocol) String() string {
 }
 
 // genZeroIPNet returns 0.0.0.0/0 or ::/0 for IPv4 or IPv6, otherwise nil
-func genZeroIPNet(family int) *net.IPNet {
-	var addLen int
-	var ip net.IP
+func genZeroIPNet(family int) netip.Prefix {
+	var a netip.Addr
 	switch family {
 	case FAMILY_V4:
-		addLen = net.IPv4len
-		ip = net.IPv4zero
+		a = v4zero
 	case FAMILY_V6:
-		addLen = net.IPv6len
-		ip = net.IPv6zero
+		a = v6zero
 	}
-	if addLen != 0 {
-		return &net.IPNet{
-			IP:   ip,
-			Mask: net.CIDRMask(0, 8*addLen),
-		}
-	}
-	return nil
+
+	p, _ := a.Prefix(0)
+	return p
 }

--- a/route_linux.go
+++ b/route_linux.go
@@ -784,8 +784,7 @@ func (v *Via) Encode() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = binary.Write(buf, native, v.Addr)
-	if err != nil {
+	if _, err = buf.Write(v.Addr.AsSlice()); err != nil {
 		return nil, err
 	}
 	return buf.Bytes(), nil
@@ -911,7 +910,7 @@ func (h *Handle) routeHandleIter(route *Route, req *nl.NetlinkRequest, msg *nl.R
 }
 
 func (h *Handle) prepareRouteReq(route *Route, req *nl.NetlinkRequest, msg *nl.RtMsg) error {
-	if req.NlMsghdr.Type != unix.RTM_GETROUTE && (!route.Dst.IsValid() || !route.Dst.IsValid()) && !route.Src.IsValid() && !route.Gw.IsValid() && route.MPLSDst == nil {
+	if req.NlMsghdr.Type != unix.RTM_GETROUTE && !route.Dst.IsValid() && !route.Src.IsValid() && !route.Gw.IsValid() && route.MPLSDst == nil {
 		return fmt.Errorf("either Dst.IP, Src.IP or Gw must be set")
 	}
 
@@ -1294,7 +1293,7 @@ func (h *Handle) RouteListFilteredIter(family int, filter *Route, filterMask uin
 				return true
 			case filterMask&RT_FILTER_DST != 0:
 				if filter.MPLSDst == nil || route.MPLSDst == nil || (*filter.MPLSDst) != (*route.MPLSDst) {
-					if filter.Dst.IsValid() {
+					if !filter.Dst.IsValid() {
 						filter.Dst = genZeroIPNet(family)
 					}
 					if route.Dst != filter.Dst {

--- a/route_test.go
+++ b/route_test.go
@@ -202,7 +202,7 @@ func TestRoute6AddDel(t *testing.T) {
 	if k > 4 || (k == 4 && m > 4) {
 		foundExpires := false
 		for _, route := range routes {
-			if route.Dst.Addr() == dst.Addr() {
+			if route.Dst == dst {
 				if route.Expires > 0 && route.Expires <= 10 {
 					foundExpires = true
 				}
@@ -443,7 +443,7 @@ func TestRouteReplace(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(routes) != 1 || routes[0].Src == ip {
+	if len(routes) != 1 || routes[0].Src != ip {
 		t.Fatal("Route not replaced properly")
 	}
 
@@ -500,7 +500,7 @@ func TestRouteAppend(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(routes) != 2 || routes[1].Src == ip {
+	if len(routes) != 2 || routes[1].Src != ip {
 		t.Fatal("Route not append properly")
 	}
 
@@ -540,15 +540,14 @@ func TestRouteAddIncomplete(t *testing.T) {
 }
 
 // expectRouteUpdate returns whether the expected updated is received within one minute.
-func expectRouteUpdate(ch <-chan RouteUpdate, t, f uint16, dst netip.Addr) bool {
+func expectRouteUpdate(ch <-chan RouteUpdate, t, f uint16, dst netip.Prefix) bool {
 	for {
 		timeout := time.After(time.Minute)
 		select {
 		case update := <-ch:
 			if update.Type == t &&
 				update.NlFlags == f &&
-				update.Route.Dst.IsValid() &&
-				update.Route.Dst.Addr() == dst {
+				update.Route.Dst == dst {
 				return true
 			}
 		case <-timeout:
@@ -587,13 +586,13 @@ func TestRouteSubscribe(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !expectRouteUpdate(ch, unix.RTM_NEWROUTE, unix.NLM_F_EXCL|unix.NLM_F_CREATE, dst.Addr()) {
+	if !expectRouteUpdate(ch, unix.RTM_NEWROUTE, unix.NLM_F_EXCL|unix.NLM_F_CREATE, dst) {
 		t.Fatal("Add update not received as expected")
 	}
 	if err := RouteDel(&route); err != nil {
 		t.Fatal(err)
 	}
-	if !expectRouteUpdate(ch, unix.RTM_DELROUTE, 0, dst.Addr()) {
+	if !expectRouteUpdate(ch, unix.RTM_DELROUTE, 0, dst) {
 		t.Fatal("Del update not received as expected")
 	}
 }
@@ -638,7 +637,7 @@ func TestRouteSubscribeWithOptions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !expectRouteUpdate(ch, unix.RTM_NEWROUTE, unix.NLM_F_EXCL|unix.NLM_F_CREATE, dst.Addr()) {
+	if !expectRouteUpdate(ch, unix.RTM_NEWROUTE, unix.NLM_F_EXCL|unix.NLM_F_CREATE, dst) {
 		t.Fatal("Add update not received as expected")
 	}
 }
@@ -687,13 +686,13 @@ func TestRouteSubscribeAt(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !expectRouteUpdate(ch, unix.RTM_NEWROUTE, unix.NLM_F_EXCL|unix.NLM_F_CREATE, dst.Addr()) {
+	if !expectRouteUpdate(ch, unix.RTM_NEWROUTE, unix.NLM_F_EXCL|unix.NLM_F_CREATE, dst) {
 		t.Fatal("Add update not received as expected")
 	}
 	if err := nh.RouteDel(&route); err != nil {
 		t.Fatal(err)
 	}
-	if !expectRouteUpdate(ch, unix.RTM_DELROUTE, 0, dst.Addr()) {
+	if !expectRouteUpdate(ch, unix.RTM_DELROUTE, 0, dst) {
 		t.Fatal("Del update not received as expected")
 	}
 }
@@ -745,7 +744,7 @@ func TestRouteSubscribeListExisting(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !expectRouteUpdate(ch, unix.RTM_NEWROUTE, 0, dst10.Addr()) {
+	if !expectRouteUpdate(ch, unix.RTM_NEWROUTE, 0, dst10) {
 		t.Fatal("Existing add update not received as expected")
 	}
 
@@ -757,19 +756,19 @@ func TestRouteSubscribeListExisting(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !expectRouteUpdate(ch, unix.RTM_NEWROUTE, unix.NLM_F_EXCL|unix.NLM_F_CREATE, dst.Addr()) {
+	if !expectRouteUpdate(ch, unix.RTM_NEWROUTE, unix.NLM_F_EXCL|unix.NLM_F_CREATE, dst) {
 		t.Fatal("Add update not received as expected")
 	}
 	if err := nh.RouteDel(&route); err != nil {
 		t.Fatal(err)
 	}
-	if !expectRouteUpdate(ch, unix.RTM_DELROUTE, 0, dst.Addr()) {
+	if !expectRouteUpdate(ch, unix.RTM_DELROUTE, 0, dst) {
 		t.Fatal("Del update not received as expected")
 	}
 	if err := nh.RouteDel(&route10); err != nil {
 		t.Fatal(err)
 	}
-	if !expectRouteUpdate(ch, unix.RTM_DELROUTE, 0, dst10.Addr()) {
+	if !expectRouteUpdate(ch, unix.RTM_DELROUTE, 0, dst10) {
 		t.Fatal("Del update not received as expected")
 	}
 }
@@ -2233,64 +2232,73 @@ func TestRtoMinLockRouteAddDel(t *testing.T) {
 	}
 }
 
-func TestRouteViaAddDel(t *testing.T) {
+// TestRouteIPv6DstIPv4MappedGwAddDel is a regression test ensuring that an
+// IPv6 destination route with an IPv4-mapped IPv6 gateway (::ffff:x.x.x.x)
+// round-trips correctly. A dummy (non-loopback) interface is required because
+// the kernel drops the gateway for routes on the loopback interface.
+func TestRouteIPv6DstIPv4MappedGwAddDel(t *testing.T) {
 	minKernelRequired(t, 5, 4)
 	t.Cleanup(setUpNetlinkTest(t))
 
-	_, err := RouteList(nil, FAMILY_V4)
+	dummy := &Dummy{LinkAttrs: LinkAttrs{Name: "dummy"}}
+	if err := LinkAdd(dummy); err != nil {
+		t.Fatal(err)
+	}
+	link, err := LinkByName(dummy.Attrs().Name)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	link, err := LinkByName("lo")
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	if err := LinkSetUp(link); err != nil {
 		t.Fatal(err)
 	}
 
+	// Record existing routes (fe80::/64 may be auto-added on the dummy).
+	routes, err := RouteList(link, FAMILY_V6)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nroutes := len(routes)
+
 	route := &Route{
 		LinkIndex: link.Attrs().Index,
-		Dst:       netip.MustParsePrefix("192.168.0.0/14"),
-		MultiPath: []*NexthopInfo{
-			{
-				LinkIndex: link.Attrs().Index,
-				Via: &Via{
-					AddrFamily: FAMILY_V6,
-					Addr:       netip.MustParseAddr("2001::1"),
-				},
-			},
-		},
+		Dst:       netip.MustParsePrefix("2001:db8:1::/48"),
+		Gw:        netip.MustParseAddr("::ffff:100.95.128.3"),
+		Flags:     int(FLAG_ONLINK),
 	}
-
 	if err := RouteAdd(route); err != nil {
 		t.Fatalf("route: %v, err: %v", route, err)
 	}
 
-	routes, err := RouteList(link, FAMILY_V4)
+	routes, err = RouteList(link, FAMILY_V6)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(routes) != 1 {
+	if len(routes) != nroutes+1 {
 		t.Fatal("Route not added properly")
 	}
 
-	got := routes[0].Via
-	want := route.MultiPath[0].Via
-	if !want.Equal(got) {
-		t.Fatalf("Route Via attribute does not match; got: %s, want: %s", got, want)
+	var added *Route
+	for i := range routes {
+		if routes[i].Dst == route.Dst {
+			added = &routes[i]
+			break
+		}
+	}
+	if added == nil {
+		t.Fatal("Added route not found in list")
+	}
+	if got, want := added.Gw, route.Gw; got != want {
+		t.Fatalf("Route Gw does not match; got: %s, want: %s", got, want)
 	}
 
 	if err := RouteDel(route); err != nil {
 		t.Fatal(err)
 	}
-	routes, err = RouteList(link, FAMILY_V4)
+	routes, err = RouteList(link, FAMILY_V6)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(routes) != 0 {
+	if len(routes) != nroutes {
 		t.Fatal("Route not removed properly")
 	}
 }
@@ -2590,14 +2598,14 @@ func TestRouteNHID(t *testing.T) {
 	nh := &Nexthop{
 		ID:      1,
 		OIF:     uint32(link0.Attrs().Index),
-		Gateway: net.ParseIP("fe80::1"),
+		Gateway: netip.MustParseAddr("fe80::1"),
 	}
 	if err = NexthopAdd(nh); err != nil {
 		t.Fatal(err)
 	}
 
 	// IPv4 prefix with IPv6 link local nexthop
-	_, dst, err := net.ParseCIDR("10.0.0.0/24")
+	dst, err := netip.ParsePrefix("10.0.0.0/24")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/rule.go
+++ b/rule.go
@@ -2,7 +2,7 @@ package netlink
 
 import (
 	"fmt"
-	"net"
+	"net/netip"
 )
 
 // Rule represents a netlink rule.
@@ -15,8 +15,8 @@ type Rule struct {
 	Tos               uint
 	TunID             uint
 	Goto              int
-	Src               *net.IPNet
-	Dst               *net.IPNet
+	Src               netip.Prefix
+	Dst               netip.Prefix
 	Flow              int
 	IifName           string
 	OifName           string
@@ -33,12 +33,12 @@ type Rule struct {
 
 func (r Rule) String() string {
 	from := "all"
-	if r.Src != nil && r.Src.String() != "<nil>" {
+	if r.Src.IsValid() {
 		from = r.Src.String()
 	}
 
 	to := "all"
-	if r.Dst != nil && r.Dst.String() != "<nil>" {
+	if r.Dst.IsValid() {
 		to = r.Dst.String()
 	}
 

--- a/rule_linux.go
+++ b/rule_linux.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"net"
+	"net/netip"
 
 	"github.com/vishvananda/netlink/nl"
 	"golang.org/x/sys/unix"
@@ -63,33 +63,23 @@ func ruleHandle(rule *Rule, req *nl.NetlinkRequest) error {
 
 	var dstFamily uint8
 	var rtAttrs []*nl.RtAttr
-	if rule.Dst != nil && rule.Dst.IP != nil {
-		dstLen, _ := rule.Dst.Mask.Size()
+	if rule.Dst.IsValid() {
+		dstLen := rule.Dst.Bits()
 		msg.Dst_len = uint8(dstLen)
-		msg.Family = uint8(nl.GetIPFamily(rule.Dst.IP))
+		msg.Family = uint8(nl.GetIPFamily(rule.Dst.Addr()))
 		dstFamily = msg.Family
-		var dstData []byte
-		if msg.Family == unix.AF_INET {
-			dstData = rule.Dst.IP.To4()
-		} else {
-			dstData = rule.Dst.IP.To16()
-		}
+		dstData := rule.Dst.Addr().AsSlice()
 		rtAttrs = append(rtAttrs, nl.NewRtAttr(unix.RTA_DST, dstData))
 	}
 
-	if rule.Src != nil && rule.Src.IP != nil {
-		msg.Family = uint8(nl.GetIPFamily(rule.Src.IP))
+	if rule.Src.IsValid() {
+		msg.Family = uint8(nl.GetIPFamily(rule.Src.Addr()))
 		if dstFamily != 0 && dstFamily != msg.Family {
 			return fmt.Errorf("source and destination ip are not the same IP family")
 		}
-		srcLen, _ := rule.Src.Mask.Size()
+		srcLen := rule.Src.Bits()
 		msg.Src_len = uint8(srcLen)
-		var srcData []byte
-		if msg.Family == unix.AF_INET {
-			srcData = rule.Src.IP.To4()
-		} else {
-			srcData = rule.Src.IP.To16()
-		}
+		srcData := rule.Src.Addr().AsSlice()
 		rtAttrs = append(rtAttrs, nl.NewRtAttr(unix.RTA_SRC, srcData))
 	}
 
@@ -245,15 +235,17 @@ func (h *Handle) RuleListFiltered(family int, filter *Rule, filterMask uint64) (
 			case unix.RTA_TABLE:
 				rule.Table = int(native.Uint32(attrs[j].Value[0:4]))
 			case nl.FRA_SRC:
-				rule.Src = &net.IPNet{
-					IP:   attrs[j].Value,
-					Mask: net.CIDRMask(int(msg.Src_len), 8*len(attrs[j].Value)),
+				addr, ok := netip.AddrFromSlice(attrs[j].Value)
+				if !ok {
+					return nil, fmt.Errorf("FRA_SRC: invalid address")
 				}
+				rule.Src, _ = addr.Prefix(int(msg.Src_len))
 			case nl.FRA_DST:
-				rule.Dst = &net.IPNet{
-					IP:   attrs[j].Value,
-					Mask: net.CIDRMask(int(msg.Dst_len), 8*len(attrs[j].Value)),
+				addr, ok := netip.AddrFromSlice(attrs[j].Value)
+				if !ok {
+					return nil, fmt.Errorf("FRA_SRC: invalid address")
 				}
+				rule.Dst, _ = addr.Prefix(int(msg.Dst_len))
 			case nl.FRA_FWMARK:
 				rule.Mark = native.Uint32(attrs[j].Value[0:4])
 			case nl.FRA_FWMASK:
@@ -382,19 +374,14 @@ func (r Rule) typeString() string {
 // to 0.0.0.0/0 or ::/0, which is how the kernel represents "from all" /
 // "to all" rules (it omits FRA_SRC/FRA_DST when prefix length is 0).
 // Two /0 prefixes are always equal regardless of IP (e.g. 0.0.0.0/0 == 1.2.3.4/0).
-func ruleIPNetEqual(a, b *net.IPNet) bool {
-	aIsDefault := a == nil || prefixLen(a) == 0
-	bIsDefault := b == nil || prefixLen(b) == 0
+func ruleIPNetEqual(a, b *netip.Prefix) bool {
+	aIsDefault := a == nil || a.Bits() == 0
+	bIsDefault := b == nil || b.Bits() == 0
 	if aIsDefault && bIsDefault {
 		return true
 	}
 	if aIsDefault != bIsDefault {
 		return false
 	}
-	return ipNetEqual(a, b)
-}
-
-func prefixLen(ipNet *net.IPNet) int {
-	ones, _ := ipNet.Mask.Size()
-	return ones
+	return a == b
 }

--- a/rule_linux.go
+++ b/rule_linux.go
@@ -68,7 +68,7 @@ func ruleHandle(rule *Rule, req *nl.NetlinkRequest) error {
 		msg.Dst_len = uint8(dstLen)
 		msg.Family = uint8(nl.GetIPFamily(rule.Dst.Addr()))
 		dstFamily = msg.Family
-		dstData := rule.Dst.Addr().AsSlice()
+		dstData := rule.Dst.Masked().Addr().AsSlice()
 		rtAttrs = append(rtAttrs, nl.NewRtAttr(unix.RTA_DST, dstData))
 	}
 
@@ -79,7 +79,7 @@ func ruleHandle(rule *Rule, req *nl.NetlinkRequest) error {
 		}
 		srcLen := rule.Src.Bits()
 		msg.Src_len = uint8(srcLen)
-		srcData := rule.Src.Addr().AsSlice()
+		srcData := rule.Src.Masked().Addr().AsSlice()
 		rtAttrs = append(rtAttrs, nl.NewRtAttr(unix.RTA_SRC, srcData))
 	}
 
@@ -239,13 +239,21 @@ func (h *Handle) RuleListFiltered(family int, filter *Rule, filterMask uint64) (
 				if !ok {
 					return nil, fmt.Errorf("FRA_SRC: invalid address")
 				}
-				rule.Src, _ = addr.Prefix(int(msg.Src_len))
+				src, err := addr.Prefix(int(msg.Src_len))
+				if err != nil {
+					return nil, fmt.Errorf("FRA_SRC: invalid prefix length %d: %w", msg.Src_len, err)
+				}
+				rule.Src = src
 			case nl.FRA_DST:
 				addr, ok := netip.AddrFromSlice(attrs[j].Value)
 				if !ok {
-					return nil, fmt.Errorf("FRA_SRC: invalid address")
+					return nil, fmt.Errorf("FRA_DST: invalid address")
 				}
-				rule.Dst, _ = addr.Prefix(int(msg.Dst_len))
+				dst, err := addr.Prefix(int(msg.Dst_len))
+				if err != nil {
+					return nil, fmt.Errorf("FRA_DST: invalid prefix length %d: %w", msg.Dst_len, err)
+				}
+				rule.Dst = dst
 			case nl.FRA_FWMARK:
 				rule.Mark = native.Uint32(attrs[j].Value[0:4])
 			case nl.FRA_FWMASK:
@@ -374,14 +382,14 @@ func (r Rule) typeString() string {
 // to 0.0.0.0/0 or ::/0, which is how the kernel represents "from all" /
 // "to all" rules (it omits FRA_SRC/FRA_DST when prefix length is 0).
 // Two /0 prefixes are always equal regardless of IP (e.g. 0.0.0.0/0 == 1.2.3.4/0).
-func ruleIPNetEqual(a, b *netip.Prefix) bool {
-	aIsDefault := a == nil || a.Bits() == 0
-	bIsDefault := b == nil || b.Bits() == 0
+func ruleIPNetEqual(a, b netip.Prefix) bool {
+	aIsDefault := !a.IsValid() || a.Bits() == 0
+	bIsDefault := !b.IsValid() || b.Bits() == 0
 	if aIsDefault && bIsDefault {
 		return true
 	}
 	if aIsDefault != bIsDefault {
 		return false
 	}
-	return a == b
+	return a.Masked() == b.Masked()
 }

--- a/rule_test.go
+++ b/rule_test.go
@@ -674,9 +674,9 @@ func ruleExists(rules []Rule, rule Rule) bool {
 func ruleEquals(a, b Rule) bool {
 	return a.Table == b.Table &&
 		((!a.Src.IsValid() && !b.Src.IsValid()) ||
-			(a.Src.IsValid() && b.Src.IsValid() && a.Src.String() == b.Src.String())) &&
+			(a.Src.IsValid() && b.Src.IsValid() && a.Src.Masked().String() == b.Src.Masked().String())) &&
 		((!a.Dst.IsValid() && !b.Dst.IsValid()) ||
-			(a.Dst.IsValid() && b.Dst.IsValid() && a.Dst.String() == b.Dst.String())) &&
+			(a.Dst.IsValid() && b.Dst.IsValid() && a.Dst.Masked().String() == b.Dst.Masked().String())) &&
 		a.OifName == b.OifName &&
 		a.Priority == b.Priority &&
 		a.Family == b.Family &&

--- a/socket.go
+++ b/socket.go
@@ -1,13 +1,13 @@
 package netlink
 
-import "net"
+import "net/netip"
 
 // SocketID identifies a single socket.
 type SocketID struct {
 	SourcePort      uint16
 	DestinationPort uint16
-	Source          net.IP
-	Destination     net.IP
+	Source          netip.Addr
+	Destination     netip.Addr
 	Interface       uint32
 	Cookie          [2]uint32
 }

--- a/socket_linux.go
+++ b/socket_linux.go
@@ -53,8 +53,8 @@ func (r *socketRequest) Serialize() []byte {
 	native.PutUint32(b.Next(4), r.States)
 	networkOrder.PutUint16(b.Next(2), r.ID.SourcePort)
 	networkOrder.PutUint16(b.Next(2), r.ID.DestinationPort)
-	r.ID.Source, _ = netip.AddrFromSlice(b.Next(16))
-	r.ID.Destination, _ = netip.AddrFromSlice(b.Next(16))
+	copy(b.Next(16), r.ID.Source.AsSlice())
+	copy(b.Next(16), r.ID.Destination.AsSlice())
 	native.PutUint32(b.Next(4), r.ID.Interface)
 	native.PutUint32(b.Next(4), r.ID.Cookie[0])
 	native.PutUint32(b.Next(4), r.ID.Cookie[1])
@@ -185,8 +185,10 @@ func (h *Handle) SocketGet(local, remote net.Addr) (*Socket, error) {
 			return nil, ErrNotImplemented
 		}
 		localIP, _ = netip.AddrFromSlice(l.IP)
+		localIP = localIP.Unmap()
 		localPort = uint16(l.Port)
 		remoteIP, _ = netip.AddrFromSlice(r.IP)
+		remoteIP = remoteIP.Unmap()
 		remotePort = uint16(r.Port)
 		protocol = unix.IPPROTO_TCP
 	case *net.UDPAddr:
@@ -195,8 +197,10 @@ func (h *Handle) SocketGet(local, remote net.Addr) (*Socket, error) {
 			return nil, ErrNotImplemented
 		}
 		localIP, _ = netip.AddrFromSlice(l.IP)
+		localIP = localIP.Unmap()
 		localPort = uint16(l.Port)
 		remoteIP, _ = netip.AddrFromSlice(r.IP)
+		remoteIP = remoteIP.Unmap()
 		remotePort = uint16(r.Port)
 		protocol = unix.IPPROTO_UDP
 	default:

--- a/socket_linux.go
+++ b/socket_linux.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"syscall"
 
 	"github.com/vishvananda/netlink/nl"
@@ -52,13 +53,8 @@ func (r *socketRequest) Serialize() []byte {
 	native.PutUint32(b.Next(4), r.States)
 	networkOrder.PutUint16(b.Next(2), r.ID.SourcePort)
 	networkOrder.PutUint16(b.Next(2), r.ID.DestinationPort)
-	if r.Family == unix.AF_INET6 {
-		copy(b.Next(16), r.ID.Source)
-		copy(b.Next(16), r.ID.Destination)
-	} else {
-		copy(b.Next(16), r.ID.Source.To4())
-		copy(b.Next(16), r.ID.Destination.To4())
-	}
+	r.ID.Source, _ = netip.AddrFromSlice(b.Next(16))
+	r.ID.Destination, _ = netip.AddrFromSlice(b.Next(16))
 	native.PutUint32(b.Next(4), r.ID.Interface)
 	native.PutUint32(b.Next(4), r.ID.Cookie[0])
 	native.PutUint32(b.Next(4), r.ID.Cookie[1])
@@ -122,12 +118,30 @@ func (s *Socket) deserialize(b []byte) error {
 	s.ID.SourcePort = networkOrder.Uint16(rb.Next(2))
 	s.ID.DestinationPort = networkOrder.Uint16(rb.Next(2))
 	if s.Family == unix.AF_INET6 {
-		s.ID.Source = net.IP(rb.Next(16))
-		s.ID.Destination = net.IP(rb.Next(16))
+		addr, ok := netip.AddrFromSlice(rb.Next(16))
+		if !ok {
+			return fmt.Errorf("source: invalid address")
+		}
+		s.ID.Source = addr
+
+		addr, ok = netip.AddrFromSlice(rb.Next(16))
+		if !ok {
+			return fmt.Errorf("destination: invalid address")
+		}
+		s.ID.Destination = addr
 	} else {
-		s.ID.Source = net.IPv4(rb.Read(), rb.Read(), rb.Read(), rb.Read())
+		addr, ok := netip.AddrFromSlice(rb.Next(4))
+		if !ok {
+			return fmt.Errorf("source: invalid address")
+		}
+		s.ID.Source = addr
 		rb.Next(12)
-		s.ID.Destination = net.IPv4(rb.Read(), rb.Read(), rb.Read(), rb.Read())
+
+		addr, ok = netip.AddrFromSlice(rb.Next(4))
+		if !ok {
+			return fmt.Errorf("destination: invalid address")
+		}
+		s.ID.Destination = addr
 		rb.Next(12)
 	}
 	s.ID.Interface = native.Uint32(rb.Next(4))
@@ -162,7 +176,7 @@ func (u *UnixSocket) deserialize(b []byte) error {
 // be incomplete and the caller should retry.
 func (h *Handle) SocketGet(local, remote net.Addr) (*Socket, error) {
 	var protocol uint8
-	var localIP, remoteIP net.IP
+	var localIP, remoteIP netip.Addr
 	var localPort, remotePort uint16
 	switch l := local.(type) {
 	case *net.TCPAddr:
@@ -170,9 +184,9 @@ func (h *Handle) SocketGet(local, remote net.Addr) (*Socket, error) {
 		if !ok {
 			return nil, ErrNotImplemented
 		}
-		localIP = l.IP
+		localIP, _ = netip.AddrFromSlice(l.IP)
 		localPort = uint16(l.Port)
-		remoteIP = r.IP
+		remoteIP, _ = netip.AddrFromSlice(r.IP)
 		remotePort = uint16(r.Port)
 		protocol = unix.IPPROTO_TCP
 	case *net.UDPAddr:
@@ -180,9 +194,9 @@ func (h *Handle) SocketGet(local, remote net.Addr) (*Socket, error) {
 		if !ok {
 			return nil, ErrNotImplemented
 		}
-		localIP = l.IP
+		localIP, _ = netip.AddrFromSlice(l.IP)
 		localPort = uint16(l.Port)
-		remoteIP = r.IP
+		remoteIP, _ = netip.AddrFromSlice(r.IP)
 		remotePort = uint16(r.Port)
 		protocol = unix.IPPROTO_UDP
 	default:
@@ -190,11 +204,11 @@ func (h *Handle) SocketGet(local, remote net.Addr) (*Socket, error) {
 	}
 
 	var family uint8
-	if localIP.To4() != nil && remoteIP.To4() != nil {
+	if localIP.Is4() && remoteIP.Is4() {
 		family = unix.AF_INET
 	}
 
-	if family == 0 && localIP.To16() != nil && remoteIP.To16() != nil {
+	if family == 0 && localIP.Is6() && remoteIP.Is6() {
 		family = unix.AF_INET6
 	}
 
@@ -255,14 +269,17 @@ func (h *Handle) SocketDestroy(local, remote net.Addr) error {
 	if !ok {
 		return ErrNotImplemented
 	}
-	localIP := localTCP.IP.To4()
-	if localIP == nil {
+	localIP4 := localTCP.IP.To4()
+	if localIP4 == nil {
 		return ErrNotImplemented
 	}
-	remoteIP := remoteTCP.IP.To4()
-	if remoteIP == nil {
+	localIP, _ := netip.AddrFromSlice(localIP4)
+
+	remoteIP4 := remoteTCP.IP.To4()
+	if remoteIP4 == nil {
 		return ErrNotImplemented
 	}
+	remoteIP, _ := netip.AddrFromSlice(remoteIP4)
 
 	req := h.newNetlinkRequest(nl.SOCK_DESTROY, unix.NLM_F_ACK)
 	req.AddData(&socketRequest{

--- a/socket_test.go
+++ b/socket_test.go
@@ -5,6 +5,7 @@ package netlink
 
 import (
 	"net"
+	"net/netip"
 	"os/user"
 	"strconv"
 	"syscall"
@@ -15,7 +16,7 @@ func TestSocketGet(t *testing.T) {
 	t.Cleanup(setUpNetlinkTestWithLoopback(t))
 
 	type Addr struct {
-		IP   net.IP
+		IP   netip.Addr
 		Port int
 	}
 
@@ -23,10 +24,10 @@ func TestSocketGet(t *testing.T) {
 		var addr Addr
 		switch v := a.(type) {
 		case *net.UDPAddr:
-			addr.IP = v.IP
+			addr.IP, _ = netip.AddrFromSlice(v.IP)
 			addr.Port = v.Port
 		case *net.TCPAddr:
-			addr.IP = v.IP
+			addr.IP, _ = netip.AddrFromSlice(v.IP)
 			addr.Port = v.Port
 		}
 		return addr
@@ -40,10 +41,10 @@ func TestSocketGet(t *testing.T) {
 
 		localAddr, remoteAddr := getAddr(local), getAddr(remote)
 
-		if got, want := socket.ID.Source, localAddr.IP; !got.Equal(want) {
+		if got, want := socket.ID.Source, localAddr.IP; got != want {
 			t.Fatalf("local ip = %v, want %v", got, want)
 		}
-		if got, want := socket.ID.Destination, remoteAddr.IP; !got.Equal(want) {
+		if got, want := socket.ID.Destination, remoteAddr.IP; got != want {
 			t.Fatalf("remote ip = %v, want %v", got, want)
 		}
 		if got, want := int(socket.ID.SourcePort), localAddr.Port; got != want {

--- a/socket_test.go
+++ b/socket_test.go
@@ -25,9 +25,11 @@ func TestSocketGet(t *testing.T) {
 		switch v := a.(type) {
 		case *net.UDPAddr:
 			addr.IP, _ = netip.AddrFromSlice(v.IP)
+			addr.IP = addr.IP.Unmap()
 			addr.Port = v.Port
 		case *net.TCPAddr:
 			addr.IP, _ = netip.AddrFromSlice(v.IP)
+			addr.IP = addr.IP.Unmap()
 			addr.Port = v.Port
 		}
 		return addr

--- a/xfrm_policy_linux.go
+++ b/xfrm_policy_linux.go
@@ -108,6 +108,9 @@ func selFromPolicy(sel *nl.XfrmSelector, policy *XfrmPolicy) {
 		sel.PrefixlenD = uint8(policy.Dst.Bits())
 	}
 	if policy.Src.IsValid() {
+		if sel.Family == uint16(nl.FAMILY_V4) && policy.Src.Addr().Is6() {
+			sel.Family = uint16(nl.FAMILY_V6)
+		}
 		sel.Saddr.FromIP(policy.Src.Addr())
 		sel.PrefixlenS = uint8(policy.Src.Bits())
 	}
@@ -323,8 +326,8 @@ func parseXfrmPolicy(m []byte, family int) (*XfrmPolicy, error) {
 
 	var policy XfrmPolicy
 
-	policy.Dst = msg.Sel.Daddr.ToIPNet(msg.Sel.PrefixlenD, uint16(family))
-	policy.Src = msg.Sel.Saddr.ToIPNet(msg.Sel.PrefixlenS, uint16(family))
+	policy.Dst = msg.Sel.Daddr.ToPrefix(msg.Sel.PrefixlenD, msg.Sel.Family)
+	policy.Src = msg.Sel.Saddr.ToPrefix(msg.Sel.PrefixlenS, msg.Sel.Family)
 	policy.Proto = Proto(msg.Sel.Proto)
 	policy.DstPort = int(nl.Swap16(msg.Sel.Dport))
 	policy.SrcPort = int(nl.Swap16(msg.Sel.Sport))

--- a/xfrm_policy_linux_test.go
+++ b/xfrm_policy_linux_test.go
@@ -44,7 +44,7 @@ func TestXfrmPolicyAddUpdateDel(t *testing.T) {
 	}
 
 	if !comparePolicies(policy, sp) {
-		t.Fatalf("unexpected policy returned")
+		t.Fatalf("unexpected policy returned.\nExpected: %v.\nGot %v", policy, sp)
 	}
 
 	// Modify the policy
@@ -85,7 +85,7 @@ func TestXfrmPolicyAddUpdateDel(t *testing.T) {
 	}
 
 	if !comparePolicies(policy, sp) {
-		t.Fatalf("unexpected policy returned")
+		t.Fatalf("unexpected policy returned\nExpected: %v.\nGot %v", policy, sp)
 	}
 
 	if err = XfrmPolicyDel(policy); err != nil {
@@ -219,7 +219,7 @@ func comparePolicies(a, b *XfrmPolicy) bool {
 	}
 	// Do not check Index which is assigned by kernel
 	return a.Dir == b.Dir && a.Priority == b.Priority &&
-		a.Src == b.Src && a.Dst == b.Dst &&
+		comparePrefix(a.Src, b.Src) && comparePrefix(a.Dst, b.Dst) &&
 		a.Action == b.Action && a.Ifindex == b.Ifindex &&
 		a.Mark.Value == b.Mark.Value && a.Mark.Mask == b.Mark.Mask &&
 		a.Ifid == b.Ifid && compareTemplates(a.Tmpls, b.Tmpls)
@@ -240,9 +240,23 @@ func compareTemplates(a, b []XfrmPolicyTmpl) bool {
 	return true
 }
 
+func comparePrefix(a, b netip.Prefix) bool {
+	if a == b {
+		return true
+	}
+	// For unspecified src/dst parseXfrmPolicy returns a /0 prefix.
+	if (!a.IsValid() && b.Bits() == 0) || (!b.IsValid() && a.Bits() == 0) {
+		return true
+	}
+	if !a.IsValid() || !b.IsValid() {
+		return false
+	}
+	return a == b
+}
+
 func getPolicy() *XfrmPolicy {
-	src, _ := ParseIPNet("127.1.1.1/32")
-	dst, _ := ParseIPNet("127.1.1.2/32")
+	src, _ := ParsePrefix("127.1.1.1/32")
+	dst, _ := ParsePrefix("127.1.1.2/32")
 	policy := &XfrmPolicy{
 		Src:     src,
 		Dst:     dst,

--- a/xfrm_state_linux.go
+++ b/xfrm_state_linux.go
@@ -466,7 +466,9 @@ func (h *Handle) xfrmStateGetOrDelete(state *XfrmState, nlProto int) (*XfrmState
 		req.AddData(out)
 	}
 	if state.Src.IsValid() {
-		out := nl.NewRtAttr(nl.XFRMA_SRCADDR, state.Src.AsSlice())
+		var srcAddr nl.XfrmAddress
+		srcAddr.FromIP(state.Src)
+		out := nl.NewRtAttr(nl.XFRMA_SRCADDR, srcAddr[:])
 		req.AddData(out)
 	}
 
@@ -511,8 +513,8 @@ func xfrmStateFromXfrmUsersaInfo(msg *nl.XfrmUsersaInfo) *XfrmState {
 	lftToLimits(&msg.Lft, &state.Limits)
 	curToStats(&msg.Curlft, &msg.Stats, &state.Statistics)
 	state.Selector = &XfrmPolicy{
-		Dst:     msg.Sel.Daddr.ToIPNet(msg.Sel.PrefixlenD, msg.Sel.Family),
-		Src:     msg.Sel.Saddr.ToIPNet(msg.Sel.PrefixlenS, msg.Sel.Family),
+		Dst:     msg.Sel.Daddr.ToPrefix(msg.Sel.PrefixlenD, msg.Sel.Family),
+		Src:     msg.Sel.Saddr.ToPrefix(msg.Sel.PrefixlenS, msg.Sel.Family),
 		Proto:   Proto(msg.Sel.Proto),
 		DstPort: int(nl.Swap16(msg.Sel.Dport)),
 		SrcPort: int(nl.Swap16(msg.Sel.Sport)),

--- a/xfrm_state_linux.go
+++ b/xfrm_state_linux.go
@@ -3,7 +3,7 @@ package netlink
 import (
 	"errors"
 	"fmt"
-	"net"
+	"net/netip"
 	"time"
 	"unsafe"
 
@@ -53,7 +53,7 @@ type XfrmStateEncap struct {
 	Type            EncapType
 	SrcPort         int
 	DstPort         int
-	OriginalAddress net.IP
+	OriginalAddress netip.Addr
 }
 
 func (e XfrmStateEncap) String() string {
@@ -102,8 +102,8 @@ func (r XfrmReplayState) String() string {
 // XfrmState represents the state of an ipsec policy. It optionally
 // contains an XfrmStateAlgo for encryption and one for authentication.
 type XfrmState struct {
-	Dst           net.IP
-	Src           net.IP
+	Dst           netip.Addr
+	Src           netip.Addr
 	Proto         Proto
 	Mode          Mode
 	Spi           int
@@ -465,8 +465,8 @@ func (h *Handle) xfrmStateGetOrDelete(state *XfrmState, nlProto int) (*XfrmState
 		out := nl.NewRtAttr(nl.XFRMA_MARK, writeMark(state.Mark))
 		req.AddData(out)
 	}
-	if state.Src != nil {
-		out := nl.NewRtAttr(nl.XFRMA_SRCADDR, state.Src.To16())
+	if state.Src.IsValid() {
+		out := nl.NewRtAttr(nl.XFRMA_SRCADDR, state.Src.AsSlice())
 		req.AddData(out)
 	}
 

--- a/xfrm_state_linux_test.go
+++ b/xfrm_state_linux_test.go
@@ -3,7 +3,7 @@ package netlink
 import (
 	"bytes"
 	"encoding/hex"
-	"net"
+	"net/netip"
 	"strings"
 	"testing"
 	"time"
@@ -90,8 +90,8 @@ func TestXfrmStateFlush(t *testing.T) {
 
 	state1 := getBaseState()
 	state2 := getBaseState()
-	state2.Src = net.ParseIP("127.1.0.1")
-	state2.Dst = net.ParseIP("127.1.0.2")
+	state2.Src = netip.MustParseAddr("127.1.0.1")
+	state2.Dst = netip.MustParseAddr("127.1.0.2")
 	state2.Proto = XFRM_PROTO_AH
 	state2.Mode = XFRM_MODE_TUNNEL
 	state2.Spi = 20
@@ -359,7 +359,7 @@ func TestXfrmStateWithOutputMarkAndMask(t *testing.T) {
 	}
 }
 func genStateSelectorForV6Payload() *XfrmPolicy {
-	_, wildcardV6Net, _ := net.ParseCIDR("::/0")
+	wildcardV6Net := netip.MustParsePrefix("::/0")
 	return &XfrmPolicy{
 		Src: wildcardV6Net,
 		Dst: wildcardV6Net,
@@ -367,7 +367,7 @@ func genStateSelectorForV6Payload() *XfrmPolicy {
 }
 
 func genStateSelectorForV4Payload() *XfrmPolicy {
-	_, wildcardV4Net, _ := net.ParseCIDR("0.0.0.0/0")
+	wildcardV4Net := netip.MustParsePrefix("0.0.0.0/0")
 	return &XfrmPolicy{
 		Src: wildcardV4Net,
 		Dst: wildcardV4Net,
@@ -377,8 +377,8 @@ func genStateSelectorForV4Payload() *XfrmPolicy {
 func getBaseState() *XfrmState {
 	return &XfrmState{
 		// Force 4 byte notation for the IPv4 addresses
-		Src:   net.ParseIP("127.0.0.1").To4(),
-		Dst:   net.ParseIP("127.0.0.2").To4(),
+		Src:   netip.MustParseAddr("127.0.0.1"),
+		Dst:   netip.MustParseAddr("127.0.0.2"),
 		Proto: XFRM_PROTO_ESP,
 		Mode:  XFRM_MODE_TUNNEL,
 		Spi:   1,
@@ -400,8 +400,8 @@ func getBaseState() *XfrmState {
 func getBaseStateV4oV6() *XfrmState {
 	return &XfrmState{
 		// Force 4 byte notation for the IPv4 addressesd
-		Src:   net.ParseIP("2001:dead::1").To16(),
-		Dst:   net.ParseIP("2001:beef::1").To16(),
+		Src:   netip.MustParseAddr("2001:dead::1"),
+		Dst:   netip.MustParseAddr("2001:beef::1"),
 		Proto: XFRM_PROTO_ESP,
 		Mode:  XFRM_MODE_TUNNEL,
 		Spi:   1,
@@ -424,8 +424,8 @@ func getBaseStateV4oV6() *XfrmState {
 func getBaseStateV6oV4() *XfrmState {
 	return &XfrmState{
 		// Force 4 byte notation for the IPv4 addressesd
-		Src:   net.ParseIP("192.168.1.1").To4(),
-		Dst:   net.ParseIP("192.168.2.2").To4(),
+		Src:   netip.MustParseAddr("192.168.1.1"),
+		Dst:   netip.MustParseAddr("192.168.2.2"),
 		Proto: XFRM_PROTO_ESP,
 		Mode:  XFRM_MODE_TUNNEL,
 		Spi:   1,
@@ -450,8 +450,8 @@ func getAeadState() *XfrmState {
 	k, _ := hex.DecodeString("d0562776bf0e75830ba3f7f8eb6c09b555aa1177")
 	return &XfrmState{
 		// Leave IPv4 addresses in Ipv4 in IPv6 notation
-		Src:   net.ParseIP("192.168.1.1"),
-		Dst:   net.ParseIP("192.168.2.2"),
+		Src:   netip.MustParseAddr("192.168.1.1"),
+		Dst:   netip.MustParseAddr("192.168.2.2"),
 		Proto: XFRM_PROTO_ESP,
 		Mode:  XFRM_MODE_TUNNEL,
 		Spi:   2,
@@ -484,7 +484,7 @@ func compareStates(a, b *XfrmState) bool {
 		}
 	}
 
-	return a.Src.Equal(b.Src) && a.Dst.Equal(b.Dst) &&
+	return a.Src == b.Src && a.Dst == b.Dst &&
 		a.Mode == b.Mode && a.Spi == b.Spi && a.Proto == b.Proto &&
 		a.Ifid == b.Ifid &&
 		compareAlgo(a.Auth, b.Auth) &&


### PR DESCRIPTION
Simply picked up the original work from https://github.com/vishvananda/netlink/pull/1148 and rebased on top of master with some adjustments. @ShimmerGlass original commit authorship is preserved in git history.

Fixes #1114 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Platform-wide migration to a modern IP/address representation for consistent prefix and address handling and clearer IPv4/IPv6 semantics.

* **Bug Fixes**
  * Stricter validation and explicit errors for malformed addresses from system attributes; more reliable broadcast/gateway handling.

* **Refactor**
  * Public APIs and types moved to value-based address/prefix semantics, simplifying presence checks, comparisons, and serialization.

* **Tests**
  * Test suite updated to use the new address primitives and direct value comparisons; added regression coverage for mapped/next-hop scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->