### PR TITLE
Enhance route type filter around RTA_DST address

### DIFF
--- a/route_linux.go
+++ b/route_linux.go
@@ -929,7 +929,11 @@ func (h *Handle) prepareRouteReq(route *Route, req *nl.NetlinkRequest, msg *nl.R
 		} else {
 			dstData = route.Dst.IP.To16()
 		}
-		rtAttrs = append(rtAttrs, nl.NewRtAttr(unix.RTA_DST, dstData))
+		if route.Type != unix.RTN_UNREACHABLE &&
+			route.Type != unix.RTN_BLACKHOLE &&
+			route.Type != unix.RTN_PROHIBIT {
+			rtAttrs = append(rtAttrs, nl.NewRtAttr(unix.RTA_DST, dstData))
+		}
 	} else if route.MPLSDst != nil {
 		family = nl.FAMILY_MPLS
 		msg.Dst_len = uint8(20)


### PR DESCRIPTION
# Problem 
Currently, destination IP address (RTA_DST, default value 0x1) is always appended & sent to the kernel. This doesn't make sense if the route type are amongst 'unreachable', 'blackhole', 'prohibit' where the request is dropped (no destination required).

This patch aims to fix that by adding route type filter before appending the destination IP address. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed route handling on Linux systems for unreachable, blackhole, and prohibited route types to ensure correct attribute assignment and improved routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->