### PR TITLE
fix: route serializing nil IP address

### DIFF
--- a/route_linux.go
+++ b/route_linux.go
@@ -929,7 +929,12 @@ func (h *Handle) prepareRouteReq(route *Route, req *nl.NetlinkRequest, msg *nl.R
 		} else {
 			dstData = route.Dst.IP.To16()
 		}
-		rtAttrs = append(rtAttrs, nl.NewRtAttr(unix.RTA_DST, dstData))
+		shouldSkipDst := (route.Type == unix.RTN_UNREACHABLE ||
+			route.Type == unix.RTN_BLACKHOLE ||
+			route.Type == unix.RTN_PROHIBIT) && (dstLen == 0)
+		if !shouldSkipDst {
+			rtAttrs = append(rtAttrs, nl.NewRtAttr(unix.RTA_DST, dstData))
+		}
 	} else if route.MPLSDst != nil {
 		family = nl.FAMILY_MPLS
 		msg.Dst_len = uint8(20)

--- a/route_test.go
+++ b/route_test.go
@@ -152,6 +152,63 @@ func TestRouteAddDel(t *testing.T) {
 	}
 }
 
+func TestRouteUnreachableEmptyDst(t *testing.T) {
+	t.Cleanup(setUpNetlinkTest(t))
+
+	// Test adding unreachable/blackhole/prohibit routes with empty Dst.IP
+	// These route types don't need RTA_DST to be serialized
+	testCases := []struct {
+		name      string
+		routeType int
+	}{
+		{"unreachable", unix.RTN_UNREACHABLE},
+		{"blackhole", unix.RTN_BLACKHOLE},
+		{"prohibit", unix.RTN_PROHIBIT},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			route := &Route{
+				Table: 100,
+				Dst: &net.IPNet{
+					IP:   net.IP{},
+					Mask: net.IPMask{},
+				},
+				Priority: 100,
+				Type:     tc.routeType,
+				Scope:    unix.RT_SCOPE_UNIVERSE,
+				Family:   FAMILY_V4,
+			}
+
+			if err := RouteAdd(route); err != nil {
+				t.Fatalf("failed to add %s route with empty Dst.IP: %v", tc.name, err)
+			}
+
+			t.Cleanup(func() {
+				if err := RouteDel(route); err != nil {
+					t.Errorf("failed to delete route %s: %v", tc.name, err)
+				}
+			})
+
+			routes, err := RouteListFiltered(FAMILY_V4, &Route{Table: 100}, RT_FILTER_TABLE)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			found := false
+			for _, r := range routes {
+				if r.Type == tc.routeType {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("%s route not found after adding", tc.name)
+			}
+		})
+	}
+}
+
 func TestRoute6AddDel(t *testing.T) {
 	t.Cleanup(setUpNetlinkTest(t))
 


### PR DESCRIPTION
# Problem
Currently, destination IP address is always appended & sent to the kernel. This doesn't make sense if the route type are among 'unreachable', 'blackhole', 'prohibit' where the request is dropped (no destination required).

## Example problematic usage
```go
rt := &netlink.Route{
    Table: tableID,
    Dst: &net.IPNet{
	    IP:   net.IP{},
	    Mask: net.IPMask{},
    },
    Priority: math.MaxInt32,
    Type:     unix.RTN_UNREACHABLE,
    Scope:    unix.RT_SCOPE_UNIVERSE,
}

netlink.RouteAdd(rt)
```

which when run with `strace` shows that the constructed message is 48 byte long: 
```bash
sendto(4, [{nlmsg_len=48, nlmsg_type=RTM_NEWROUTE, nlmsg_flags=NLM_F_REQUEST|NLM_F_ACK|NLM_F_EXCL|NLM_F_CREATE, nlmsg_seq=13, nlmsg_pid=0}, {rtm_family=AF_INET, rtm_dst_len=0, rtm_src_len=0, rtm_tos=0, rtm_table=0x65, rtm_protocol=RTPROT_BOOT, rtm_scope=RT_SCOPE_UNIVERSE, rtm_type=RTN_UNREACHABLE, rtm_flags=0}, [{nla_len=4, nla_type=RTA_DST}, [{nla_len=8, nla_type=RTA_PRIORITY}, 2147483647], [{nla_len=8, nla_type=RTA_OIF}, 0]]], 48, 0, {sa_family=AF_NETLINK, nl_pid=0, nl_groups=00000000}, 12) = 48
```

and the kernel complains "numerical result out of range" 

# The fix 
This patch aims to fix that by adding route type filter before appending the destination IP address.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved Linux route request behavior for unreachable/blackhole/prohibit route types when the destination is unspecified, avoiding incorrect destination attributes and improving reliability.
* **Tests**
  * Added tests to exercise adding, listing, and deleting those route types with an empty destination to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->