### PR TITLE
fix: zero the genlmsghdr reserved field in Genlmsg

### DIFF
--- a/nl/genetlink_linux.go
+++ b/nl/genetlink_linux.go
@@ -72,8 +72,9 @@ const (
 )
 
 type Genlmsg struct {
-	Command uint8
-	Version uint8
+	Command  uint8
+	Version  uint8
+	Reserved uint16
 }
 
 func (msg *Genlmsg) Len() int {


### PR DESCRIPTION
The kernel struct is defined as follows:

```
	struct genlmsghdr {
                __u8    cmd;
                __u8    version;
                __u16   reserved;
        };
```

Genlmsg declared only Command and Version (2 bytes), but SizeofGenlmsg is 4 and Serialize() unsafe-casts the struct to [4]byte. The extra two bytes contained arbitrary contents read from adjacent memory and emitted as the genlmsghdr reserved field.

The kernel's genl_header_check() conditionally rejects a non-zero reserved field with EINVAL ("genlmsghdr.reserved field is not 0") which surfaced when adding new netdev commands.

Add an explicit Reserved uint16 field so the struct is genuinely 4 bytes and serializes the reserved word as zero.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal data structure layout to support binary serialization operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->