### PR TITLE
netkit: serialize peer NumRxQueues/NumTxQueues on create

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -2924,6 +2924,12 @@ func addNetkitAttrs(nk *Netkit, linkInfo *nl.RtAttr, flag int) error {
 	if nk.peerLinkAttrs.Name != "" {
 		peer.AddRtAttr(unix.IFLA_IFNAME, nl.ZeroTerminated(nk.peerLinkAttrs.Name))
 	}
+	if nk.peerLinkAttrs.NumRxQueues > 0 {
+		peer.AddRtAttr(unix.IFLA_NUM_RX_QUEUES, nl.Uint32Attr(uint32(nk.peerLinkAttrs.NumRxQueues)))
+	}
+	if nk.peerLinkAttrs.NumTxQueues > 0 {
+		peer.AddRtAttr(unix.IFLA_NUM_TX_QUEUES, nl.Uint32Attr(uint32(nk.peerLinkAttrs.NumTxQueues)))
+	}
 	if nk.peerLinkAttrs.MTU > 0 {
 		peer.AddRtAttr(unix.IFLA_MTU, nl.Uint32Attr(uint32(nk.peerLinkAttrs.MTU)))
 	}


### PR DESCRIPTION
addNetkitAttrs emitted the peer's name, MTU, GSO sizes and namespace into the IFLA_NETKIT_PEER_INFO nest, but not its queue counts, so a peer created via SetPeerAttrs always came up with the default single rx/tx queue. veth already serializes PeerNumRxQueues/PeerNumTxQueues; do the same for netkit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced peer network interface configuration by adding support for receive and transmit queue attribute settings during device modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->