### PR TITLE
devlink: add DevLinkGetPortList(bus, device string)

### DIFF
--- a/devlink_linux.go
+++ b/devlink_linux.go
@@ -587,6 +587,35 @@ func DevLinkGetAllPortList() ([]*DevlinkPort, error) {
 	return pkgHandle.DevLinkGetAllPortList()
 }
 
+// DevLinkGetPortList returns the devlink ports for the device identified by
+// bus and device (e.g. "pci", "0000:0c:00.0").  Unlike DevLinkGetAllPortList,
+// the kernel filters the dump to the target device, making this efficient on
+// systems with many SR-IOV VFs.
+// If the returned error is [ErrDumpInterrupted], results may be inconsistent
+// or incomplete.
+func (h *Handle) DevLinkGetPortList(bus, device string) ([]*DevlinkPort, error) {
+	_, req, err := h.createCmdReq(nl.DEVLINK_CMD_PORT_GET, bus, device)
+	if err != nil {
+		return nil, err
+	}
+	req.Flags |= unix.NLM_F_DUMP
+	msgs, executeErr := req.Execute(unix.NETLINK_GENERIC, 0)
+	if executeErr != nil && !errors.Is(executeErr, ErrDumpInterrupted) {
+		return nil, executeErr
+	}
+	ports, err := parseDevLinkAllPortList(msgs)
+	if err != nil {
+		return nil, err
+	}
+	return ports, executeErr
+}
+
+// DevLinkGetPortList returns the devlink ports for the device identified by
+// bus and device (e.g. "pci", "0000:0c:00.0").
+func DevLinkGetPortList(bus, device string) ([]*DevlinkPort, error) {
+	return pkgHandle.DevLinkGetPortList(bus, device)
+}
+
 func parseDevlinkPortMsg(msgs [][]byte) (*DevlinkPort, error) {
 	m := msgs[0]
 	attrs, err := nl.ParseRouteAttr(m[nl.SizeofGenlmsg:])

--- a/devlink_test.go
+++ b/devlink_test.go
@@ -112,6 +112,24 @@ func TestDevLinkGetAllPortList(t *testing.T) {
 	}
 }
 
+func TestDevLinkGetPortList(t *testing.T) {
+	minKernelRequired(t, 5, 4)
+	if bus == "" || device == "" {
+		t.Log("devlink bus and device are empty, skipping test")
+		t.SkipNow()
+	}
+
+	ports, err := DevLinkGetPortList(bus, device)
+	assert.NoError(t, err)
+
+	t.Log("devlink port count = ", len(ports))
+	for _, port := range ports {
+		assert.Equal(t, bus, port.BusName, "unexpected bus name in port")
+		assert.Equal(t, device, port.DeviceName, "unexpected device name in port")
+		logPort(t, port)
+	}
+}
+
 func TestDevLinkAddDelSfPort(t *testing.T) {
 	var addAttrs DevLinkPortAddAttrs
 	minKernelRequired(t, 5, 13)


### PR DESCRIPTION
DevLinkGetAllPortList issues an unfiltered DEVLINK_CMD_PORT_GET dump that returns every port on the system.  When DEVLINK_ATTR_BUS_NAME and DEVLINK_ATTR_DEV_NAME are included in the dump request the kernel restricts the reply to the named device, which is what `devlink port show pci/0000:0c:00.0` does on the CLI.

Add DevLinkGetPortList (and the Handle method counterpart) that reuses createCmdReq + NLM_F_DUMP to issue this device-scoped dump, following the same conventions as DevLinkGetAllPortList and DevlinkGetDeviceParams. Add a corresponding test mirroring TestDevLinkGetAllPortList.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new public API to retrieve and list all devlink ports associated with a specified bus and device pair combination.

* **Tests**
  * Introduced test coverage for the devlink port retrieval API, validating port enumeration accuracy, attribute verification against requested identifiers, and minimum kernel version requirement enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->