### PR TITLE
Fix spelling mistakes in netlink.go doc comment; capitalization tweaks

### DIFF
--- a/netlink.go
+++ b/netlink.go
@@ -1,11 +1,11 @@
 // Package netlink provides a simple library for netlink. Netlink is
-// the interface a user-space program in linux uses to communicate with
-// the kernel. It can be used to add and remove interfaces, set up ip
-// addresses and routes, and confiugre ipsec. Netlink communication
+// the interface a user-space program in Linux uses to communicate with
+// the kernel. It can be used to add and remove interfaces, set up IP
+// addresses and routes, and configure ipsec. Netlink communication
 // requires elevated privileges, so in most cases this code needs to
 // be run as root. The low level primitives for netlink are contained
 // in the nl subpackage. This package attempts to provide a high-level
-// interface that is loosly modeled on the iproute2 cli.
+// interface that is loosely modeled on the iproute2 CLI.
 package netlink
 
 import (


### PR DESCRIPTION
This fixes spelling mistakes in the package doc comment -- hopefully uncontroversial.

It also capitalizes Linux (a proper noun) and changes IP and CLI to all-caps, as they're acronyms. Happy to just put through the spelling fix if you prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated package-level documentation to correct capitalization, spelling, and phrasing for improved clarity and consistency.
  * Standardized technical terms and adjusted wording for better readability (examples: Linux, CLI, ipsec).
  * Confirmed no changes to runtime behavior, exported APIs, or public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->