### PR TITLE
conntrack: handle flow Status

### DIFF
--- a/conntrack_linux.go
+++ b/conntrack_linux.go
@@ -251,6 +251,7 @@ type ProtoInfoTCP struct {
 
 // Protocol returns "tcp".
 func (*ProtoInfoTCP) Protocol() string { return "tcp" }
+
 func (p *ProtoInfoTCP) toNlData() ([]*nl.RtAttr, error) {
 	ctProtoInfo := nl.NewRtAttr(unix.NLA_F_NESTED|nl.CTA_PROTOINFO, []byte{})
 	ctProtoInfoTCP := nl.NewRtAttr(unix.NLA_F_NESTED|nl.CTA_PROTOINFO_TCP, []byte{})
@@ -289,7 +290,6 @@ type IPTuple struct {
 // toNlData generates the inner fields of a nested tuple netlink datastructure
 // does not generate the "nested"-flagged outer message.
 func (t *IPTuple) toNlData(family uint8) ([]*nl.RtAttr, error) {
-
 	var srcIPsFlag, dstIPsFlag int
 	if family == nl.FAMILY_V4 {
 		srcIPsFlag = nl.CTA_IP_V4_SRC
@@ -318,6 +318,25 @@ func (t *IPTuple) toNlData(family uint8) ([]*nl.RtAttr, error) {
 	return []*nl.RtAttr{ctTupleIP, ctTupleProto}, nil
 }
 
+const (
+	ConntrackStatusExpected = 1 << iota
+	ConntrackStatusSeenReply
+	ConntrackStatusAssured
+	ConntrackStatusConfirmed
+	ConntrackStatusSrcNAT
+	ConntrackStatusDstNAT
+	ConntrackStatusSeqAdj
+	ConntrackStatusSrcNATDone
+	ConntrackStatusDstNATDone
+	ConntrackStatusDying
+	ConntrackStatusFixedTimeout
+	ConntrackStatusTemplate
+	ConntrackStatusNATClash
+	ConntrackStatusHelper
+	ConntrackStatusOffload
+	ConntrackStatusHWOffload
+)
+
 type ConntrackFlow struct {
 	FamilyType uint8
 	Forward    IPTuple
@@ -327,8 +346,23 @@ type ConntrackFlow struct {
 	TimeStart  uint64
 	TimeStop   uint64
 	TimeOut    uint32
+	Status     uint32
 	Labels     []byte
 	ProtoInfo  ProtoInfo
+}
+
+func (s *ConntrackFlow) statusStrings() (orig, repl string) {
+	if s.Status&ConntrackStatusSeenReply == 0 {
+		orig = "[UNREPLIED] "
+	}
+	if s.Status&ConntrackStatusHWOffload != 0 {
+		repl = "[HW_OFFLOAD] "
+	} else if s.Status&ConntrackStatusOffload != 0 {
+		repl = "[OFFLOAD] "
+	} else if s.Status&ConntrackStatusAssured != 0 {
+		repl = "[ASSURED] "
+	}
+	return
 }
 
 func (s *ConntrackFlow) String() string {
@@ -338,10 +372,13 @@ func (s *ConntrackFlow) String() string {
 	start := time.Unix(0, int64(s.TimeStart))
 	stop := time.Unix(0, int64(s.TimeStop))
 	timeout := int32(s.TimeOut)
-	res := fmt.Sprintf("%s\t%d src=%s dst=%s sport=%d dport=%d packets=%d bytes=%d\tsrc=%s dst=%s sport=%d dport=%d packets=%d bytes=%d mark=0x%x ",
+	status1, status2 := s.statusStrings()
+	res := fmt.Sprintf("%s\t%d src=%s dst=%s sport=%d dport=%d packets=%d bytes=%d %ssrc=%s dst=%s sport=%d dport=%d packets=%d bytes=%d %smark=0x%x ",
 		nl.L4ProtoMap[s.Forward.Protocol], s.Forward.Protocol,
 		s.Forward.SrcIP.String(), s.Forward.DstIP.String(), s.Forward.SrcPort, s.Forward.DstPort, s.Forward.Packets, s.Forward.Bytes,
+		status1,
 		s.Reverse.SrcIP.String(), s.Reverse.DstIP.String(), s.Reverse.SrcPort, s.Reverse.DstPort, s.Reverse.Packets, s.Reverse.Bytes,
+		status2,
 		s.Mark)
 	if len(s.Labels) > 0 {
 		res += fmt.Sprintf("labels=0x%x ", s.Labels)
@@ -417,8 +454,14 @@ func (s *ConntrackFlow) toNlData() ([]*nl.RtAttr, error) {
 
 	ctMark := nl.NewRtAttr(nl.CTA_MARK, nl.BEUint32Attr(s.Mark))
 	ctTimeout := nl.NewRtAttr(nl.CTA_TIMEOUT, nl.BEUint32Attr(s.TimeOut))
-
 	payload = append(payload, ctTupleOrig, ctTupleReply, ctMark, ctTimeout)
+
+	// Set status if any bits have been set.
+	if s.Status != 0 {
+		ctStatus := nl.NewRtAttr(nl.CTA_STATUS, nl.BEUint32Attr(s.Status))
+		payload = append(payload, ctStatus)
+	}
+
 	// Labels: nil => do not send; 16 zero bytes => clear all labels.
 	if s.Labels != nil {
 		if len(s.Labels) != 16 {
@@ -585,7 +628,6 @@ func parseTimeStamp(r *bytes.Reader, readSize uint16) (tstart, tstop uint64) {
 		}
 	}
 	return
-
 }
 
 func parseProtoInfoTCPState(r *bytes.Reader) (s uint8) {
@@ -644,6 +686,11 @@ func parseProtoInfo(r *bytes.Reader, attrLen uint16) (p ProtoInfo) {
 
 func parseTimeOut(r *bytes.Reader) (ttimeout uint32) {
 	parseBERaw32(r, &ttimeout)
+	return
+}
+
+func parseConntrackStatus(r *bytes.Reader) (status uint32) {
+	parseBERaw32(r, &status)
 	return
 }
 
@@ -713,7 +760,9 @@ func parseRawData(data []byte) *ConntrackFlow {
 				s.Labels = parseConnectionLabels(reader)
 			case nl.CTA_TIMEOUT:
 				s.TimeOut = parseTimeOut(reader)
-			case nl.CTA_ID, nl.CTA_STATUS, nl.CTA_USE:
+			case nl.CTA_STATUS:
+				s.Status = parseConntrackStatus(reader)
+			case nl.CTA_ID, nl.CTA_USE:
 				skipNfAttrValue(reader, l)
 			case nl.CTA_ZONE:
 				s.Zone = parseConnectionZone(reader)
@@ -770,6 +819,8 @@ const (
 	ConntrackOrigDstPort                         // --orig-port-dst port    Destination port in original direction
 	ConntrackMatchLabels                         // --label label1,label2   Labels used in entry
 	ConntrackUnmatchLabels                       // --label label1,label2   Labels not used in entry
+	ConntrackMatchStatus                         // --status status         Status bits set on entry
+	ConntrackUnmatchStatus                       // --status status         Status bits not set on entry
 	ConntrackNatSrcIP      = ConntrackReplySrcIP // deprecated use instead ConntrackReplySrcIP
 	ConntrackNatDstIP      = ConntrackReplyDstIP // deprecated use instead ConntrackReplyDstIP
 	ConntrackNatAnyIP      = ConntrackReplyAnyIP // deprecated use instead ConntrackReplyAnyIP
@@ -782,11 +833,13 @@ type CustomConntrackFilter interface {
 }
 
 type ConntrackFilter struct {
-	ipNetFilter map[ConntrackFilterType]*net.IPNet
-	portFilter  map[ConntrackFilterType]uint16
-	protoFilter uint8
-	labelFilter map[ConntrackFilterType][][]byte
-	zoneFilter  *uint16
+	ipNetFilter    map[ConntrackFilterType]*net.IPNet
+	portFilter     map[ConntrackFilterType]uint16
+	protoFilter    uint8
+	statusFilter   uint32
+	statusUnFilter uint32
+	labelFilter    map[ConntrackFilterType][][]byte
+	zoneFilter     *uint16
 }
 
 // AddIPNet adds a IP subnet to the conntrack filter
@@ -840,6 +893,21 @@ func (f *ConntrackFilter) AddProtocol(proto uint8) error {
 	return nil
 }
 
+// AddStatus adds the provided status flags to the conntrack filter. If tp is ConntrackMatchStatus, only flows with all
+// the provided status flags will match. If tp is ConntrackUnmatchStatus, only flows without any of the provided status
+// flags will match.
+func (f *ConntrackFilter) AddStatus(tp ConntrackFilterType, status uint32) error {
+	switch tp {
+	case ConntrackMatchStatus:
+		f.statusFilter |= status
+	case ConntrackUnmatchStatus:
+		f.statusUnFilter |= status
+	default:
+		return errors.New("Invalid filter type")
+	}
+	return nil
+}
+
 // AddLabels adds the provided list (zero or more) of labels to the conntrack filter
 // ConntrackFilterType here can be either:
 //  1. ConntrackMatchLabels: This matches every flow that has a label value (len(flow.Labels) > 0)
@@ -876,7 +944,13 @@ func (f *ConntrackFilter) AddZone(zone uint16) error {
 // MatchConntrackFlow applies the filter to the flow and returns true if the flow matches the filter
 // false otherwise
 func (f *ConntrackFilter) MatchConntrackFlow(flow *ConntrackFlow) bool {
-	if len(f.ipNetFilter) == 0 && len(f.portFilter) == 0 && f.protoFilter == 0 && len(f.labelFilter) == 0 && f.zoneFilter == nil {
+	if len(f.ipNetFilter) == 0 &&
+		len(f.portFilter) == 0 &&
+		f.protoFilter == 0 &&
+		f.statusFilter == 0 &&
+		f.statusUnFilter == 0 &&
+		len(f.labelFilter) == 0 &&
+		f.zoneFilter == nil {
 		// empty filter always not match
 		return false
 	}
@@ -889,6 +963,14 @@ func (f *ConntrackFilter) MatchConntrackFlow(flow *ConntrackFlow) bool {
 
 	// Conntrack zone filter
 	if f.zoneFilter != nil && *f.zoneFilter != flow.Zone {
+		return false
+	}
+
+	if f.statusFilter != 0 && flow.Status&f.statusFilter != f.statusFilter {
+		return false
+	}
+
+	if f.statusUnFilter != 0 && flow.Status&f.statusUnFilter != 0 {
 		return false
 	}
 

--- a/conntrack_linux.go
+++ b/conntrack_linux.go
@@ -351,18 +351,24 @@ type ConntrackFlow struct {
 	ProtoInfo  ProtoInfo
 }
 
-func (s *ConntrackFlow) statusStrings() (orig, repl string) {
+func (s *ConntrackFlow) statusStrings() (s1, s2 string) {
 	if s.Status&ConntrackStatusSeenReply == 0 {
-		orig = "[UNREPLIED] "
+		s1 = "[UNREPLIED] "
 	}
-	if s.Status&ConntrackStatusHWOffload != 0 {
-		repl = "[HW_OFFLOAD] "
-	} else if s.Status&ConntrackStatusOffload != 0 {
-		repl = "[OFFLOAD] "
-	} else if s.Status&ConntrackStatusAssured != 0 {
-		repl = "[ASSURED] "
+
+	var annotation string
+	switch {
+	case s.Status&ConntrackStatusHWOffload != 0:
+		annotation = ", HW_OFFLOAD"
+	case s.Status&ConntrackStatusOffload != 0:
+		annotation = ", OFFLOAD"
+	case s.Status&ConntrackStatusAssured != 0:
+		annotation = ", ASSURED"
 	}
-	return
+
+	s2 = fmt.Sprintf("[status=%#b%s] ", s.Status, annotation)
+
+	return s1, s2
 }
 
 func (s *ConntrackFlow) String() string {

--- a/conntrack_test.go
+++ b/conntrack_test.go
@@ -24,6 +24,7 @@ func CheckErrorFail(t *testing.T, err error) {
 		t.Fatalf("Fatal Error: %s", err)
 	}
 }
+
 func CheckError(t *testing.T, err error) {
 	if err != nil {
 		t.Errorf("Error: %s", err)
@@ -149,12 +150,21 @@ func nsCreateAndEnter(t *testing.T) (*netns.NsHandle, *netns.NsHandle, *Handle) 
 	return &origns, &ns, h
 }
 
-func applyFilter(flowList []ConntrackFlow, ipv4Filter *ConntrackFilter, ipv6Filter *ConntrackFilter) (ipv4Match, ipv6Match uint) {
+func applyFilter(flowList []ConntrackFlow, filter *ConntrackFilter) (matches uint) {
 	for _, flow := range flowList {
-		if ipv4Filter.MatchConntrackFlow(&flow) == true {
+		if filter.MatchConntrackFlow(&flow) {
+			matches++
+		}
+	}
+	return matches
+}
+
+func applyFilterv4v6(flowList []ConntrackFlow, ipv4Filter *ConntrackFilter, ipv6Filter *ConntrackFilter) (ipv4Match, ipv6Match uint) {
+	for _, flow := range flowList {
+		if ipv4Filter.MatchConntrackFlow(&flow) {
 			ipv4Match++
 		}
-		if ipv6Filter.MatchConntrackFlow(&flow) == true {
+		if ipv6Filter.MatchConntrackFlow(&flow) {
 			ipv6Match++
 		}
 	}
@@ -451,6 +461,8 @@ func TestConntrackFilter(t *testing.T) {
 				DstPort:  5000,
 				Protocol: 6,
 			},
+			Status: ConntrackStatusSrcNATDone | ConntrackStatusConfirmed |
+				ConntrackStatusAssured | ConntrackStatusSeenReply,
 			Labels: []byte{0, 0, 0, 0, 3, 4, 61, 141, 207, 170, 2, 0, 0, 0, 0, 0},
 			Zone:   200,
 		},
@@ -474,7 +486,7 @@ func TestConntrackFilter(t *testing.T) {
 		})
 
 	// Empty filter
-	v4Match, v6Match := applyFilter(flowList, &ConntrackFilter{}, &ConntrackFilter{})
+	v4Match, v6Match := applyFilterv4v6(flowList, &ConntrackFilter{}, &ConntrackFilter{})
 	if v4Match > 0 || v6Match > 0 {
 		t.Fatalf("Error, empty filter cannot match, v4:%d, v6:%d", v4Match, v6Match)
 	}
@@ -518,6 +530,28 @@ func TestConntrackFilter(t *testing.T) {
 		t.Fatalf("Error, it should fail adding a port filter with a wrong protocol")
 	}
 
+	// Status filter
+	filterStatus := &ConntrackFilter{}
+	err = filterStatus.AddStatus(ConntrackMatchStatus, ConntrackStatusAssured)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	matches := applyFilter(flowList, filterStatus)
+	if matches != 1 {
+		t.Fatalf("Error, there should be 1 match, got: %d", matches)
+	}
+
+	// Anti-status filter
+	filterStatus = &ConntrackFilter{}
+	err = filterStatus.AddStatus(ConntrackUnmatchStatus, ConntrackStatusAssured)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	matches = applyFilter(flowList, filterStatus)
+	if matches != 2 {
+		t.Fatalf("Error, there should be 2 match, got: %d", matches)
+	}
+
 	// Proto filter
 	filterV4 := &ConntrackFilter{}
 	err = filterV4.AddProtocol(6)
@@ -531,7 +565,7 @@ func TestConntrackFilter(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	v4Match, v6Match = applyFilter(flowList, filterV4, filterV6)
+	v4Match, v6Match = applyFilterv4v6(flowList, filterV4, filterV6)
 	if v4Match != 1 || v6Match != 1 {
 		t.Fatalf("Error, there should be only 1 match for TCP:%d, UDP:%d", v4Match, v6Match)
 	}
@@ -549,7 +583,7 @@ func TestConntrackFilter(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	v4Match, v6Match = applyFilter(flowList, filterV4, filterV6)
+	v4Match, v6Match = applyFilterv4v6(flowList, filterV4, filterV6)
 	if v4Match != 1 || v6Match != 1 {
 		t.Fatalf("Error, there should be only 1 match, v4:%d, v6:%d", v4Match, v6Match)
 	}
@@ -567,7 +601,7 @@ func TestConntrackFilter(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	v4Match, v6Match = applyFilter(flowList, filterV4, filterV6)
+	v4Match, v6Match = applyFilterv4v6(flowList, filterV4, filterV6)
 	if v4Match != 1 || v6Match != 1 {
 		t.Fatalf("Error, there should be only 1 match, v4:%d, v6:%d", v4Match, v6Match)
 	}
@@ -585,7 +619,7 @@ func TestConntrackFilter(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	v4Match, v6Match = applyFilter(flowList, filterV4, filterV6)
+	v4Match, v6Match = applyFilterv4v6(flowList, filterV4, filterV6)
 	if v4Match != 1 || v6Match != 1 {
 		t.Fatalf("Error, there should be only 1 match, v4:%d, v6:%d", v4Match, v6Match)
 	}
@@ -603,7 +637,7 @@ func TestConntrackFilter(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	v4Match, v6Match = applyFilter(flowList, filterV4, filterV6)
+	v4Match, v6Match = applyFilterv4v6(flowList, filterV4, filterV6)
 	if v4Match != 2 || v6Match != 0 {
 		t.Fatalf("Error, there should be an exact match, v4:%d, v6:%d", v4Match, v6Match)
 	}
@@ -621,7 +655,7 @@ func TestConntrackFilter(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	v4Match, v6Match = applyFilter(flowList, filterV4, filterV6)
+	v4Match, v6Match = applyFilterv4v6(flowList, filterV4, filterV6)
 	if v4Match != 2 || v6Match != 1 {
 		t.Fatalf("Error, there should be an exact match, v4:%d, v6:%d", v4Match, v6Match)
 	}
@@ -647,7 +681,7 @@ func TestConntrackFilter(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	v4Match, v6Match = applyFilter(flowList, filterV4, filterV6)
+	v4Match, v6Match = applyFilterv4v6(flowList, filterV4, filterV6)
 	if v4Match != 2 || v6Match != 1 {
 		t.Fatalf("Error, there should be only 1 match, v4:%d, v6:%d", v4Match, v6Match)
 	}
@@ -673,7 +707,7 @@ func TestConntrackFilter(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	v4Match, v6Match = applyFilter(flowList, filterV4, filterV6)
+	v4Match, v6Match = applyFilterv4v6(flowList, filterV4, filterV6)
 	if v4Match != 2 || v6Match != 1 {
 		t.Fatalf("Error, there should be only 1 match, v4:%d, v6:%d", v4Match, v6Match)
 	}
@@ -699,7 +733,7 @@ func TestConntrackFilter(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	v4Match, v6Match = applyFilter(flowList, filterV4, filterV6)
+	v4Match, v6Match = applyFilterv4v6(flowList, filterV4, filterV6)
 	if v4Match != 2 || v6Match != 1 {
 		t.Fatalf("Error, there should be only 1 match, v4:%d, v6:%d", v4Match, v6Match)
 	}
@@ -725,7 +759,7 @@ func TestConntrackFilter(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	v4Match, v6Match = applyFilter(flowList, filterV4, filterV6)
+	v4Match, v6Match = applyFilterv4v6(flowList, filterV4, filterV6)
 	if v4Match != 2 || v6Match != 0 {
 		t.Fatalf("Error, there should be an exact match, v4:%d, v6:%d", v4Match, v6Match)
 	}
@@ -751,7 +785,7 @@ func TestConntrackFilter(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	v4Match, v6Match = applyFilter(flowList, filterV4, filterV6)
+	v4Match, v6Match = applyFilterv4v6(flowList, filterV4, filterV6)
 	if v4Match != 2 || v6Match != 1 {
 		t.Fatalf("Error, there should be an exact match, v4:%d, v6:%d", v4Match, v6Match)
 	}
@@ -776,7 +810,7 @@ func TestConntrackFilter(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	v4Match, v6Match = applyFilter(flowList, filterV4, filterV6)
+	v4Match, v6Match = applyFilterv4v6(flowList, filterV4, filterV6)
 	if v4Match != 1 || v6Match != 1 {
 		t.Fatalf("Error, there should be only 1 match, v4:%d, v6:%d", v4Match, v6Match)
 	}
@@ -802,7 +836,7 @@ func TestConntrackFilter(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	v4Match, v6Match = applyFilter(flowList, filterV4, filterV6)
+	v4Match, v6Match = applyFilterv4v6(flowList, filterV4, filterV6)
 	if v4Match != 1 || v6Match != 1 {
 		t.Fatalf("Error, there should be only 1 match, v4:%d, v6:%d", v4Match, v6Match)
 	}
@@ -823,7 +857,7 @@ func TestConntrackFilter(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	v4Match, v6Match = applyFilter(flowList, filterV4, filterV6)
+	v4Match, v6Match = applyFilterv4v6(flowList, filterV4, filterV6)
 	if v4Match != 1 || v6Match != 0 {
 		t.Fatalf("Error, there should be only 1 match, v4:%d, v6:%d", v4Match, v6Match)
 	}
@@ -834,7 +868,7 @@ func TestConntrackFilter(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	filterV6 = &ConntrackFilter{}
-	v4Match, v6Match = applyFilter(flowList, filterV4, filterV6)
+	v4Match, v6Match = applyFilterv4v6(flowList, filterV4, filterV6)
 	if v4Match != 2 || v6Match != 0 {
 		t.Fatalf("Error, there should be only 1 match, v4:%d, v6:%d", v4Match, v6Match)
 	}
@@ -935,8 +969,9 @@ func TestParseRawData(t *testing.T) {
 				22, 134, 80, 142, 230, 127, 74, 166,
 				/* >> CTA_LABELS */
 				20, 0, 22, 0,
-				0, 0, 0, 0, 5, 0, 18, 172, 66, 2, 1, 0, 0, 0, 0, 0},
-			expConntrackFlow: "udp\t17 src=192.168.0.10 dst=192.168.0.3 sport=48385 dport=53 packets=1 bytes=55\t" +
+				0, 0, 0, 0, 5, 0, 18, 172, 66, 2, 1, 0, 0, 0, 0, 0,
+			},
+			expConntrackFlow: "udp\t17 src=192.168.0.10 dst=192.168.0.3 sport=48385 dport=53 packets=1 bytes=55 " +
 				"src=192.168.0.3 dst=192.168.0.10 sport=53 dport=48385 packets=1 bytes=71 mark=0x5 labels=0x00000000050012ac4202010000000000 " +
 				"start=2021-06-07 13:41:30.39632247 +0000 UTC stop=1970-01-01 00:00:00 +0000 UTC timeout=32(sec)",
 		},
@@ -1033,10 +1068,11 @@ func TestParseRawData(t *testing.T) {
 				16, 0, 20, 128,
 				/* >>>> CTA_TIMESTAMP_START */
 				12, 0, 1, 0,
-				22, 134, 80, 175, 134, 10, 182, 221},
-			expConntrackFlow: "tcp\t6 src=192.168.0.10 dst=192.168.77.73 sport=42625 dport=3333 packets=11 bytes=1914\t" +
-				"src=192.168.77.73 dst=192.168.0.10 sport=3333 dport=42625 packets=10 bytes=1858 mark=0x5 zone=100 " +
-				"start=2021-06-07 13:43:50.511990493 +0000 UTC stop=1970-01-01 00:00:00 +0000 UTC timeout=152(sec)",
+				22, 134, 80, 175, 134, 10, 182, 221,
+			},
+			expConntrackFlow: "tcp\t6 src=192.168.0.10 dst=192.168.77.73 sport=42625 dport=3333 packets=11 bytes=1914 " +
+				"src=192.168.77.73 dst=192.168.0.10 sport=3333 dport=42625 packets=10 bytes=1858 [ASSURED] " +
+				"mark=0x5 zone=100 start=2021-06-07 13:43:50.511990493 +0000 UTC stop=1970-01-01 00:00:00 +0000 UTC timeout=152(sec)",
 		},
 	}
 
@@ -1100,6 +1136,7 @@ func TestConntrackUpdateV4(t *testing.T) {
 		// No point checking equivalence of timeout, but value must
 		// be reasonable to allow for a potentially slow subsequent read.
 		TimeOut: 100,
+		Status:  ConntrackStatusConfirmed,
 		Mark:    12,
 		ProtoInfo: &ProtoInfoTCP{
 			State: nl.TCP_CONNTRACK_SYN_SENT2,
@@ -1152,13 +1189,14 @@ func TestConntrackUpdateV4(t *testing.T) {
 	checkProtoInfosEqual(t, flow.ProtoInfo, match.ProtoInfo)
 
 	// Change the conntrack and update the kernel entry.
+	flow.Status |= ConntrackStatusAssured | ConntrackStatusSeenReply
 	flow.Mark = 10
 	flow.ProtoInfo = &ProtoInfoTCP{
 		State: nl.TCP_CONNTRACK_ESTABLISHED,
 	}
 	err = h.ConntrackUpdate(ConntrackTable, nl.FAMILY_V4, &flow)
 	if err != nil {
-		t.Fatalf("failed to update conntrack with new mark: %s", err)
+		t.Fatalf("failed to update conntrack with new mark and status: %s", err)
 	}
 
 	// Look for updated conntrack.
@@ -1233,6 +1271,7 @@ func TestConntrackUpdateV6(t *testing.T) {
 		// No point checking equivalence of timeout, but value must
 		// be reasonable to allow for a potentially slow subsequent read.
 		TimeOut: 100,
+		Status:  ConntrackStatusConfirmed,
 		Mark:    12,
 		ProtoInfo: &ProtoInfoTCP{
 			State: nl.TCP_CONNTRACK_SYN_SENT2,
@@ -1285,6 +1324,7 @@ func TestConntrackUpdateV6(t *testing.T) {
 	checkProtoInfosEqual(t, flow.ProtoInfo, match.ProtoInfo)
 
 	// Change the conntrack and update the kernel entry.
+	flow.Status |= ConntrackStatusAssured | ConntrackStatusSeenReply
 	flow.Mark = 10
 	flow.ProtoInfo = &ProtoInfoTCP{
 		State: nl.TCP_CONNTRACK_ESTABLISHED,
@@ -1364,6 +1404,7 @@ func TestConntrackCreateV4(t *testing.T) {
 		// No point checking equivalence of timeout, but value must
 		// be reasonable to allow for a potentially slow subsequent read.
 		TimeOut: 100,
+		Status:  ConntrackStatusConfirmed,
 		Mark:    12,
 		ProtoInfo: &ProtoInfoTCP{
 			State: nl.TCP_CONNTRACK_ESTABLISHED,
@@ -1768,6 +1809,7 @@ func TestConntrackLabels(t *testing.T) {
 		// No point checking equivalence of timeout, but value must
 		// be reasonable to allow for a potentially slow subsequent read.
 		TimeOut: 100,
+		Status:  ConntrackStatusConfirmed,
 		Mark:    12,
 		Labels:  []byte{0, 0, 0, 0, 3, 4, 61, 141, 207, 170, 2, 0, 0, 0, 0, 0},
 		ProtoInfo: &ProtoInfoTCP{
@@ -1879,6 +1921,7 @@ func TestConntrackFlowToNlData(t *testing.T) {
 			Protocol: unix.IPPROTO_TCP,
 		},
 		Mark:    5,
+		Status:  ConntrackStatusConfirmed | ConntrackStatusAssured | ConntrackStatusSeenReply,
 		Labels:  []byte{0, 0, 0, 0, 3, 4, 61, 141, 207, 170, 2, 0, 0, 0, 0, 0},
 		TimeOut: 10,
 		ProtoInfo: &ProtoInfoTCP{
@@ -1902,6 +1945,7 @@ func TestConntrackFlowToNlData(t *testing.T) {
 			Protocol: unix.IPPROTO_TCP,
 		},
 		Mark:    5,
+		Status:  ConntrackStatusConfirmed | ConntrackStatusAssured | ConntrackStatusSeenReply,
 		Labels:  []byte{0, 0, 0, 0, 3, 4, 61, 141, 207, 170, 2, 0, 0, 0, 0, 0},
 		TimeOut: 10,
 		ProtoInfo: &ProtoInfoTCP{
@@ -1941,10 +1985,16 @@ func TestConntrackFlowToNlData(t *testing.T) {
 }
 
 func checkFlowsEqual(t *testing.T, f1, f2 *ConntrackFlow) {
+	t.Helper()
+
 	// No point checking timeout as it will differ between reads.
 	// Timestart and timestop may also differ.
 	if f1.FamilyType != f2.FamilyType {
 		t.Logf("Conntrack flow FamilyTypes differ. Tuple1: %d, Tuple2: %d.\n", f1.FamilyType, f2.FamilyType)
+		t.Fail()
+	}
+	if f1.Status != f2.Status {
+		t.Logf("Conntrack flow Statuses differ. Tuple1: %#b, Tuple2: %#b.\n", f1.Status, f2.Status)
 		t.Fail()
 	}
 	if f1.Mark != f2.Mark {
@@ -1967,6 +2017,8 @@ func checkFlowsEqual(t *testing.T, f1, f2 *ConntrackFlow) {
 }
 
 func checkProtoInfosEqual(t *testing.T, p1, p2 ProtoInfo) {
+	t.Helper()
+
 	t.Logf("Checking protoinfo fields equal:\n\t p1: %+v\n\t p2: %+v", p1, p2)
 	if !protoInfosEqual(p1, p2) {
 		t.Logf("Protoinfo structs differ: P1: %+v, P2: %+v", p1, p2)

--- a/conntrack_test.go
+++ b/conntrack_test.go
@@ -972,7 +972,7 @@ func TestParseRawData(t *testing.T) {
 				0, 0, 0, 0, 5, 0, 18, 172, 66, 2, 1, 0, 0, 0, 0, 0,
 			},
 			expConntrackFlow: "udp\t17 src=192.168.0.10 dst=192.168.0.3 sport=48385 dport=53 packets=1 bytes=55 " +
-				"src=192.168.0.3 dst=192.168.0.10 sport=53 dport=48385 packets=1 bytes=71 mark=0x5 labels=0x00000000050012ac4202010000000000 " +
+				"src=192.168.0.3 dst=192.168.0.10 sport=53 dport=48385 packets=1 bytes=71 [status=0b110001010] mark=0x5 labels=0x00000000050012ac4202010000000000 " +
 				"start=2021-06-07 13:41:30.39632247 +0000 UTC stop=1970-01-01 00:00:00 +0000 UTC timeout=32(sec)",
 		},
 		{
@@ -1071,7 +1071,7 @@ func TestParseRawData(t *testing.T) {
 				22, 134, 80, 175, 134, 10, 182, 221,
 			},
 			expConntrackFlow: "tcp\t6 src=192.168.0.10 dst=192.168.77.73 sport=42625 dport=3333 packets=11 bytes=1914 " +
-				"src=192.168.77.73 dst=192.168.0.10 sport=3333 dport=42625 packets=10 bytes=1858 [ASSURED] " +
+				"src=192.168.77.73 dst=192.168.0.10 sport=3333 dport=42625 packets=10 bytes=1858 [status=0b110001110, ASSURED] " +
 				"mark=0x5 zone=100 start=2021-06-07 13:43:50.511990493 +0000 UTC stop=1970-01-01 00:00:00 +0000 UTC timeout=152(sec)",
 		},
 	}


### PR DESCRIPTION
Currently the Status field of conntrack flows is ignored. This change:

* adds constants for the bits of the status field
* parses the Status field when dumping flows
* handles Status values when creating or updating flows
* adds status strings to ConntrackFlow.String() to match the conntrack
  cli

with unit tests for all of the above.

The change to String() could cause backwards compatibility issues. Let me know if 
that's a problem and I can revert those bits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conntrack flows now include and display status markers (e.g., unreplied, assured, offload) in human-readable output.
  * Filtering can now match or exclude flows by status bits; a new API lets callers add status criteria to filters.

* **Tests**
  * Expanded test coverage for status handling, parsing/formatting, and filter matching to ensure correct behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->