### PR TITLE
fix: GUE avoid set protocol

### DIFF
--- a/fou_linux.go
+++ b/fou_linux.go
@@ -73,11 +73,6 @@ func (h *Handle) FouAdd(f Fou) error {
 		return err
 	}
 
-	// setting ip protocol conflicts with encapsulation type GUE
-	if f.EncapType == FOU_ENCAP_GUE && f.Protocol != 0 {
-		return errors.New("GUE encapsulation doesn't specify an IP protocol")
-	}
-
 	req := h.newNetlinkRequest(fam_id, unix.NLM_F_ACK)
 
 	// int to byte for port
@@ -88,7 +83,10 @@ func (h *Handle) FouAdd(f Fou) error {
 		nl.NewRtAttr(FOU_ATTR_PORT, bp),
 		nl.NewRtAttr(FOU_ATTR_TYPE, []byte{uint8(f.EncapType)}),
 		nl.NewRtAttr(FOU_ATTR_AF, []byte{uint8(f.Family)}),
-		nl.NewRtAttr(FOU_ATTR_IPPROTO, []byte{uint8(f.Protocol)}),
+	}
+	// FOU_ATTR_IPPROTO must be omitted for GUE; kernels ≥ 6.x return ERANGE if present.
+	if f.EncapType != FOU_ENCAP_GUE {
+		attrs = append(attrs, nl.NewRtAttr(FOU_ATTR_IPPROTO, []byte{uint8(f.Protocol)}))
 	}
 	raw := []byte{FOU_CMD_ADD, 1, 0, 0}
 	for _, a := range attrs {

--- a/fou_test.go
+++ b/fou_test.go
@@ -130,3 +130,48 @@ func TestFouAddDel(t *testing.T) {
 		t.Fatalf("expected 0 fou, got %d", len(list))
 	}
 }
+
+func TestFouAddDelGUE(t *testing.T) {
+	minKernelRequired(t, 3, 18)
+	t.Cleanup(setUpNetlinkTestWithKModule(t, "fou"))
+
+	// GUE with Protocol=0 must succeed on all kernels (including ≥ 6.x which
+	// rejects FOU_ATTR_IPPROTO when encap type is GUE).
+	gue := Fou{
+		Port:      5556,
+		Family:    FAMILY_V4,
+		EncapType: FOU_ENCAP_GUE,
+	}
+	if err := FouAdd(gue); err != nil {
+		t.Fatalf("FouAdd GUE: %v", err)
+	}
+
+	list, err := FouList(FAMILY_V4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected 1 fou entry, got %d", len(list))
+	}
+	if list[0].Port != gue.Port {
+		t.Errorf("expected port %d, got %d", gue.Port, list[0].Port)
+	}
+	if list[0].EncapType != FOU_ENCAP_GUE {
+		t.Errorf("expected encaptype GUE (%d), got %d", FOU_ENCAP_GUE, list[0].EncapType)
+	}
+	if list[0].Protocol != 0 {
+		t.Errorf("expected protocol 0 for GUE, got %d", list[0].Protocol)
+	}
+
+	if err := FouDel(Fou{Port: gue.Port, Family: gue.Family}); err != nil {
+		t.Fatalf("FouDel GUE: %v", err)
+	}
+
+	list, err = FouList(FAMILY_V4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 0 {
+		t.Fatalf("expected 0 fou entries after delete, got %d", len(list))
+	}
+}


### PR DESCRIPTION
## Problem

`FouAdd` unconditionally included `FOU_ATTR_IPPROTO` in the netlink message for every
encapsulation type. On Linux kernels ≥ 6.19, `fou_nl_cmd_add_port` rejects the presence
of `FOU_ATTR_IPPROTO` when `FOU_ATTR_TYPE=FOU_ENCAP_GUE`, returning `ERANGE`
("numerical result out of range").

The `ip` tool (iproute2) handles this correctly by omitting `FOU_ATTR_IPPROTO` for GUE.

### Reproducer (run as root on Linux ≥ 6.19)

```go
err := netlink.FouAdd(netlink.Fou{
    Port:      5555,
    Family:    unix.AF_INET,
    EncapType: netlink.FOU_ENCAP_GUE,
    // Protocol intentionally zero — correct for GUE
})
// Returns: "numerical result out of range" (ERANGE) on kernel ≥ 6.x
// Expected: nil
```

Verified on `6.19.13-orbstack`. The equivalent `ip` command succeeds:
```
ip fou add port 5555 gue
```

### Real-world impact

**kube-router** (`cloudnativelabs/kube-router`) uses `FOU_ENCAP_GUE` with no Protocol in
its `ensureFOUPort` function. On any modern kernel this call fails, causing BGP hold-timer
expiry loops because the network routes controller goroutine gets stuck on every route sync
cycle.

## Root cause

```go
// before — FOU_ATTR_IPPROTO always sent, even for GUE
attrs := []*nl.RtAttr{
    nl.NewRtAttr(FOU_ATTR_PORT, bp),
    nl.NewRtAttr(FOU_ATTR_TYPE, []byte{uint8(f.EncapType)}),
    nl.NewRtAttr(FOU_ATTR_AF, []byte{uint8(f.Family)}),
    nl.NewRtAttr(FOU_ATTR_IPPROTO, []byte{uint8(f.Protocol)}), // always sent
}
```

A client-side guard (`if GUE && Protocol != 0 → return error`) only blocked non-zero
Protocol values. It still let `Protocol=0` through to the kernel, which is enough to
trigger the rejection.

## Fix

Conditionally append `FOU_ATTR_IPPROTO` only for non-GUE (direct) encapsulation, and
remove the now-redundant client-side guard:

```go
attrs := []*nl.RtAttr{
    nl.NewRtAttr(FOU_ATTR_PORT, bp),
    nl.NewRtAttr(FOU_ATTR_TYPE, []byte{uint8(f.EncapType)}),
    nl.NewRtAttr(FOU_ATTR_AF, []byte{uint8(f.Family)}),
}
if f.EncapType != FOU_ENCAP_GUE {
    attrs = append(attrs, nl.NewRtAttr(FOU_ATTR_IPPROTO, []byte{uint8(f.Protocol)}))
}
```

## Tests

Added `TestFouAddDelGUE` in `fou_test.go`:
- Calls `FouAdd` with `EncapType=FOU_ENCAP_GUE`, `Protocol=0` — must succeed
- Verifies `FouList` returns the entry with the correct port, encap type, and protocol
- Cleans up with `FouDel` and verifies the list is empty


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GUE encapsulation handling to omit unnecessary attributes, fixing issues with certain protocol configurations.

* **Tests**
  * Added test coverage for GUE encapsulation behavior to ensure proper functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->