### PR TITLE
fou: Don't set "FOU_ATTR_IPPROTO" if protocol is empty

### DIFF
--- a/fou_linux.go
+++ b/fou_linux.go
@@ -88,8 +88,16 @@ func (h *Handle) FouAdd(f Fou) error {
 		nl.NewRtAttr(FOU_ATTR_PORT, bp),
 		nl.NewRtAttr(FOU_ATTR_TYPE, []byte{uint8(f.EncapType)}),
 		nl.NewRtAttr(FOU_ATTR_AF, []byte{uint8(f.Family)}),
-		nl.NewRtAttr(FOU_ATTR_IPPROTO, []byte{uint8(f.Protocol)}),
 	}
+
+	// Only add FOU_ATTR_IPPROTO if a non-zero protocol is specified.
+	// This ensures compatibility with modern kernels since the fix
+	// for CVE-2026-23083.
+	if f.Protocol > 0 {
+		attrs = append(attrs,
+			nl.NewRtAttr(FOU_ATTR_IPPROTO, []byte{uint8(f.Protocol)}))
+	}
+
 	raw := []byte{FOU_CMD_ADD, 1, 0, 0}
 	for _, a := range attrs {
 		raw = append(raw, a.Serialize()...)

--- a/fou_test.go
+++ b/fou_test.go
@@ -130,3 +130,50 @@ func TestFouAddDel(t *testing.T) {
 		t.Fatalf("expected 0 fou, got %d", len(list))
 	}
 }
+
+// Repeat the Add/Delete test, but simulating the GUE case,
+// which doesn't explicitly specify a protocol.
+func TestFouAddDelGUE(t *testing.T) {
+	minKernelRequired(t, 3, 18)
+	t.Cleanup(setUpNetlinkTestWithKModule(t, "fou"))
+
+	fou := Fou{
+		Port:      5556,
+		Family:    FAMILY_V4,
+		EncapType: FOU_ENCAP_GUE,
+	}
+
+	if err := FouAdd(fou); err != nil {
+		t.Fatal(err)
+	}
+
+	list, err := FouList(FAMILY_V4)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(list) != 1 {
+		t.Fatalf("expected 1 fou, got %d", len(list))
+	}
+
+	if list[0].EncapType != FOU_ENCAP_GUE {
+		t.Errorf("expected encaptype %d, got %d", FOU_ENCAP_GUE, list[0].EncapType)
+	}
+
+	if list[0].Protocol != 0 {
+		t.Errorf("expected protocol 0, got %d", list[0].Protocol)
+	}
+
+	if err := FouDel(Fou{Port: fou.Port, Family: fou.Family}); err != nil {
+		t.Fatal(err)
+	}
+
+	list, err = FouList(FAMILY_V4)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(list) != 0 {
+		t.Fatalf("expected 0 fou, got %d", len(list))
+	}
+}


### PR DESCRIPTION
## Summary

The "fou" kernel module has recently been updated to no longer allow the `FOU_ATTR_IPPROTO` attribute to be set to a value less than 1 (see CVE-2026-23083).  This is not compatible with `(*netlink.Handle).FouAdd`, which indiscriminately adds the attribute even when it is unset on the input struct.  However, leaving the "protocol" unset is valid configuration for certain types of encapsulation (such as GUE). As a result, `(*netlink.Handle).FouAdd)` fails on very recent kernel versions with an error of the following form:

```
create fou port ({2 6081 0 2 <nil> <nil> 0 0}): numerical result out of range.
```

See a relevant commit to the linux kernel for the root cause: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=1cc98b8887cabb1808d2f4a37cd10a7be7574771

The fix for this is fairly straightforward: simply don't set `FOU_ATTR_IPPROTO` if a protocol is not defined. This is exactly what iproute2 does already (see [ipfou.c#L82](https://github.com/iproute2/iproute2/blob/main/ip/ipfou.c#L82) and [ipfou.c#L154](https://github.com/iproute2/iproute2/blob/main/ip/ipfou.c#L154)).

## Testing

* I tested this patched version with our real-world use-case, which fixed the issue on the v6.18.22 kernel.
* I added a new test which at least exercises the new code path, and ran this on a machine on the v6.18.22 kernel with the `fou` module loaded (to enable the test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed conditional inclusion of protocol attribute in FOU encapsulation requests when protocol value is unspecified.

* **Tests**
  * Added test coverage for GUE encapsulation add, list, and delete operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->