### PR TITLE
nl: pool receive buffers before Go 1.26

### DIFF
--- a/nl/nl_linux.go
+++ b/nl/nl_linux.go
@@ -919,14 +919,7 @@ func (s *NetlinkSocket) Receive() ([]syscall.NetlinkMessage, *unix.SockaddrNetli
 	if err != nil {
 		return nil, nil, err
 	}
-	var (
-		deadline time.Time
-		fromAddr *unix.SockaddrNetlink
-		rb       [RECEIVE_BUFFER_SIZE]byte
-		nr       int
-		from     unix.Sockaddr
-		innerErr error
-	)
+	var deadline time.Time
 	receiveTimeout := atomic.LoadInt64(&s.receiveTimeout)
 	if receiveTimeout != 0 {
 		deadline = time.Now().Add(time.Duration(receiveTimeout))
@@ -934,13 +927,7 @@ func (s *NetlinkSocket) Receive() ([]syscall.NetlinkMessage, *unix.SockaddrNetli
 	if err := s.file.SetReadDeadline(deadline); err != nil {
 		return nil, nil, err
 	}
-	err = rawConn.Read(func(fd uintptr) (done bool) {
-		nr, from, innerErr = unix.Recvfrom(int(fd), rb[:], 0)
-		return innerErr != unix.EWOULDBLOCK
-	})
-	if innerErr != nil {
-		return nil, nil, innerErr
-	}
+	nl, from, err := receiveNetlinkMessages(rawConn)
 	if err != nil {
 		// The timeout was previously implemented using SO_RCVTIMEO on a blocking
 		// socket. So, continue to return EAGAIN when the timeout is reached.
@@ -953,17 +940,17 @@ func (s *NetlinkSocket) Receive() ([]syscall.NetlinkMessage, *unix.SockaddrNetli
 	if !ok {
 		return nil, nil, fmt.Errorf("Error converting to netlink sockaddr")
 	}
+	return nl, fromAddr, nil
+}
+
+func parseNetlinkMessage(rb []byte, nr int) ([]syscall.NetlinkMessage, error) {
 	if nr < unix.NLMSG_HDRLEN {
-		return nil, nil, fmt.Errorf("Got short response from netlink")
+		return nil, fmt.Errorf("Got short response from netlink")
 	}
 	msgLen := nlmAlignOf(nr)
 	rb2 := make([]byte, msgLen)
-	copy(rb2, rb[:msgLen])
-	nl, err := syscall.ParseNetlinkMessage(rb2)
-	if err != nil {
-		return nil, nil, err
-	}
-	return nl, fromAddr, nil
+	copy(rb2, rb[:nr])
+	return syscall.ParseNetlinkMessage(rb2)
 }
 
 // SetSendTimeout allows to set a send timeout on the socket

--- a/nl/nl_linux_test.go
+++ b/nl/nl_linux_test.go
@@ -63,6 +63,32 @@ func TestIfInfomsgDeserializeSerialize(t *testing.T) {
 	testDeserializeSerialize(t, orig, safemsg, msg)
 }
 
+func TestParseNetlinkMessageCopiesReceivedBytes(t *testing.T) {
+	const payloadLen = 3
+	nr := unix.NLMSG_HDRLEN + payloadLen
+	rb := make([]byte, RECEIVE_BUFFER_SIZE)
+	native := NativeEndian()
+	native.PutUint32(rb[0:4], uint32(nr))
+	native.PutUint16(rb[4:6], 0x10)
+	native.PutUint16(rb[6:8], 0)
+	native.PutUint32(rb[8:12], 1)
+	native.PutUint32(rb[12:16], 2)
+	copy(rb[unix.NLMSG_HDRLEN:nr], []byte{1, 2, 3})
+
+	msgs, err := parseNetlinkMessage(rb, nr)
+	if err != nil {
+		t.Fatalf("ParseNetlinkMessage failed: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("Expected 1 message, got %d", len(msgs))
+	}
+
+	copy(rb[unix.NLMSG_HDRLEN:nr], []byte{5, 6, 7})
+	if !bytes.Equal(msgs[0].Data, []byte{1, 2, 3}) {
+		t.Fatalf("Message data references receive buffer, got %v", msgs[0].Data)
+	}
+}
+
 func TestIfSocketCloses(t *testing.T) {
 	nlSock, err := Subscribe(unix.NETLINK_ROUTE, unix.RTNLGRP_NEIGH)
 	if err != nil {

--- a/nl/receive_linux_go126.go
+++ b/nl/receive_linux_go126.go
@@ -1,0 +1,30 @@
+//go:build linux && go1.26
+
+package nl
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func receiveNetlinkMessages(rawConn syscall.RawConn) ([]syscall.NetlinkMessage, unix.Sockaddr, error) {
+	var (
+		rb       [RECEIVE_BUFFER_SIZE]byte
+		nr       int
+		from     unix.Sockaddr
+		innerErr error
+	)
+	err := rawConn.Read(func(fd uintptr) (done bool) {
+		nr, from, innerErr = unix.Recvfrom(int(fd), rb[:], 0)
+		return innerErr != unix.EWOULDBLOCK
+	})
+	if innerErr != nil {
+		return nil, nil, innerErr
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+	nl, err := parseNetlinkMessage(rb[:], nr)
+	return nl, from, err
+}

--- a/nl/receive_linux_legacy.go
+++ b/nl/receive_linux_legacy.go
@@ -1,0 +1,41 @@
+//go:build linux && !go1.26
+
+package nl
+
+import (
+	"sync"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+var receiveBufferPool = sync.Pool{
+	New: func() any {
+		buf := make([]byte, RECEIVE_BUFFER_SIZE)
+		return &buf
+	},
+}
+
+func receiveNetlinkMessages(rawConn syscall.RawConn) ([]syscall.NetlinkMessage, unix.Sockaddr, error) {
+	bufp := receiveBufferPool.Get().(*[]byte)
+	rb := *bufp
+	defer receiveBufferPool.Put(bufp)
+
+	var (
+		nr       int
+		from     unix.Sockaddr
+		innerErr error
+	)
+	err := rawConn.Read(func(fd uintptr) (done bool) {
+		nr, from, innerErr = unix.Recvfrom(int(fd), rb, 0)
+		return innerErr != unix.EWOULDBLOCK
+	})
+	if innerErr != nil {
+		return nil, nil, innerErr
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+	nl, err := parseNetlinkMessage(rb, nr)
+	return nl, from, err
+}


### PR DESCRIPTION
**Motivation**

fix excessive allocations in NetlinkSocket.Receive when building with Go versions before 1.26.

**Description**
Before Go 1.26, the receive buffer used by Receive may escape and be heap allocated on every receive call. Under high-frequency netlink receive workloads, such as kube-proxy/IPVS sync loops, this can cause significant allocation pressure and GC overhead.

To avoid this for pre-Go 1.26 builds, this PR uses a `sync.Pool` to reuse large receive buffers.

For Go 1.26 and newer, Receive keeps using a local stack buffer, since the newer compiler can handle this case without the same allocation issue.  https://go.dev/doc/go1.26#compiler

The build tags are split as follows:
- go1.26: use the local receive buffer implementation.
- !go1.26: use the a `sync.Pool` to reuse large receive buffers.

**Compatibility**

Go 1.26 and newer keep the existing per-call local buffer behavior.
Go 1.25 and older use a `sync.Pool` to reuse large receive buffers.
Future Go versions, such as Go 1.27, will continue to match the go1.26 build tag and use the Go 1.26+ implementation.
