### PR TITLE
fix: normalize IPv4 addresses and fix byte alignment in Multipath Via attribute

### DIFF
--- a/route_linux.go
+++ b/route_linux.go
@@ -780,11 +780,20 @@ func (v *Via) Family() int {
 
 func (v *Via) Encode() ([]byte, error) {
 	buf := &bytes.Buffer{}
+
 	err := binary.Write(buf, native, uint16(v.AddrFamily))
 	if err != nil {
 		return nil, err
 	}
-	err = binary.Write(buf, native, v.Addr)
+	addr := v.Addr
+	if v.AddrFamily == nl.FAMILY_V4 {
+		ipv4 := addr.To4()
+		if ipv4 == nil {
+			return nil, fmt.Errorf("invalid IPv4 address in Via struct")
+		}
+		addr = ipv4
+	}
+	err = binary.Write(buf, native, addr)
 	if err != nil {
 		return nil, err
 	}

--- a/route_test.go
+++ b/route_test.go
@@ -2472,6 +2472,101 @@ func TestRouteViaAddDel(t *testing.T) {
 	}
 }
 
+// TestRouteMultiPathViaIPv4Mapped verifies that adding a Multipath route
+// with a 16-byte IPv4-mapped address is correctly normalized to 4 bytes
+// during encoding, preventing kernel invalid gateway rejections.
+func TestRouteMultiPathViaIPv4Mapped(t *testing.T) {
+	minKernelRequired(t, 5, 4)
+	t.Cleanup(setUpNetlinkTest(t))
+
+	link, err := LinkByName("lo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := LinkSetUp(link); err != nil {
+		t.Fatal(err)
+	}
+
+	buggyViaIP := net.ParseIP("1.1.1.1")
+	if len(buggyViaIP) != 16 {
+		t.Fatalf("expected a 16-byte IP object for the test, but got %d bytes", len(buggyViaIP))
+	}
+
+	dst := &net.IPNet{
+		IP:   net.IPv4(192, 168, 99, 0),
+		Mask: net.CIDRMask(24, 32),
+	}
+
+	route := &Route{
+		LinkIndex: link.Attrs().Index,
+		Dst:       dst,
+		MultiPath: []*NexthopInfo{
+			{
+				LinkIndex: link.Attrs().Index,
+				Flags:     int(FLAG_ONLINK),
+				Via: &Via{
+					AddrFamily: FAMILY_V4,
+					Addr:       buggyViaIP, // intentionally trying to send the 16-byte IP to the Kernel
+				},
+			},
+		},
+	}
+
+	if err := RouteAdd(route); err != nil {
+		t.Fatalf("RouteAdd should handle 16-byte IPv4 Via addresses: %v", err)
+	}
+
+	routes, err := RouteListFiltered(FAMILY_V4, &Route{Dst: dst}, RT_FILTER_DST)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(routes) != 1 {
+		t.Fatal("Route was not added to the kernel properly")
+	}
+
+	if err := RouteDel(route); err != nil {
+		t.Fatal(err)
+	}
+
+	routesAfterDel, err := RouteListFiltered(FAMILY_V4, &Route{Dst: dst}, RT_FILTER_DST)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(routesAfterDel) != 0 {
+		t.Fatal("Route was not deleted from the kernel properly")
+	}
+}
+
+// TestViaEncodeIPv4Mapped verifies that a 16-byte IPv4-mapped address
+// is correctly compressed and encoded into a strictly 6-byte slice
+// (2 bytes for AddrFamily + 4 bytes for the IPv4 address).
+func TestViaEncodeIPv4Mapped(t *testing.T) {
+	via := &Via{
+		AddrFamily: FAMILY_V4,
+		Addr:       net.ParseIP("1.1.1.1"),
+	}
+
+	b, err := via.Encode()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(b) != 6 {
+		t.Fatalf("expected encoded Via length to be 6 bytes, got %d", len(b))
+	}
+
+	gotFamily := int(native.Uint16(b[0:2]))
+	if gotFamily != FAMILY_V4 {
+		t.Fatalf("unexpected address family; got %d, want %d", gotFamily, FAMILY_V4)
+	}
+
+	gotAddr := net.IP(b[2:6])
+	wantAddr := net.IPv4(1, 1, 1, 1)
+	if !gotAddr.Equal(wantAddr) {
+		t.Fatalf("unexpected IPv4 address; got %s, want %s", gotAddr, wantAddr)
+	}
+}
+
 func TestRouteUIDOption(t *testing.T) {
 	t.Cleanup(setUpNetlinkTest(t))
 


### PR DESCRIPTION
Fixes an issue where passing an IPv4 address generated by `net.ParseIP()` to a Multipath `Via` attribute causes the kernel to reject the route with an `invalid gateway` error. 

The problem is that `net.ParseIP()` returns a 16-byte slice, and `Via.Encode()` was writing all 16 bytes to the `RTA_VIA` attribute. The kernel strictly expects 4 bytes for `AF_INET`. 

This PR simply adds a `.To4()` conversion inside `Via.Encode()` for `FAMILY_V4` to ensure we only serialize the correct 4 bytes. I also included a test (`TestRouteMultiPathViaIPv4Mapped`) to cover this case.

Fixes #1064

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalized IPv4 `Via` address encoding by converting inputs to proper IPv4 form, returning an error when an IPv4 conversion isn’t possible to better match kernel behavior.

* **Tests**
  * Added a kernel-version-gated regression test for multipath routes using IPv4-mapped `Via` addresses (add/verify/delete).
  * Added unit tests for `Via` encoding with IPv4 `AddrFamily`, validating the encoded family and IPv4 bytes for `1.1.1.1`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->