### PR TITLE
*: remove pkgHandle, remove HandleOptions.NetNS, add NewHandleAtWithOptions

### DIFF
--- a/addr_linux.go
+++ b/addr_linux.go
@@ -31,7 +31,7 @@ const (
 // will be automatically computed based on the IP mask if /30 or larger.
 // If `net.IPv4zero` is given as the broadcast address, broadcast is disabled.
 func AddrAdd(link Link, addr *Addr) error {
-	return pkgHandle.AddrAdd(link, addr)
+	return pkgHandle().AddrAdd(link, addr)
 }
 
 // AddrAdd will add an IP address to a link device.
@@ -54,7 +54,7 @@ func (h *Handle) AddrAdd(link Link, addr *Addr) error {
 // will be automatically computed based on the IP mask if /30 or larger.
 // If `net.IPv4zero` is given as the broadcast address, broadcast is disabled.
 func AddrReplace(link Link, addr *Addr) error {
-	return pkgHandle.AddrReplace(link, addr)
+	return pkgHandle().AddrReplace(link, addr)
 }
 
 // AddrReplace will replace (or, if not present, add) an IP address on a link device.
@@ -73,7 +73,7 @@ func (h *Handle) AddrReplace(link Link, addr *Addr) error {
 //
 // Equivalent to: `ip addr del $addr dev $link`
 func AddrDel(link Link, addr *Addr) error {
-	return pkgHandle.AddrDel(link, addr)
+	return pkgHandle().AddrDel(link, addr)
 }
 
 // AddrDel will delete an IP address from a link device.
@@ -191,7 +191,7 @@ func (h *Handle) addrHandle(link Link, addr *Addr, req *nl.NetlinkRequest) error
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func AddrList(link Link, family int) ([]Addr, error) {
-	return pkgHandle.AddrList(link, family)
+	return pkgHandle().AddrList(link, family)
 }
 
 // AddrList gets a list of IP addresses in the system.
@@ -384,7 +384,7 @@ func addrSubscribeAt(newNs, curNs netns.NsHandle, ch chan<- AddrUpdate, done <-c
 		}()
 	}
 	if listExisting {
-		req := pkgHandle.newNetlinkRequest(unix.RTM_GETADDR,
+		req := pkgHandle().newNetlinkRequest(unix.RTM_GETADDR,
 			unix.NLM_F_DUMP)
 		infmsg := nl.NewIfInfomsg(unix.AF_UNSPEC)
 		req.AddData(infmsg)

--- a/bridge_linux.go
+++ b/bridge_linux.go
@@ -15,7 +15,7 @@ import (
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func BridgeVlanTunnelShow() ([]nl.TunnelInfo, error) {
-	return pkgHandle.BridgeVlanTunnelShow()
+	return pkgHandle().BridgeVlanTunnelShow()
 }
 
 func (h *Handle) BridgeVlanTunnelShow() ([]nl.TunnelInfo, error) {
@@ -29,7 +29,7 @@ func (h *Handle) BridgeVlanTunnelShow() ([]nl.TunnelInfo, error) {
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func BridgeVlanTunnelShowDev(link Link) ([]nl.TunnelInfo, error) {
-	return pkgHandle.BridgeVlanTunnelShowDev(link)
+	return pkgHandle().BridgeVlanTunnelShowDev(link)
 }
 
 func (h *Handle) BridgeVlanTunnelShowDev(link Link) ([]nl.TunnelInfo, error) {
@@ -137,7 +137,7 @@ func parseTunnelInfo(nestAttr *syscall.NetlinkRouteAttr, results []nl.TunnelInfo
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func BridgeVlanList() (map[int32][]*nl.BridgeVlanInfo, error) {
-	return pkgHandle.BridgeVlanList()
+	return pkgHandle().BridgeVlanList()
 }
 
 // BridgeVlanList gets a map of device id to bridge vlan infos.
@@ -187,13 +187,13 @@ func (h *Handle) BridgeVlanList() (map[int32][]*nl.BridgeVlanInfo, error) {
 // BridgeVlanAddTunnelInfo adds a new vlan filter entry
 // Equivalent to: `bridge vlan add dev DEV vid VID tunnel_info id TUNID [ self ] [ master ]`
 func BridgeVlanAddTunnelInfo(link Link, vid uint16, tunid uint32, self, master bool) error {
-	return pkgHandle.BridgeVlanAddTunnelInfo(link, vid, 0, tunid, 0, self, master)
+	return pkgHandle().BridgeVlanAddTunnelInfo(link, vid, 0, tunid, 0, self, master)
 }
 
 // BridgeVlanAddRangeTunnelInfoRange adds a new vlan filter entry
 // Equivalent to: `bridge vlan add dev DEV vid VID-VIDEND tunnel_info id VIN-VINEND [ self ] [ master ]`
 func BridgeVlanAddRangeTunnelInfoRange(link Link, vid, vidEnd uint16, tunid, tunidEnd uint32, self, master bool) error {
-	return pkgHandle.BridgeVlanAddTunnelInfo(link, vid, vidEnd, tunid, tunidEnd, self, master)
+	return pkgHandle().BridgeVlanAddTunnelInfo(link, vid, vidEnd, tunid, tunidEnd, self, master)
 }
 
 func (h *Handle) BridgeVlanAddTunnelInfo(link Link, vid, vidEnd uint16, tunid, tunidEnd uint32, self, master bool) error {
@@ -203,13 +203,13 @@ func (h *Handle) BridgeVlanAddTunnelInfo(link Link, vid, vidEnd uint16, tunid, t
 // BridgeVlanDelTunnelInfo adds a new vlan filter entry
 // Equivalent to: `bridge vlan del dev DEV vid VID tunnel_info id TUNID [ self ] [ master ]`
 func BridgeVlanDelTunnelInfo(link Link, vid uint16, tunid uint32, self, master bool) error {
-	return pkgHandle.BridgeVlanDelTunnelInfo(link, vid, 0, tunid, 0, self, master)
+	return pkgHandle().BridgeVlanDelTunnelInfo(link, vid, 0, tunid, 0, self, master)
 }
 
 // BridgeVlanDelRangeTunnelInfoRange adds a new vlan filter entry
 // Equivalent to: `bridge vlan del dev DEV vid VID-VIDEND tunnel_info id VIN-VINEND [ self ] [ master ]`
 func BridgeVlanDelRangeTunnelInfoRange(link Link, vid, vidEnd uint16, tunid, tunidEnd uint32, self, master bool) error {
-	return pkgHandle.BridgeVlanDelTunnelInfo(link, vid, vidEnd, tunid, tunidEnd, self, master)
+	return pkgHandle().BridgeVlanDelTunnelInfo(link, vid, vidEnd, tunid, tunidEnd, self, master)
 }
 
 func (h *Handle) BridgeVlanDelTunnelInfo(link Link, vid, vidEnd uint16, tunid, tunidEnd uint32, self, master bool) error {
@@ -219,7 +219,7 @@ func (h *Handle) BridgeVlanDelTunnelInfo(link Link, vid, vidEnd uint16, tunid, t
 // BridgeVlanAdd adds a new vlan filter entry
 // Equivalent to: `bridge vlan add dev DEV vid VID [ pvid ] [ untagged ] [ self ] [ master ]`
 func BridgeVlanAdd(link Link, vid uint16, pvid, untagged, self, master bool) error {
-	return pkgHandle.BridgeVlanAdd(link, vid, pvid, untagged, self, master)
+	return pkgHandle().BridgeVlanAdd(link, vid, pvid, untagged, self, master)
 }
 
 // BridgeVlanAdd adds a new vlan filter entry
@@ -231,7 +231,7 @@ func (h *Handle) BridgeVlanAdd(link Link, vid uint16, pvid, untagged, self, mast
 // BridgeVlanAddRange adds a new vlan filter entry
 // Equivalent to: `bridge vlan add dev DEV vid VID-VIDEND [ pvid ] [ untagged ] [ self ] [ master ]`
 func BridgeVlanAddRange(link Link, vid, vidEnd uint16, pvid, untagged, self, master bool) error {
-	return pkgHandle.BridgeVlanAddRange(link, vid, vidEnd, pvid, untagged, self, master)
+	return pkgHandle().BridgeVlanAddRange(link, vid, vidEnd, pvid, untagged, self, master)
 }
 
 // BridgeVlanAddRange adds a new vlan filter entry
@@ -243,7 +243,7 @@ func (h *Handle) BridgeVlanAddRange(link Link, vid, vidEnd uint16, pvid, untagge
 // BridgeVlanDel adds a new vlan filter entry
 // Equivalent to: `bridge vlan del dev DEV vid VID [ pvid ] [ untagged ] [ self ] [ master ]`
 func BridgeVlanDel(link Link, vid uint16, pvid, untagged, self, master bool) error {
-	return pkgHandle.BridgeVlanDel(link, vid, pvid, untagged, self, master)
+	return pkgHandle().BridgeVlanDel(link, vid, pvid, untagged, self, master)
 }
 
 // BridgeVlanDel adds a new vlan filter entry
@@ -255,7 +255,7 @@ func (h *Handle) BridgeVlanDel(link Link, vid uint16, pvid, untagged, self, mast
 // BridgeVlanDelRange adds a new vlan filter entry
 // Equivalent to: `bridge vlan del dev DEV vid VID-VIDEND [ pvid ] [ untagged ] [ self ] [ master ]`
 func BridgeVlanDelRange(link Link, vid, vidEnd uint16, pvid, untagged, self, master bool) error {
-	return pkgHandle.BridgeVlanDelRange(link, vid, vidEnd, pvid, untagged, self, master)
+	return pkgHandle().BridgeVlanDelRange(link, vid, vidEnd, pvid, untagged, self, master)
 }
 
 // BridgeVlanDelRange adds a new vlan filter entry
@@ -333,7 +333,7 @@ func (h *Handle) bridgeVlanModify(cmd int, link Link, vid, vidEnd uint16, tunid,
 // BridgeVniAdd adds a new vni filter entry
 // Equivalent to: `bridge vni add dev DEV vni VNI`
 func BridgeVniAdd(link Link, vni uint32) error {
-	return pkgHandle.BridgeVniAdd(link, vni)
+	return pkgHandle().BridgeVniAdd(link, vni)
 }
 
 // BridgeVniAdd adds a new vni filter entry
@@ -345,7 +345,7 @@ func (h *Handle) BridgeVniAdd(link Link, vni uint32) error {
 // BridgeVniAddRange adds a new vni filter entry
 // Equivalent to: `bridge vni add dev DEV vni VNI-VNIEND`
 func BridgeVniAddRange(link Link, vniStart, vniEnd uint32) error {
-	return pkgHandle.BridgeVniAddRange(link, vniStart, vniEnd)
+	return pkgHandle().BridgeVniAddRange(link, vniStart, vniEnd)
 }
 
 // BridgeVniAddRange adds a new vni filter entry
@@ -357,7 +357,7 @@ func (h *Handle) BridgeVniAddRange(link Link, vniStart, vniEnd uint32) error {
 // BridgeVniDel deletes a vni filter entry
 // Equivalent to: `bridge vni del dev DEV vni VNI`
 func BridgeVniDel(link Link, vni uint32) error {
-	return pkgHandle.BridgeVniDel(link, vni)
+	return pkgHandle().BridgeVniDel(link, vni)
 }
 
 // BridgeVniDel deletes a vni filter entry
@@ -369,7 +369,7 @@ func (h *Handle) BridgeVniDel(link Link, vni uint32) error {
 // BridgeVniDelRange deletes a vni filter entry
 // Equivalent to: `bridge vni del dev DEV vni VNI-VNIEND`
 func BridgeVniDelRange(link Link, vniStart, vniEnd uint32) error {
-	return pkgHandle.BridgeVniDelRange(link, vniStart, vniEnd)
+	return pkgHandle().BridgeVniDelRange(link, vniStart, vniEnd)
 }
 
 // BridgeVniDelRange deletes a vni filter entry
@@ -403,7 +403,7 @@ func (h *Handle) bridgeVniModify(cmd int, link Link, vniStart, vniEnd uint32) er
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func BridgeVniList() (map[int32][]*nl.BridgeVniInfo, error) {
-	return pkgHandle.BridgeVniList()
+	return pkgHandle().BridgeVniList()
 }
 
 // BridgeVniList gets a map of device id to vni filter infos.

--- a/chain_linux.go
+++ b/chain_linux.go
@@ -10,7 +10,7 @@ import (
 // ChainDel will delete a chain from the system.
 func ChainDel(link Link, chain Chain) error {
 	// Equivalent to: `tc chain del $chain`
-	return pkgHandle.ChainDel(link, chain)
+	return pkgHandle().ChainDel(link, chain)
 }
 
 // ChainDel will delete a chain from the system.
@@ -22,7 +22,7 @@ func (h *Handle) ChainDel(link Link, chain Chain) error {
 // ChainAdd will add a chain to the system.
 // Equivalent to: `tc chain add`
 func ChainAdd(link Link, chain Chain) error {
-	return pkgHandle.ChainAdd(link, chain)
+	return pkgHandle().ChainAdd(link, chain)
 }
 
 // ChainAdd will add a chain to the system.
@@ -62,7 +62,7 @@ func (h *Handle) chainModify(cmd, flags int, link Link, chain Chain) error {
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func ChainList(link Link, parent uint32) ([]Chain, error) {
-	return pkgHandle.ChainList(link, parent)
+	return pkgHandle().ChainList(link, parent)
 }
 
 // ChainList gets a list of chains in the system.

--- a/class_linux.go
+++ b/class_linux.go
@@ -65,7 +65,7 @@ func NewHtbClass(attrs ClassAttrs, cattrs HtbClassAttrs) *HtbClass {
 // ClassDel will delete a class from the system.
 // Equivalent to: `tc class del $class`
 func ClassDel(class Class) error {
-	return pkgHandle.ClassDel(class)
+	return pkgHandle().ClassDel(class)
 }
 
 // ClassDel will delete a class from the system.
@@ -78,7 +78,7 @@ func (h *Handle) ClassDel(class Class) error {
 // Equivalent to: `tc class change $class`
 // The parent and handle MUST NOT be changed.
 func ClassChange(class Class) error {
-	return pkgHandle.ClassChange(class)
+	return pkgHandle().ClassChange(class)
 }
 
 // ClassChange will change a class in place
@@ -94,7 +94,7 @@ func (h *Handle) ClassChange(class Class) error {
 // If a class already exist with this parent/handle pair, the class is changed.
 // If a class does not already exist with this parent/handle, a new class is created.
 func ClassReplace(class Class) error {
-	return pkgHandle.ClassReplace(class)
+	return pkgHandle().ClassReplace(class)
 }
 
 // ClassReplace will replace a class to the system.
@@ -109,7 +109,7 @@ func (h *Handle) ClassReplace(class Class) error {
 // ClassAdd will add a class to the system.
 // Equivalent to: `tc class add $class`
 func ClassAdd(class Class) error {
-	return pkgHandle.ClassAdd(class)
+	return pkgHandle().ClassAdd(class)
 }
 
 // ClassAdd will add a class to the system.
@@ -206,7 +206,7 @@ func classPayload(req *nl.NetlinkRequest, class Class) error {
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func ClassList(link Link, parent uint32) ([]Class, error) {
-	return pkgHandle.ClassList(link, parent)
+	return pkgHandle().ClassList(link, parent)
 }
 
 // ClassList gets a list of classes in the system.

--- a/conntrack_linux.go
+++ b/conntrack_linux.go
@@ -49,32 +49,32 @@ type InetFamily uint8
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func ConntrackTableList(table ConntrackTableType, family InetFamily) ([]*ConntrackFlow, error) {
-	return pkgHandle.ConntrackTableList(table, family)
+	return pkgHandle().ConntrackTableList(table, family)
 }
 
 // ConntrackTableFlush flushes all the flows of a specified table
 // conntrack -F [table]            Flush table
 // The flush operation applies to all the family types
 func ConntrackTableFlush(table ConntrackTableType) error {
-	return pkgHandle.ConntrackTableFlush(table)
+	return pkgHandle().ConntrackTableFlush(table)
 }
 
 // ConntrackCreate creates a new conntrack flow in the desired table
 // conntrack -I [table]		Create a conntrack or expectation
 func ConntrackCreate(table ConntrackTableType, family InetFamily, flow *ConntrackFlow) error {
-	return pkgHandle.ConntrackCreate(table, family, flow)
+	return pkgHandle().ConntrackCreate(table, family, flow)
 }
 
 // ConntrackUpdate updates an existing conntrack flow in the desired table using the handle
 // conntrack -U [table]		Update a conntrack
 func ConntrackUpdate(table ConntrackTableType, family InetFamily, flow *ConntrackFlow) error {
-	return pkgHandle.ConntrackUpdate(table, family, flow)
+	return pkgHandle().ConntrackUpdate(table, family, flow)
 }
 
 // ConntrackDelete deletes an existing conntrack flow in the desired table
 // conntrack -D [table]		Delete conntrack flow
 func ConntrackDelete(table ConntrackTableType, family InetFamily, flow *ConntrackFlow) error {
-	return pkgHandle.ConntrackDelete(table, family, flow)
+	return pkgHandle().ConntrackDelete(table, family, flow)
 }
 
 // ConntrackDeleteFilter deletes entries on the specified table on the base of the filter
@@ -82,13 +82,13 @@ func ConntrackDelete(table ConntrackTableType, family InetFamily, flow *Conntrac
 //
 // Deprecated: use [ConntrackDeleteFilters] instead.
 func ConntrackDeleteFilter(table ConntrackTableType, family InetFamily, filter CustomConntrackFilter) (uint, error) {
-	return pkgHandle.ConntrackDeleteFilters(table, family, filter)
+	return pkgHandle().ConntrackDeleteFilters(table, family, filter)
 }
 
 // ConntrackDeleteFilters deletes entries on the specified table matching any of the specified filters
 // conntrack -D [table] parameters         Delete conntrack or expectation
 func ConntrackDeleteFilters(table ConntrackTableType, family InetFamily, filters ...CustomConntrackFilter) (uint, error) {
-	return pkgHandle.ConntrackDeleteFilters(table, family, filters...)
+	return pkgHandle().ConntrackDeleteFilters(table, family, filters...)
 }
 
 // ConntrackTableList returns the flow list of a table of a specific family using the netlink handle passed

--- a/devlink_linux.go
+++ b/devlink_linux.go
@@ -385,7 +385,7 @@ func (h *Handle) DevLinkGetDeviceList() ([]*DevlinkDevice, error) {
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func DevLinkGetDeviceList() ([]*DevlinkDevice, error) {
-	return pkgHandle.DevLinkGetDeviceList()
+	return pkgHandle().DevLinkGetDeviceList()
 }
 
 func parseDevlinkDevice(msgs [][]byte) (*DevlinkDevice, error) {
@@ -450,7 +450,7 @@ func (h *Handle) DevLinkGetDeviceByName(Bus string, Device string) (*DevlinkDevi
 // DevlinkGetDeviceByName provides a pointer to devlink device and nil error,
 // otherwise returns an error code.
 func DevLinkGetDeviceByName(Bus string, Device string) (*DevlinkDevice, error) {
-	return pkgHandle.DevLinkGetDeviceByName(Bus, Device)
+	return pkgHandle().DevLinkGetDeviceByName(Bus, Device)
 }
 
 // DevLinkSetEswitchMode sets eswitch mode if able to set successfully or
@@ -479,7 +479,7 @@ func (h *Handle) DevLinkSetEswitchMode(Dev *DevlinkDevice, NewMode string) error
 // Equivalent to: `devlink dev eswitch set $dev mode switchdev`
 // Equivalent to: `devlink dev eswitch set $dev mode legacy`
 func DevLinkSetEswitchMode(Dev *DevlinkDevice, NewMode string) error {
-	return pkgHandle.DevLinkSetEswitchMode(Dev, NewMode)
+	return pkgHandle().DevLinkSetEswitchMode(Dev, NewMode)
 }
 
 func (port *DevlinkPort) parseAttributes(attrs []syscall.NetlinkRouteAttr) error {
@@ -584,7 +584,7 @@ func (h *Handle) DevLinkGetAllPortList() ([]*DevlinkPort, error) {
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func DevLinkGetAllPortList() ([]*DevlinkPort, error) {
-	return pkgHandle.DevLinkGetAllPortList()
+	return pkgHandle().DevLinkGetAllPortList()
 }
 
 func parseDevlinkPortMsg(msgs [][]byte) (*DevlinkPort, error) {
@@ -621,7 +621,7 @@ func (h *Handle) DevLinkGetPortByIndex(Bus string, Device string, PortIndex uint
 
 // DevlinkGetDeviceResources returns devlink device resources
 func DevlinkGetDeviceResources(bus string, device string) (*DevlinkResources, error) {
-	return pkgHandle.DevlinkGetDeviceResources(bus, device)
+	return pkgHandle().DevlinkGetDeviceResources(bus, device)
 }
 
 // DevlinkGetDeviceResources returns devlink device resources
@@ -685,7 +685,7 @@ func (h *Handle) DevlinkGetDeviceParams(bus string, device string) ([]*DevlinkPa
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func DevlinkGetDeviceParams(bus string, device string) ([]*DevlinkParam, error) {
-	return pkgHandle.DevlinkGetDeviceParams(bus, device)
+	return pkgHandle().DevlinkGetDeviceParams(bus, device)
 }
 
 // DevlinkGetDeviceParamByName returns specific parameter for devlink device
@@ -717,7 +717,7 @@ func (h *Handle) DevlinkGetDeviceParamByName(bus string, device string, param st
 // DevlinkGetDeviceParamByName returns specific parameter for devlink device
 // Equivalent to: `devlink dev param show <bus>/<device> name <param>`
 func DevlinkGetDeviceParamByName(bus string, device string, param string) (*DevlinkParam, error) {
-	return pkgHandle.DevlinkGetDeviceParamByName(bus, device, param)
+	return pkgHandle().DevlinkGetDeviceParamByName(bus, device, param)
 }
 
 // DevlinkSplitPort splits a devlink port.
@@ -736,7 +736,7 @@ func (h *Handle) DevlinkSplitPort(port *DevlinkPort, count uint32) error {
 }
 
 func DevlinkSplitPort(port *DevlinkPort, count uint32) error {
-	return pkgHandle.DevlinkSplitPort(port, count)
+	return pkgHandle().DevlinkSplitPort(port, count)
 }
 
 // DevlinkUnsplitPort: unsplit devlink port
@@ -754,7 +754,7 @@ func (h *Handle) DevlinkUnsplitPort(port *DevlinkPort) error {
 }
 
 func DevlinkUnsplitPort(port *DevlinkPort) error {
-	return pkgHandle.DevlinkUnsplitPort(port)
+	return pkgHandle().DevlinkUnsplitPort(port)
 }
 
 // DevlinkSetDeviceParam set specific parameter for devlink device
@@ -826,13 +826,13 @@ func (h *Handle) DevlinkSetDeviceParam(bus string, device string, param string, 
 // cmode argument should contain valid cmode value as uint8, modes are define in nl.DEVLINK_PARAM_CMODE_* constants
 // value argument should have one of the following types: uint8, uint16, uint32, string, bool
 func DevlinkSetDeviceParam(bus string, device string, param string, cmode uint8, value interface{}) error {
-	return pkgHandle.DevlinkSetDeviceParam(bus, device, param, cmode, value)
+	return pkgHandle().DevlinkSetDeviceParam(bus, device, param, cmode, value)
 }
 
 // DevLinkGetPortByIndex provides a pointer to devlink portand nil error,
 // otherwise returns an error code.
 func DevLinkGetPortByIndex(Bus string, Device string, PortIndex uint32) (*DevlinkPort, error) {
-	return pkgHandle.DevLinkGetPortByIndex(Bus, Device, PortIndex)
+	return pkgHandle().DevLinkGetPortByIndex(Bus, Device, PortIndex)
 }
 
 // DevLinkPortAdd adds a devlink port and returns a port on success
@@ -866,7 +866,7 @@ func (h *Handle) DevLinkPortAdd(Bus string, Device string, Flavour uint16, Attrs
 // DevLinkPortAdd adds a devlink port and returns a port on success
 // otherwise returns nil port and an error code.
 func DevLinkPortAdd(Bus string, Device string, Flavour uint16, Attrs DevLinkPortAddAttrs) (*DevlinkPort, error) {
-	return pkgHandle.DevLinkPortAdd(Bus, Device, Flavour, Attrs)
+	return pkgHandle().DevLinkPortAdd(Bus, Device, Flavour, Attrs)
 }
 
 // DevLinkPortDel deletes a devlink port and returns success or error code.
@@ -883,7 +883,7 @@ func (h *Handle) DevLinkPortDel(Bus string, Device string, PortIndex uint32) err
 
 // DevLinkPortDel deletes a devlink port and returns success or error code.
 func DevLinkPortDel(Bus string, Device string, PortIndex uint32) error {
-	return pkgHandle.DevLinkPortDel(Bus, Device, PortIndex)
+	return pkgHandle().DevLinkPortDel(Bus, Device, PortIndex)
 }
 
 // DevlinkPortFnSet sets one or more port function attributes specified by the attribute mask.
@@ -914,7 +914,7 @@ func (h *Handle) DevlinkPortFnSet(Bus string, Device string, PortIndex uint32, F
 // DevlinkPortFnSet sets one or more port function attributes specified by the attribute mask.
 // It returns 0 on success or error code.
 func DevlinkPortFnSet(Bus string, Device string, PortIndex uint32, FnAttrs DevlinkPortFnSetAttrs) error {
-	return pkgHandle.DevlinkPortFnSet(Bus, Device, PortIndex, FnAttrs)
+	return pkgHandle().DevlinkPortFnSet(Bus, Device, PortIndex, FnAttrs)
 }
 
 // devlinkInfoGetter is function that is responsible for getting devlink info message
@@ -937,7 +937,8 @@ func (h *Handle) DevlinkGetDeviceInfoByName(Bus string, Device string, getInfoMs
 // otherwise returns an error code.
 // Equivalent to: `devlink dev info $dev`
 func DevlinkGetDeviceInfoByName(Bus string, Device string) (*DevlinkDeviceInfo, error) {
-	return pkgHandle.DevlinkGetDeviceInfoByName(Bus, Device, pkgHandle.getDevlinkInfoMsg)
+	h := pkgHandle()
+	return h.DevlinkGetDeviceInfoByName(Bus, Device, h.getDevlinkInfoMsg)
 }
 
 // DevlinkGetDeviceInfoByNameAsMap returns devlink info for selected device as a map,
@@ -961,19 +962,22 @@ func (h *Handle) DevlinkGetDeviceInfoByNameAsMap(Bus string, Device string, getI
 // otherwise returns an error code.
 // Equivalent to: `devlink dev info $dev`
 func DevlinkGetDeviceInfoByNameAsMap(Bus string, Device string) (map[string]string, error) {
-	return pkgHandle.DevlinkGetDeviceInfoByNameAsMap(Bus, Device, pkgHandle.getDevlinkInfoMsg)
+	h := pkgHandle()
+	return h.DevlinkGetDeviceInfoByNameAsMap(Bus, Device, h.getDevlinkInfoMsg)
 }
 
 // GetDevlinkInfo returns devlink info for target device,
 // otherwise returns an error code.
 func (d *DevlinkDevice) GetDevlinkInfo() (*DevlinkDeviceInfo, error) {
-	return pkgHandle.DevlinkGetDeviceInfoByName(d.BusName, d.DeviceName, pkgHandle.getDevlinkInfoMsg)
+	h := pkgHandle()
+	return h.DevlinkGetDeviceInfoByName(d.BusName, d.DeviceName, h.getDevlinkInfoMsg)
 }
 
 // GetDevlinkInfoAsMap returns devlink info for target device as a map,
 // otherwise returns an error code.
 func (d *DevlinkDevice) GetDevlinkInfoAsMap() (map[string]string, error) {
-	return pkgHandle.DevlinkGetDeviceInfoByNameAsMap(d.BusName, d.DeviceName, pkgHandle.getDevlinkInfoMsg)
+	h := pkgHandle()
+	return h.DevlinkGetDeviceInfoByNameAsMap(d.BusName, d.DeviceName, h.getDevlinkInfoMsg)
 }
 
 func (h *Handle) getDevlinkInfoMsg(bus, device string) ([]byte, error) {

--- a/devlink_test.go
+++ b/devlink_test.go
@@ -200,7 +200,7 @@ func init() {
 }
 
 func TestDevlinkGetDeviceInfoByNameAsMap(t *testing.T) {
-	info, err := pkgHandle.DevlinkGetDeviceInfoByNameAsMap("pci", "0000:00:00.0", mockDevlinkInfoGetter)
+	info, err := pkgHandle().DevlinkGetDeviceInfoByNameAsMap("pci", "0000:00:00.0", mockDevlinkInfoGetter)
 	assert.NoError(t, err)
 
 	testInfo := devlinkTestInfoParesd()
@@ -210,7 +210,7 @@ func TestDevlinkGetDeviceInfoByNameAsMap(t *testing.T) {
 }
 
 func TestDevlinkGetDeviceInfoByName(t *testing.T) {
-	info, err := pkgHandle.DevlinkGetDeviceInfoByName("pci", "0000:00:00.0", mockDevlinkInfoGetter)
+	info, err := pkgHandle().DevlinkGetDeviceInfoByName("pci", "0000:00:00.0", mockDevlinkInfoGetter)
 	assert.NoError(t, err)
 
 	testInfo := parseInfoData(devlinkTestInfoParesd())
@@ -218,12 +218,12 @@ func TestDevlinkGetDeviceInfoByName(t *testing.T) {
 }
 
 func TestDevlinkGetDeviceInfoByNameAsMapFail(t *testing.T) {
-	_, err := pkgHandle.DevlinkGetDeviceInfoByNameAsMap("pci", "0000:00:00.0", mockDevlinkInfoGetterEmpty)
+	_, err := pkgHandle().DevlinkGetDeviceInfoByNameAsMap("pci", "0000:00:00.0", mockDevlinkInfoGetterEmpty)
 	assert.Error(t, err)
 }
 
 func TestDevlinkGetDeviceInfoByNameFail(t *testing.T) {
-	_, err := pkgHandle.DevlinkGetDeviceInfoByName("pci", "0000:00:00.0", mockDevlinkInfoGetterEmpty)
+	_, err := pkgHandle().DevlinkGetDeviceInfoByName("pci", "0000:00:00.0", mockDevlinkInfoGetterEmpty)
 	assert.Error(t, err)
 }
 

--- a/filter_linux.go
+++ b/filter_linux.go
@@ -283,7 +283,7 @@ func (filter *Flower) decode(data []syscall.NetlinkRouteAttr) error {
 // FilterDel will delete a filter from the system.
 // Equivalent to: `tc filter del $filter`
 func FilterDel(filter Filter) error {
-	return pkgHandle.FilterDel(filter)
+	return pkgHandle().FilterDel(filter)
 }
 
 // FilterDel will delete a filter from the system.
@@ -295,7 +295,7 @@ func (h *Handle) FilterDel(filter Filter) error {
 // FilterAdd will add a filter to the system.
 // Equivalent to: `tc filter add $filter`
 func FilterAdd(filter Filter) error {
-	return pkgHandle.FilterAdd(filter)
+	return pkgHandle().FilterAdd(filter)
 }
 
 // FilterAdd will add a filter to the system.
@@ -307,7 +307,7 @@ func (h *Handle) FilterAdd(filter Filter) error {
 // FilterReplace will replace a filter.
 // Equivalent to: `tc filter replace $filter`
 func FilterReplace(filter Filter) error {
-	return pkgHandle.FilterReplace(filter)
+	return pkgHandle().FilterReplace(filter)
 }
 
 // FilterReplace will replace a filter.
@@ -457,7 +457,7 @@ func (h *Handle) filterModify(filter Filter, proto, flags int) error {
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func FilterList(link Link, parent uint32) ([]Filter, error) {
-	return pkgHandle.FilterList(link, parent)
+	return pkgHandle().FilterList(link, parent)
 }
 
 // FilterList gets a list of filters in the system.

--- a/fou_linux.go
+++ b/fou_linux.go
@@ -64,7 +64,7 @@ func FouFamilyId() (int, error) {
 }
 
 func FouAdd(f Fou) error {
-	return pkgHandle.FouAdd(f)
+	return pkgHandle().FouAdd(f)
 }
 
 func (h *Handle) FouAdd(f Fou) error {
@@ -100,7 +100,7 @@ func (h *Handle) FouAdd(f Fou) error {
 }
 
 func FouDel(f Fou) error {
-	return pkgHandle.FouDel(f)
+	return pkgHandle().FouDel(f)
 }
 
 func (h *Handle) FouDel(f Fou) error {
@@ -137,7 +137,7 @@ func (h *Handle) FouDel(f Fou) error {
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func FouList(fam int) ([]Fou, error) {
-	return pkgHandle.FouList(fam)
+	return pkgHandle().FouList(fam)
 }
 
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent

--- a/genetlink_linux.go
+++ b/genetlink_linux.go
@@ -150,7 +150,7 @@ func (h *Handle) GenlFamilyList() ([]*GenlFamily, error) {
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func GenlFamilyList() ([]*GenlFamily, error) {
-	return pkgHandle.GenlFamilyList()
+	return pkgHandle().GenlFamilyList()
 }
 
 func (h *Handle) GenlFamilyGet(name string) (*GenlFamily, error) {
@@ -176,5 +176,5 @@ func (h *Handle) GenlFamilyGet(name string) (*GenlFamily, error) {
 }
 
 func GenlFamilyGet(name string) (*GenlFamily, error) {
-	return pkgHandle.GenlFamilyGet(name)
+	return pkgHandle().GenlFamilyGet(name)
 }

--- a/gtp_linux.go
+++ b/gtp_linux.go
@@ -102,7 +102,7 @@ func (h *Handle) GTPPDPList() ([]*PDP, error) {
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func GTPPDPList() ([]*PDP, error) {
-	return pkgHandle.GTPPDPList()
+	return pkgHandle().GTPPDPList()
 }
 
 func gtpPDPGet(req *nl.NetlinkRequest) (*PDP, error) {
@@ -138,7 +138,7 @@ func (h *Handle) GTPPDPByTID(link Link, tid int) (*PDP, error) {
 }
 
 func GTPPDPByTID(link Link, tid int) (*PDP, error) {
-	return pkgHandle.GTPPDPByTID(link, tid)
+	return pkgHandle().GTPPDPByTID(link, tid)
 }
 
 func (h *Handle) GTPPDPByITEI(link Link, itei int) (*PDP, error) {
@@ -159,7 +159,7 @@ func (h *Handle) GTPPDPByITEI(link Link, itei int) (*PDP, error) {
 }
 
 func GTPPDPByITEI(link Link, itei int) (*PDP, error) {
-	return pkgHandle.GTPPDPByITEI(link, itei)
+	return pkgHandle().GTPPDPByITEI(link, itei)
 }
 
 func (h *Handle) GTPPDPByMSAddress(link Link, addr net.IP) (*PDP, error) {
@@ -180,7 +180,7 @@ func (h *Handle) GTPPDPByMSAddress(link Link, addr net.IP) (*PDP, error) {
 }
 
 func GTPPDPByMSAddress(link Link, addr net.IP) (*PDP, error) {
-	return pkgHandle.GTPPDPByMSAddress(link, addr)
+	return pkgHandle().GTPPDPByMSAddress(link, addr)
 }
 
 func (h *Handle) GTPPDPAdd(link Link, pdp *PDP) error {
@@ -214,7 +214,7 @@ func (h *Handle) GTPPDPAdd(link Link, pdp *PDP) error {
 }
 
 func GTPPDPAdd(link Link, pdp *PDP) error {
-	return pkgHandle.GTPPDPAdd(link, pdp)
+	return pkgHandle().GTPPDPAdd(link, pdp)
 }
 
 func (h *Handle) GTPPDPDel(link Link, pdp *PDP) error {
@@ -244,5 +244,5 @@ func (h *Handle) GTPPDPDel(link Link, pdp *PDP) error {
 }
 
 func GTPPDPDel(link Link, pdp *PDP) error {
-	return pkgHandle.GTPPDPDel(link, pdp)
+	return pkgHandle().GTPPDPDel(link, pdp)
 }

--- a/handle_linux.go
+++ b/handle_linux.go
@@ -57,10 +57,6 @@ type HandleOptions struct {
 	// number of times if they fail with EINTR before finally returning
 	// [ErrDumpInterrupted].
 	RetryInterrupted bool
-
-	// NetNS specifies the network namespace to operate on. If not set, the
-	// current network namespace will be used.
-	NetNS *netns.NsHandle
 }
 
 // Handle is a handle for the netlink requests on a
@@ -111,7 +107,7 @@ func (h *Handle) SupportsNetlinkFamily(nlFamily int) bool {
 // supports will be automatically added.
 func NewHandle(nlFamilies ...int) (*Handle, error) {
 	none := netns.None()
-	return newHandle(none, HandleOptions{NetNS: &none}, nlFamilies...)
+	return newHandle(none, none, HandleOptions{}, nlFamilies...)
 }
 
 // SetSocketTimeout sets the send and receive timeout for each socket in the
@@ -189,21 +185,27 @@ func (h *Handle) SetStrictCheck(state bool) error {
 // specified by ns. If ns=netns.None(), current network namespace
 // will be assumed
 func NewHandleAt(ns netns.NsHandle, nlFamilies ...int) (*Handle, error) {
-	return newHandle(netns.None(), HandleOptions{NetNS: &ns}, nlFamilies...)
+	return newHandle(ns, netns.None(), HandleOptions{}, nlFamilies...)
 }
 
 // NewHandleAtFrom works as NewHandle but allows client to specify the
 // new and the origin netns Handle.
 func NewHandleAtFrom(newNs, curNs netns.NsHandle) (*Handle, error) {
-	return newHandle(curNs, HandleOptions{NetNS: &newNs})
+	return newHandle(newNs, curNs, HandleOptions{})
 }
 
 // NewHandleWithOptions returns a Handle created using the specified options.
 func NewHandleWithOptions(opts HandleOptions, nlFamilies ...int) (*Handle, error) {
-	return newHandle(netns.None(), opts, nlFamilies...)
+	return newHandle(netns.None(), netns.None(), opts, nlFamilies...)
 }
 
-func newHandle(curNs netns.NsHandle, opts HandleOptions, nlFamilies ...int) (*Handle, error) {
+// NewHandleAtWithOptions returns a Handle created using the specified options
+// in the specified network namespace.
+func NewHandleAtWithOptions(ns netns.NsHandle, opts HandleOptions, nlFamilies ...int) (*Handle, error) {
+	return newHandle(ns, netns.None(), opts, nlFamilies...)
+}
+
+func newHandle(newNs, curNs netns.NsHandle, opts HandleOptions, nlFamilies ...int) (*Handle, error) {
 	h := &Handle{
 		sockets: map[int]*nl.SocketHandle{},
 		options: opts,
@@ -211,11 +213,6 @@ func newHandle(curNs netns.NsHandle, opts HandleOptions, nlFamilies ...int) (*Ha
 	fams := nl.SupportedNlFamilies
 	if len(nlFamilies) != 0 {
 		fams = nlFamilies
-	}
-
-	newNs := netns.None()
-	if opts.NetNS != nil {
-		newNs = *opts.NetNS
 	}
 
 	for _, f := range fams {

--- a/handle_linux.go
+++ b/handle_linux.go
@@ -11,38 +11,37 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// Empty handle used by the netlink package methods
-var pkgHandle = &Handle{}
+// pkgOptions holds the options configured via [ConfigureHandle] for use by
+// the package-level global functions.
+var pkgOptions HandleOptions
+var oncePkgOptions sync.Once
 
-var configMu sync.Mutex
-var configDone bool
-
-// ConfigureHandle configures the default, package-wide netlink handle used by
-// the netlink package's global functions like [LinkList] and [AddrList] with
-// the given opts. It does not affect any existing or future [Handle] returned
-// by the library.
+// ConfigureHandle configures the options used by the netlink package's global
+// functions like [LinkList] and [AddrList]. It does not affect any existing or
+// future [Handle] returned by [NewHandle] and friends; those need to be
+// configured explicitly and don't inherit from this configuration.
 //
-// This function is not safe to call concurrently with any netlink operations
-// using the global package handle. Invoke it from init() functions only.
+// This function is not safe to call concurrently with other global functions.
+// Invoke it from init() functions only.
 //
 // Returns an error if called more than once per process.
 func ConfigureHandle(opts HandleOptions) error {
-	configMu.Lock()
-	defer configMu.Unlock()
-
-	if configDone {
+	called := false
+	oncePkgOptions.Do(func() {
+		pkgOptions = opts
+		called = true
+	})
+	if !called {
 		return fmt.Errorf("netlink package handle already configured")
 	}
-
-	h, err := NewHandleWithOptions(opts)
-	if err != nil {
-		return fmt.Errorf("creating handle: %w", err)
-	}
-
-	configDone = true
-	pkgHandle = h
-
 	return nil
+}
+
+// pkgHandle returns a socket-less Handle initialized with the package-level
+// options. It is used by global package functions; each call opens its own
+// sockets in the caller's current network namespace.
+func pkgHandle() *Handle {
+	return &Handle{options: pkgOptions}
 }
 
 // HandleOptions defines the options for creating a netlink Handle, allowing the
@@ -248,7 +247,9 @@ func (h *Handle) Delete() {
 func (h *Handle) newNetlinkRequest(proto, flags int) *nl.NetlinkRequest {
 	// Do this so that package API still use nl package variable nextSeqNr
 	if h.sockets == nil {
-		return nl.NewNetlinkRequest(proto, flags)
+		req := nl.NewNetlinkRequest(proto, flags)
+		req.RetryInterrupted = h.options.RetryInterrupted
+		return req
 	}
 	return &nl.NetlinkRequest{
 		NlMsghdr: unix.NlMsghdr{

--- a/handle_linux_test.go
+++ b/handle_linux_test.go
@@ -1,6 +1,7 @@
 package netlink
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -19,18 +20,13 @@ func TestSetGetSocketTimeout(t *testing.T) {
 }
 
 func TestConfigureHandle(t *testing.T) {
-	orig := pkgHandle
-	origDone := configDone
 	t.Cleanup(func() {
-		configMu.Lock()
-		defer configMu.Unlock()
-
-		pkgHandle = orig
-		configDone = origDone
+		pkgOptions = HandleOptions{}
+		oncePkgOptions = sync.Once{}
 	})
 
 	assert.NoError(t, ConfigureHandle(HandleOptions{DisableVFInfoCollection: true}))
-	assert.NotEqual(t, orig, pkgHandle)
-	assert.NoError(t, pkgHandle.Close())
+	assert.True(t, pkgOptions.DisableVFInfoCollection)
+
 	assert.Error(t, ConfigureHandle(HandleOptions{}))
 }

--- a/ipset_linux.go
+++ b/ipset_linux.go
@@ -77,52 +77,52 @@ type IpsetCreateOptions struct {
 
 // IpsetProtocol returns the ipset protocol version from the kernel
 func IpsetProtocol() (uint8, uint8, error) {
-	return pkgHandle.IpsetProtocol()
+	return pkgHandle().IpsetProtocol()
 }
 
 // IpsetCreate creates a new ipset
 func IpsetCreate(setname, typename string, options IpsetCreateOptions) error {
-	return pkgHandle.IpsetCreate(setname, typename, options)
+	return pkgHandle().IpsetCreate(setname, typename, options)
 }
 
 // IpsetDestroy destroys an existing ipset
 func IpsetDestroy(setname string) error {
-	return pkgHandle.IpsetDestroy(setname)
+	return pkgHandle().IpsetDestroy(setname)
 }
 
 // IpsetFlush flushes an existing ipset
 func IpsetFlush(setname string) error {
-	return pkgHandle.IpsetFlush(setname)
+	return pkgHandle().IpsetFlush(setname)
 }
 
 // IpsetSwap swaps two ipsets.
 func IpsetSwap(setname, othersetname string) error {
-	return pkgHandle.IpsetSwap(setname, othersetname)
+	return pkgHandle().IpsetSwap(setname, othersetname)
 }
 
 // IpsetList dumps an specific ipset.
 func IpsetList(setname string) (*IPSetResult, error) {
-	return pkgHandle.IpsetList(setname)
+	return pkgHandle().IpsetList(setname)
 }
 
 // IpsetListAll dumps all ipsets.
 func IpsetListAll() ([]IPSetResult, error) {
-	return pkgHandle.IpsetListAll()
+	return pkgHandle().IpsetListAll()
 }
 
 // IpsetAdd adds an entry to an existing ipset.
 func IpsetAdd(setname string, entry *IPSetEntry) error {
-	return pkgHandle.IpsetAdd(setname, entry)
+	return pkgHandle().IpsetAdd(setname, entry)
 }
 
 // IpsetDel deletes an entry from an existing ipset.
 func IpsetDel(setname string, entry *IPSetEntry) error {
-	return pkgHandle.IpsetDel(setname, entry)
+	return pkgHandle().IpsetDel(setname, entry)
 }
 
 // IpsetTest tests whether an entry is in a set or not.
 func IpsetTest(setname string, entry *IPSetEntry) (bool, error) {
-	return pkgHandle.IpsetTest(setname, entry)
+	return pkgHandle().IpsetTest(setname, entry)
 }
 
 func (h *Handle) IpsetProtocol() (protocol uint8, minVersion uint8, err error) {

--- a/link_linux.go
+++ b/link_linux.go
@@ -106,7 +106,7 @@ func (h *Handle) LinkSetARPOff(link Link) error {
 }
 
 func LinkSetARPOff(link Link) error {
-	return pkgHandle.LinkSetARPOff(link)
+	return pkgHandle().LinkSetARPOff(link)
 }
 
 func (h *Handle) LinkSetARPOn(link Link) error {
@@ -125,7 +125,7 @@ func (h *Handle) LinkSetARPOn(link Link) error {
 }
 
 func LinkSetARPOn(link Link) error {
-	return pkgHandle.LinkSetARPOn(link)
+	return pkgHandle().LinkSetARPOn(link)
 }
 
 func (h *Handle) SetPromiscOn(link Link) error {
@@ -146,7 +146,7 @@ func (h *Handle) SetPromiscOn(link Link) error {
 // LinkSetAllmulticastOn enables the reception of all hardware multicast packets for the link device.
 // Equivalent to: `ip link set $link allmulticast on`
 func LinkSetAllmulticastOn(link Link) error {
-	return pkgHandle.LinkSetAllmulticastOn(link)
+	return pkgHandle().LinkSetAllmulticastOn(link)
 }
 
 // LinkSetAllmulticastOn enables the reception of all hardware multicast packets for the link device.
@@ -169,7 +169,7 @@ func (h *Handle) LinkSetAllmulticastOn(link Link) error {
 // LinkSetAllmulticastOff disables the reception of all hardware multicast packets for the link device.
 // Equivalent to: `ip link set $link allmulticast off`
 func LinkSetAllmulticastOff(link Link) error {
-	return pkgHandle.LinkSetAllmulticastOff(link)
+	return pkgHandle().LinkSetAllmulticastOff(link)
 }
 
 // LinkSetAllmulticastOff disables the reception of all hardware multicast packets for the link device.
@@ -191,7 +191,7 @@ func (h *Handle) LinkSetAllmulticastOff(link Link) error {
 // LinkSetMulticastOn enables the reception of multicast packets for the link device.
 // Equivalent to: `ip link set $link multicast on`
 func LinkSetMulticastOn(link Link) error {
-	return pkgHandle.LinkSetMulticastOn(link)
+	return pkgHandle().LinkSetMulticastOn(link)
 }
 
 // LinkSetMulticastOn enables the reception of multicast packets for the link device.
@@ -214,7 +214,7 @@ func (h *Handle) LinkSetMulticastOn(link Link) error {
 // LinkSetAllmulticastOff disables the reception of multicast packets for the link device.
 // Equivalent to: `ip link set $link multicast off`
 func LinkSetMulticastOff(link Link) error {
-	return pkgHandle.LinkSetMulticastOff(link)
+	return pkgHandle().LinkSetMulticastOff(link)
 }
 
 // LinkSetAllmulticastOff disables the reception of multicast packets for the link device.
@@ -234,7 +234,7 @@ func (h *Handle) LinkSetMulticastOff(link Link) error {
 }
 
 func MacvlanMACAddrAdd(link Link, addr net.HardwareAddr) error {
-	return pkgHandle.MacvlanMACAddrAdd(link, addr)
+	return pkgHandle().MacvlanMACAddrAdd(link, addr)
 }
 
 func (h *Handle) MacvlanMACAddrAdd(link Link, addr net.HardwareAddr) error {
@@ -242,7 +242,7 @@ func (h *Handle) MacvlanMACAddrAdd(link Link, addr net.HardwareAddr) error {
 }
 
 func MacvlanMACAddrDel(link Link, addr net.HardwareAddr) error {
-	return pkgHandle.MacvlanMACAddrDel(link, addr)
+	return pkgHandle().MacvlanMACAddrDel(link, addr)
 }
 
 func (h *Handle) MacvlanMACAddrDel(link Link, addr net.HardwareAddr) error {
@@ -250,7 +250,7 @@ func (h *Handle) MacvlanMACAddrDel(link Link, addr net.HardwareAddr) error {
 }
 
 func MacvlanMACAddrFlush(link Link) error {
-	return pkgHandle.MacvlanMACAddrFlush(link)
+	return pkgHandle().MacvlanMACAddrFlush(link)
 }
 
 func (h *Handle) MacvlanMACAddrFlush(link Link) error {
@@ -258,7 +258,7 @@ func (h *Handle) MacvlanMACAddrFlush(link Link) error {
 }
 
 func MacvlanMACAddrSet(link Link, addrs []net.HardwareAddr) error {
-	return pkgHandle.MacvlanMACAddrSet(link, addrs)
+	return pkgHandle().MacvlanMACAddrSet(link, addrs)
 }
 
 func (h *Handle) MacvlanMACAddrSet(link Link, addrs []net.HardwareAddr) error {
@@ -306,7 +306,7 @@ func (h *Handle) macvlanMACAddrChange(link Link, addrs []net.HardwareAddr, mode 
 // Note that passthrough mode cannot be set to and from and will fail.
 // Equivalent to: `ip link set $link type (macvlan|macvtap) mode $mode
 func LinkSetMacvlanMode(link Link, mode MacvlanMode) error {
-	return pkgHandle.LinkSetMacvlanMode(link, mode)
+	return pkgHandle().LinkSetMacvlanMode(link, mode)
 }
 
 // LinkSetMacvlanMode sets the mode of the macvlan or macvtap link device.
@@ -334,7 +334,7 @@ func (h *Handle) LinkSetMacvlanMode(link Link, mode MacvlanMode) error {
 }
 
 func BridgeSetMcastSnoop(link Link, on bool) error {
-	return pkgHandle.BridgeSetMcastSnoop(link, on)
+	return pkgHandle().BridgeSetMcastSnoop(link, on)
 }
 
 func (h *Handle) BridgeSetMcastSnoop(link Link, on bool) error {
@@ -344,7 +344,7 @@ func (h *Handle) BridgeSetMcastSnoop(link Link, on bool) error {
 }
 
 func BridgeSetVlanFiltering(link Link, on bool) error {
-	return pkgHandle.BridgeSetVlanFiltering(link, on)
+	return pkgHandle().BridgeSetVlanFiltering(link, on)
 }
 
 func (h *Handle) BridgeSetVlanFiltering(link Link, on bool) error {
@@ -354,7 +354,7 @@ func (h *Handle) BridgeSetVlanFiltering(link Link, on bool) error {
 }
 
 func BridgeSetVlanDefaultPVID(link Link, pvid uint16) error {
-	return pkgHandle.BridgeSetVlanDefaultPVID(link, pvid)
+	return pkgHandle().BridgeSetVlanDefaultPVID(link, pvid)
 }
 
 func (h *Handle) BridgeSetVlanDefaultPVID(link Link, pvid uint16) error {
@@ -364,7 +364,7 @@ func (h *Handle) BridgeSetVlanDefaultPVID(link Link, pvid uint16) error {
 }
 
 func SetPromiscOn(link Link) error {
-	return pkgHandle.SetPromiscOn(link)
+	return pkgHandle().SetPromiscOn(link)
 }
 
 func (h *Handle) SetPromiscOff(link Link) error {
@@ -382,13 +382,13 @@ func (h *Handle) SetPromiscOff(link Link) error {
 }
 
 func SetPromiscOff(link Link) error {
-	return pkgHandle.SetPromiscOff(link)
+	return pkgHandle().SetPromiscOff(link)
 }
 
 // LinkSetUp enables the link device.
 // Equivalent to: `ip link set $link up`
 func LinkSetUp(link Link) error {
-	return pkgHandle.LinkSetUp(link)
+	return pkgHandle().LinkSetUp(link)
 }
 
 // LinkSetUp enables the link device.
@@ -411,7 +411,7 @@ func (h *Handle) LinkSetUp(link Link) error {
 // LinkSetDown disables link device.
 // Equivalent to: `ip link set $link down`
 func LinkSetDown(link Link) error {
-	return pkgHandle.LinkSetDown(link)
+	return pkgHandle().LinkSetDown(link)
 }
 
 // LinkSetDown disables link device.
@@ -433,7 +433,7 @@ func (h *Handle) LinkSetDown(link Link) error {
 // LinkSetMTU sets the mtu of the link device.
 // Equivalent to: `ip link set $link mtu $mtu`
 func LinkSetMTU(link Link, mtu int) error {
-	return pkgHandle.LinkSetMTU(link, mtu)
+	return pkgHandle().LinkSetMTU(link, mtu)
 }
 
 // LinkSetMTU sets the mtu of the link device.
@@ -460,7 +460,7 @@ func (h *Handle) LinkSetMTU(link Link, mtu int) error {
 // LinkSetName sets the name of the link device.
 // Equivalent to: `ip link set $link name $name`
 func LinkSetName(link Link, name string) error {
-	return pkgHandle.LinkSetName(link, name)
+	return pkgHandle().LinkSetName(link, name)
 }
 
 // LinkSetName sets the name of the link device.
@@ -484,7 +484,7 @@ func (h *Handle) LinkSetName(link Link, name string) error {
 // LinkSetAlias sets the alias of the link device.
 // Equivalent to: `ip link set dev $link alias $name`
 func LinkSetAlias(link Link, name string) error {
-	return pkgHandle.LinkSetAlias(link, name)
+	return pkgHandle().LinkSetAlias(link, name)
 }
 
 // LinkSetAlias sets the alias of the link device.
@@ -508,7 +508,7 @@ func (h *Handle) LinkSetAlias(link Link, name string) error {
 // LinkAddAltName adds a new alternative name for the link device.
 // Equivalent to: `ip link property add $link altname $name`
 func LinkAddAltName(link Link, name string) error {
-	return pkgHandle.LinkAddAltName(link, name)
+	return pkgHandle().LinkAddAltName(link, name)
 }
 
 // LinkAddAltName adds a new alternative name for the link device.
@@ -534,7 +534,7 @@ func (h *Handle) LinkAddAltName(link Link, name string) error {
 // LinkDelAltName delete an alternative name for the link device.
 // Equivalent to: `ip link property del $link altname $name`
 func LinkDelAltName(link Link, name string) error {
-	return pkgHandle.LinkDelAltName(link, name)
+	return pkgHandle().LinkDelAltName(link, name)
 }
 
 // LinkDelAltName delete an alternative name for the link device.
@@ -560,7 +560,7 @@ func (h *Handle) LinkDelAltName(link Link, name string) error {
 // LinkSetHardwareAddr sets the hardware address of the link device.
 // Equivalent to: `ip link set $link address $hwaddr`
 func LinkSetHardwareAddr(link Link, hwaddr net.HardwareAddr) error {
-	return pkgHandle.LinkSetHardwareAddr(link, hwaddr)
+	return pkgHandle().LinkSetHardwareAddr(link, hwaddr)
 }
 
 // LinkSetHardwareAddr sets the hardware address of the link device.
@@ -584,7 +584,7 @@ func (h *Handle) LinkSetHardwareAddr(link Link, hwaddr net.HardwareAddr) error {
 // LinkSetVfHardwareAddr sets the hardware address of a vf for the link.
 // Equivalent to: `ip link set $link vf $vf mac $hwaddr`
 func LinkSetVfHardwareAddr(link Link, vf int, hwaddr net.HardwareAddr) error {
-	return pkgHandle.LinkSetVfHardwareAddr(link, vf, hwaddr)
+	return pkgHandle().LinkSetVfHardwareAddr(link, vf, hwaddr)
 }
 
 // LinkSetVfHardwareAddr sets the hardware address of a vf for the link.
@@ -614,7 +614,7 @@ func (h *Handle) LinkSetVfHardwareAddr(link Link, vf int, hwaddr net.HardwareAdd
 // LinkSetVfVlan sets the vlan of a vf for the link.
 // Equivalent to: `ip link set $link vf $vf vlan $vlan`
 func LinkSetVfVlan(link Link, vf, vlan int) error {
-	return pkgHandle.LinkSetVfVlan(link, vf, vlan)
+	return pkgHandle().LinkSetVfVlan(link, vf, vlan)
 }
 
 // LinkSetVfVlan sets the vlan of a vf for the link.
@@ -644,7 +644,7 @@ func (h *Handle) LinkSetVfVlan(link Link, vf, vlan int) error {
 // LinkSetVfVlanQos sets the vlan and qos priority of a vf for the link.
 // Equivalent to: `ip link set $link vf $vf vlan $vlan qos $qos`
 func LinkSetVfVlanQos(link Link, vf, vlan, qos int) error {
-	return pkgHandle.LinkSetVfVlanQos(link, vf, vlan, qos)
+	return pkgHandle().LinkSetVfVlanQos(link, vf, vlan, qos)
 }
 
 // LinkSetVfVlanQos sets the vlan and qos priority of a vf for the link.
@@ -675,7 +675,7 @@ func (h *Handle) LinkSetVfVlanQos(link Link, vf, vlan, qos int) error {
 // LinkSetVfVlanQosProto sets the vlan, qos and protocol of a vf for the link.
 // Equivalent to: `ip link set $link vf $vf vlan $vlan qos $qos proto $proto`
 func LinkSetVfVlanQosProto(link Link, vf, vlan, qos, proto int) error {
-	return pkgHandle.LinkSetVfVlanQosProto(link, vf, vlan, qos, proto)
+	return pkgHandle().LinkSetVfVlanQosProto(link, vf, vlan, qos, proto)
 }
 
 // LinkSetVfVlanQosProto sets the vlan, qos and protocol of a vf for the link.
@@ -712,7 +712,7 @@ func (h *Handle) LinkSetVfVlanQosProto(link Link, vf, vlan, qos, proto int) erro
 // LinkSetVfTxRate sets the tx rate of a vf for the link.
 // Equivalent to: `ip link set $link vf $vf rate $rate`
 func LinkSetVfTxRate(link Link, vf, rate int) error {
-	return pkgHandle.LinkSetVfTxRate(link, vf, rate)
+	return pkgHandle().LinkSetVfTxRate(link, vf, rate)
 }
 
 // LinkSetVfTxRate sets the tx rate of a vf for the link.
@@ -742,7 +742,7 @@ func (h *Handle) LinkSetVfTxRate(link Link, vf, rate int) error {
 // LinkSetVfRate sets the min and max tx rate of a vf for the link.
 // Equivalent to: `ip link set $link vf $vf min_tx_rate $min_rate max_tx_rate $max_rate`
 func LinkSetVfRate(link Link, vf, minRate, maxRate int) error {
-	return pkgHandle.LinkSetVfRate(link, vf, minRate, maxRate)
+	return pkgHandle().LinkSetVfRate(link, vf, minRate, maxRate)
 }
 
 // LinkSetVfRate sets the min and max tx rate of a vf for the link.
@@ -773,7 +773,7 @@ func (h *Handle) LinkSetVfRate(link Link, vf, minRate, maxRate int) error {
 // LinkSetVfState enables/disables virtual link state on a vf.
 // Equivalent to: `ip link set $link vf $vf state $state`
 func LinkSetVfState(link Link, vf int, state uint32) error {
-	return pkgHandle.LinkSetVfState(link, vf, state)
+	return pkgHandle().LinkSetVfState(link, vf, state)
 }
 
 // LinkSetVfState enables/disables virtual link state on a vf.
@@ -803,7 +803,7 @@ func (h *Handle) LinkSetVfState(link Link, vf int, state uint32) error {
 // LinkSetVfSpoofchk enables/disables spoof check on a vf for the link.
 // Equivalent to: `ip link set $link vf $vf spoofchk $check`
 func LinkSetVfSpoofchk(link Link, vf int, check bool) error {
-	return pkgHandle.LinkSetVfSpoofchk(link, vf, check)
+	return pkgHandle().LinkSetVfSpoofchk(link, vf, check)
 }
 
 // LinkSetVfSpoofchk enables/disables spoof check on a vf for the link.
@@ -837,7 +837,7 @@ func (h *Handle) LinkSetVfSpoofchk(link Link, vf int, check bool) error {
 // LinkSetVfTrust enables/disables trust state on a vf for the link.
 // Equivalent to: `ip link set $link vf $vf trust $state`
 func LinkSetVfTrust(link Link, vf int, state bool) error {
-	return pkgHandle.LinkSetVfTrust(link, vf, state)
+	return pkgHandle().LinkSetVfTrust(link, vf, state)
 }
 
 // LinkSetVfTrust enables/disables trust state on a vf for the link.
@@ -871,13 +871,13 @@ func (h *Handle) LinkSetVfTrust(link Link, vf int, state bool) error {
 // LinkSetVfNodeGUID sets the node GUID of a vf for the link.
 // Equivalent to: `ip link set dev $link vf $vf node_guid $nodeguid`
 func LinkSetVfNodeGUID(link Link, vf int, nodeguid net.HardwareAddr) error {
-	return pkgHandle.LinkSetVfGUID(link, vf, nodeguid, nl.IFLA_VF_IB_NODE_GUID)
+	return pkgHandle().LinkSetVfGUID(link, vf, nodeguid, nl.IFLA_VF_IB_NODE_GUID)
 }
 
 // LinkSetVfPortGUID sets the port GUID of a vf for the link.
 // Equivalent to: `ip link set dev $link vf $vf port_guid $portguid`
 func LinkSetVfPortGUID(link Link, vf int, portguid net.HardwareAddr) error {
-	return pkgHandle.LinkSetVfGUID(link, vf, portguid, nl.IFLA_VF_IB_PORT_GUID)
+	return pkgHandle().LinkSetVfGUID(link, vf, portguid, nl.IFLA_VF_IB_PORT_GUID)
 }
 
 // LinkSetVfGUID sets the node or port GUID of a vf for the link.
@@ -915,7 +915,7 @@ func (h *Handle) LinkSetVfGUID(link Link, vf int, vfGuid net.HardwareAddr, guidT
 // LinkSetMaster sets the master of the link device.
 // Equivalent to: `ip link set $link master $master`
 func LinkSetMaster(link Link, master Link) error {
-	return pkgHandle.LinkSetMaster(link, master)
+	return pkgHandle().LinkSetMaster(link, master)
 }
 
 // LinkSetMaster sets the master of the link device.
@@ -936,7 +936,7 @@ func (h *Handle) LinkSetMaster(link Link, master Link) error {
 // LinkSetNoMaster removes the master of the link device.
 // Equivalent to: `ip link set $link nomaster`
 func LinkSetNoMaster(link Link) error {
-	return pkgHandle.LinkSetNoMaster(link)
+	return pkgHandle().LinkSetNoMaster(link)
 }
 
 // LinkSetNoMaster removes the master of the link device.
@@ -948,7 +948,7 @@ func (h *Handle) LinkSetNoMaster(link Link) error {
 // LinkSetMasterByIndex sets the master of the link device.
 // Equivalent to: `ip link set $link master $master`
 func LinkSetMasterByIndex(link Link, masterIndex int) error {
-	return pkgHandle.LinkSetMasterByIndex(link, masterIndex)
+	return pkgHandle().LinkSetMasterByIndex(link, masterIndex)
 }
 
 // LinkSetMasterByIndex sets the master of the link device.
@@ -976,7 +976,7 @@ func (h *Handle) LinkSetMasterByIndex(link Link, masterIndex int) error {
 // pid must be a pid of a running process.
 // Equivalent to: `ip link set $link netns $pid`
 func LinkSetNsPid(link Link, nspid int) error {
-	return pkgHandle.LinkSetNsPid(link, nspid)
+	return pkgHandle().LinkSetNsPid(link, nspid)
 }
 
 // LinkSetNsPid puts the device into a new network namespace. The
@@ -1005,7 +1005,7 @@ func (h *Handle) LinkSetNsPid(link Link, nspid int) error {
 // fd must be an open file descriptor to a network namespace.
 // Similar to: `ip link set $link netns $ns`
 func LinkSetNsFd(link Link, fd int) error {
-	return pkgHandle.LinkSetNsFd(link, fd)
+	return pkgHandle().LinkSetNsFd(link, fd)
 }
 
 // LinkSetNsFd puts the device into a new network namespace. The
@@ -1056,7 +1056,7 @@ func LinkSetXdpFdWithFlags(link Link, fd, flags int) error {
 // LinkSetGSOMaxSegs sets the GSO maximum segment count of the link device.
 // Equivalent to: `ip link set $link gso_max_segs $maxSegs`
 func LinkSetGSOMaxSegs(link Link, maxSegs int) error {
-	return pkgHandle.LinkSetGSOMaxSegs(link, maxSegs)
+	return pkgHandle().LinkSetGSOMaxSegs(link, maxSegs)
 }
 
 // LinkSetGSOMaxSegs sets the GSO maximum segment count of the link device.
@@ -1083,7 +1083,7 @@ func (h *Handle) LinkSetGSOMaxSegs(link Link, maxSize int) error {
 // LinkSetGSOMaxSize sets the IPv6 GSO maximum size of the link device.
 // Equivalent to: `ip link set $link gso_max_size $maxSize`
 func LinkSetGSOMaxSize(link Link, maxSize int) error {
-	return pkgHandle.LinkSetGSOMaxSize(link, maxSize)
+	return pkgHandle().LinkSetGSOMaxSize(link, maxSize)
 }
 
 // LinkSetGSOMaxSize sets the IPv6 GSO maximum size of the link device.
@@ -1110,7 +1110,7 @@ func (h *Handle) LinkSetGSOMaxSize(link Link, maxSize int) error {
 // LinkSetGROMaxSize sets the IPv6 GRO maximum size of the link device.
 // Equivalent to: `ip link set $link gro_max_size $maxSize`
 func LinkSetGROMaxSize(link Link, maxSize int) error {
-	return pkgHandle.LinkSetGROMaxSize(link, maxSize)
+	return pkgHandle().LinkSetGROMaxSize(link, maxSize)
 }
 
 // LinkSetGROMaxSize sets the IPv6 GRO maximum size of the link device.
@@ -1137,7 +1137,7 @@ func (h *Handle) LinkSetGROMaxSize(link Link, maxSize int) error {
 // LinkSetGSOIPv4MaxSize sets the IPv4 GSO maximum size of the link device.
 // Equivalent to: `ip link set $link gso_ipv4_max_size $maxSize`
 func LinkSetGSOIPv4MaxSize(link Link, maxSize int) error {
-	return pkgHandle.LinkSetGSOIPv4MaxSize(link, maxSize)
+	return pkgHandle().LinkSetGSOIPv4MaxSize(link, maxSize)
 }
 
 // LinkSetGSOIPv4MaxSize sets the IPv4 GSO maximum size of the link device.
@@ -1164,7 +1164,7 @@ func (h *Handle) LinkSetGSOIPv4MaxSize(link Link, maxSize int) error {
 // LinkSetGROIPv4MaxSize sets the IPv4 GRO maximum size of the link device.
 // Equivalent to: `ip link set $link gro_ipv4_max_size $maxSize`
 func LinkSetGROIPv4MaxSize(link Link, maxSize int) error {
-	return pkgHandle.LinkSetGROIPv4MaxSize(link, maxSize)
+	return pkgHandle().LinkSetGROIPv4MaxSize(link, maxSize)
 }
 
 // LinkSetGROIPv4MaxSize sets the IPv4 GRO maximum size of the link device.
@@ -1192,7 +1192,7 @@ func (h *Handle) LinkSetGROIPv4MaxSize(link Link, maxSize int) error {
 // Equivalent to: `ip link set $link type vxlan { remote | group } $group`
 // Note: netlink does not support changing the group address family. If attempted, this will return an EOPNOTSUPP error.
 func LinkSetVXLANGroup(link *Vxlan, group net.IP) error {
-	return pkgHandle.LinkSetVXLANGroup(link, group)
+	return pkgHandle().LinkSetVXLANGroup(link, group)
 }
 
 // LinkSetVXLANGroup sets the group address of a VXLAN link device.
@@ -1234,7 +1234,7 @@ func (h *Handle) LinkSetVXLANGroup(link *Vxlan, group net.IP) error {
 // LinkSetVXLANVtepDevIndex sets the VTEP device index of a VXLAN link device.
 // Equivalent to: `ip link set $link type [ dev $dev ]`
 func LinkSetVXLANVtepDevIndex(link *Vxlan, ifIndex int) error {
-	return pkgHandle.LinkSetVXLANVtepDevIndex(link, ifIndex)
+	return pkgHandle().LinkSetVXLANVtepDevIndex(link, ifIndex)
 }
 
 // LinkSetVXLANVtepDevIndex sets the VTEP device index of a VXLAN link device.
@@ -1458,7 +1458,7 @@ func cleanupFds(fds []*os.File) {
 // are taken from the parameters in the link object.
 // Equivalent to: `ip link add $link`
 func LinkAdd(link Link) error {
-	return pkgHandle.LinkAdd(link)
+	return pkgHandle().LinkAdd(link)
 }
 
 // LinkAdd adds a new link device. The type and features of the device
@@ -1469,7 +1469,7 @@ func (h *Handle) LinkAdd(link Link) error {
 }
 
 func LinkModify(link Link) error {
-	return pkgHandle.LinkModify(link)
+	return pkgHandle().LinkModify(link)
 }
 
 func (h *Handle) LinkModify(link Link) error {
@@ -1949,7 +1949,7 @@ func (h *Handle) linkModify(link Link, flags int) error {
 // the link object for it to be deleted. The other values are ignored.
 // Equivalent to: `ip link del $link`
 func LinkDel(link Link) error {
-	return pkgHandle.LinkDel(link)
+	return pkgHandle().LinkDel(link)
 }
 
 // LinkDel deletes link device. Either Index or Name must be set in
@@ -2011,7 +2011,7 @@ func (h *Handle) linkByAliasDump(alias string) (Link, error) {
 // filtering a dump of all link names. In this case, if the returned error is
 // [ErrDumpInterrupted] the result may be missing or outdated.
 func LinkByName(name string) (Link, error) {
-	return pkgHandle.LinkByName(name)
+	return pkgHandle().LinkByName(name)
 }
 
 // LinkByName finds a link by name and returns a pointer to the object.
@@ -2057,7 +2057,7 @@ func (h *Handle) LinkByName(name string) (Link, error) {
 // filtering a dump of all link names. In this case, if the returned error is
 // [ErrDumpInterrupted] the result may be missing or outdated.
 func LinkByAlias(alias string) (Link, error) {
-	return pkgHandle.LinkByAlias(alias)
+	return pkgHandle().LinkByAlias(alias)
 }
 
 // LinkByAlias finds a link by its alias and returns a pointer to the object.
@@ -2096,7 +2096,7 @@ func (h *Handle) LinkByAlias(alias string) (Link, error) {
 
 // LinkByIndex finds a link by index and returns a pointer to the object.
 func LinkByIndex(index int) (Link, error) {
-	return pkgHandle.LinkByIndex(index)
+	return pkgHandle().LinkByIndex(index)
 }
 
 // LinkByIndex finds a link by index and returns a pointer to the object.
@@ -2512,7 +2512,7 @@ func readSysPropAsInt64(ifname, prop string) (int64, error) {
 // LinkList gets a list of link devices.
 // Equivalent to: `ip link show`
 func LinkList() ([]Link, error) {
-	return pkgHandle.LinkList()
+	return pkgHandle().LinkList()
 }
 
 // LinkList gets a list of link devices.
@@ -2619,7 +2619,7 @@ func linkSubscribeAt(newNs, curNs netns.NsHandle, ch chan<- LinkUpdate, done <-c
 		}()
 	}
 	if listExisting {
-		req := pkgHandle.newNetlinkRequest(unix.RTM_GETLINK,
+		req := pkgHandle().newNetlinkRequest(unix.RTM_GETLINK,
 			unix.NLM_F_DUMP)
 		msg := nl.NewIfInfomsg(unix.AF_UNSPEC)
 		req.AddData(msg)
@@ -2680,7 +2680,7 @@ func linkSubscribeAt(newNs, curNs netns.NsHandle, ch chan<- LinkUpdate, done <-c
 }
 
 func LinkSetHairpin(link Link, mode bool) error {
-	return pkgHandle.LinkSetHairpin(link, mode)
+	return pkgHandle().LinkSetHairpin(link, mode)
 }
 
 func (h *Handle) LinkSetHairpin(link Link, mode bool) error {
@@ -2688,7 +2688,7 @@ func (h *Handle) LinkSetHairpin(link Link, mode bool) error {
 }
 
 func LinkSetGuard(link Link, mode bool) error {
-	return pkgHandle.LinkSetGuard(link, mode)
+	return pkgHandle().LinkSetGuard(link, mode)
 }
 
 func (h *Handle) LinkSetGuard(link Link, mode bool) error {
@@ -2697,7 +2697,7 @@ func (h *Handle) LinkSetGuard(link Link, mode bool) error {
 
 // LinkSetBRSlaveGroupFwdMask set the group_fwd_mask of a bridge slave interface
 func LinkSetBRSlaveGroupFwdMask(link Link, mask uint16) error {
-	return pkgHandle.LinkSetBRSlaveGroupFwdMask(link, mask)
+	return pkgHandle().LinkSetBRSlaveGroupFwdMask(link, mask)
 }
 
 // LinkSetBRSlaveGroupFwdMask set the group_fwd_mask of a bridge slave interface
@@ -2706,7 +2706,7 @@ func (h *Handle) LinkSetBRSlaveGroupFwdMask(link Link, mask uint16) error {
 }
 
 func LinkSetFastLeave(link Link, mode bool) error {
-	return pkgHandle.LinkSetFastLeave(link, mode)
+	return pkgHandle().LinkSetFastLeave(link, mode)
 }
 
 func (h *Handle) LinkSetFastLeave(link Link, mode bool) error {
@@ -2714,7 +2714,7 @@ func (h *Handle) LinkSetFastLeave(link Link, mode bool) error {
 }
 
 func LinkSetLearning(link Link, mode bool) error {
-	return pkgHandle.LinkSetLearning(link, mode)
+	return pkgHandle().LinkSetLearning(link, mode)
 }
 
 func (h *Handle) LinkSetLearning(link Link, mode bool) error {
@@ -2722,7 +2722,7 @@ func (h *Handle) LinkSetLearning(link Link, mode bool) error {
 }
 
 func LinkSetVlanTunnel(link Link, mode bool) error {
-	return pkgHandle.LinkSetVlanTunnel(link, mode)
+	return pkgHandle().LinkSetVlanTunnel(link, mode)
 }
 
 func (h *Handle) LinkSetVlanTunnel(link Link, mode bool) error {
@@ -2730,7 +2730,7 @@ func (h *Handle) LinkSetVlanTunnel(link Link, mode bool) error {
 }
 
 func LinkSetRootBlock(link Link, mode bool) error {
-	return pkgHandle.LinkSetRootBlock(link, mode)
+	return pkgHandle().LinkSetRootBlock(link, mode)
 }
 
 func (h *Handle) LinkSetRootBlock(link Link, mode bool) error {
@@ -2738,7 +2738,7 @@ func (h *Handle) LinkSetRootBlock(link Link, mode bool) error {
 }
 
 func LinkSetFlood(link Link, mode bool) error {
-	return pkgHandle.LinkSetFlood(link, mode)
+	return pkgHandle().LinkSetFlood(link, mode)
 }
 
 func (h *Handle) LinkSetFlood(link Link, mode bool) error {
@@ -2746,7 +2746,7 @@ func (h *Handle) LinkSetFlood(link Link, mode bool) error {
 }
 
 func LinkSetIsolated(link Link, mode bool) error {
-	return pkgHandle.LinkSetIsolated(link, mode)
+	return pkgHandle().LinkSetIsolated(link, mode)
 }
 
 func (h *Handle) LinkSetIsolated(link Link, mode bool) error {
@@ -2754,7 +2754,7 @@ func (h *Handle) LinkSetIsolated(link Link, mode bool) error {
 }
 
 func LinkSetBrProxyArp(link Link, mode bool) error {
-	return pkgHandle.LinkSetBrProxyArp(link, mode)
+	return pkgHandle().LinkSetBrProxyArp(link, mode)
 }
 
 func (h *Handle) LinkSetBrProxyArp(link Link, mode bool) error {
@@ -2762,7 +2762,7 @@ func (h *Handle) LinkSetBrProxyArp(link Link, mode bool) error {
 }
 
 func LinkSetBrProxyArpWiFi(link Link, mode bool) error {
-	return pkgHandle.LinkSetBrProxyArpWiFi(link, mode)
+	return pkgHandle().LinkSetBrProxyArpWiFi(link, mode)
 }
 
 func (h *Handle) LinkSetBrProxyArpWiFi(link Link, mode bool) error {
@@ -2770,7 +2770,7 @@ func (h *Handle) LinkSetBrProxyArpWiFi(link Link, mode bool) error {
 }
 
 func LinkSetBrNeighSuppress(link Link, mode bool) error {
-	return pkgHandle.LinkSetBrNeighSuppress(link, mode)
+	return pkgHandle().LinkSetBrNeighSuppress(link, mode)
 }
 
 func (h *Handle) LinkSetBrNeighSuppress(link Link, mode bool) error {
@@ -2802,7 +2802,7 @@ func (h *Handle) setProtinfoAttr(link Link, mode bool, attr int) error {
 // LinkSetTxQLen sets the transaction queue length for the link.
 // Equivalent to: `ip link set $link txqlen $qlen`
 func LinkSetTxQLen(link Link, qlen int) error {
-	return pkgHandle.LinkSetTxQLen(link, qlen)
+	return pkgHandle().LinkSetTxQLen(link, qlen)
 }
 
 // LinkSetTxQLen sets the transaction queue length for the link.
@@ -2830,7 +2830,7 @@ func (h *Handle) LinkSetTxQLen(link Link, qlen int) error {
 // with iproute2 as well use it as a reference in nft filters.
 // Equivalent to: `ip link set $link group $id`
 func LinkSetGroup(link Link, group int) error {
-	return pkgHandle.LinkSetGroup(link, group)
+	return pkgHandle().LinkSetGroup(link, group)
 }
 
 // LinkSetGroup sets the link group id which can be used to perform mass actions
@@ -2858,7 +2858,7 @@ func (h *Handle) LinkSetGroup(link Link, group int) error {
 // LinkSetIP6AddrGenMode sets the IPv6 address generation mode of the link device.
 // Equivalent to: `ip link set $link addrgenmode $mode`
 func LinkSetIP6AddrGenMode(link Link, mode int) error {
-	return pkgHandle.LinkSetIP6AddrGenMode(link, mode)
+	return pkgHandle().LinkSetIP6AddrGenMode(link, mode)
 }
 
 // LinkSetIP6AddrGenMode sets the IPv6 address generation mode of the link device.
@@ -4141,7 +4141,7 @@ func (h *Handle) LinkSetBondSlaveQueueId(link Link, queueId uint16) error {
 
 // LinkSetBondSlaveQueueId modify bond slave queue-id.
 func LinkSetBondSlaveQueueId(link Link, queueId uint16) error {
-	return pkgHandle.LinkSetBondSlaveQueueId(link, queueId)
+	return pkgHandle().LinkSetBondSlaveQueueId(link, queueId)
 }
 
 func vethStatsSerialize(stats ethtoolStats) ([]byte, error) {

--- a/link_test.go
+++ b/link_test.go
@@ -3672,7 +3672,7 @@ func TestLinkSetBondSlaveQueueId(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := pkgHandle.LinkSetBondSlaveQueueId(slave, 1); err != nil {
+	if err := LinkSetBondSlaveQueueId(slave, 1); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/neigh_linux.go
+++ b/neigh_linux.go
@@ -87,7 +87,7 @@ func (msg *Ndmsg) Len() int {
 // NeighAdd will add an IP to MAC mapping to the ARP table
 // Equivalent to: `ip neigh add ....`
 func NeighAdd(neigh *Neigh) error {
-	return pkgHandle.NeighAdd(neigh)
+	return pkgHandle().NeighAdd(neigh)
 }
 
 // NeighAdd will add an IP to MAC mapping to the ARP table
@@ -99,7 +99,7 @@ func (h *Handle) NeighAdd(neigh *Neigh) error {
 // NeighSet will add or replace an IP to MAC mapping to the ARP table
 // Equivalent to: `ip neigh replace....`
 func NeighSet(neigh *Neigh) error {
-	return pkgHandle.NeighSet(neigh)
+	return pkgHandle().NeighSet(neigh)
 }
 
 // NeighSet will add or replace an IP to MAC mapping to the ARP table
@@ -111,7 +111,7 @@ func (h *Handle) NeighSet(neigh *Neigh) error {
 // NeighAppend will append an entry to FDB
 // Equivalent to: `bridge fdb append...`
 func NeighAppend(neigh *Neigh) error {
-	return pkgHandle.NeighAppend(neigh)
+	return pkgHandle().NeighAppend(neigh)
 }
 
 // NeighAppend will append an entry to FDB
@@ -123,7 +123,7 @@ func (h *Handle) NeighAppend(neigh *Neigh) error {
 // NeighAppend will append an entry to FDB
 // Equivalent to: `bridge fdb append...`
 func neighAdd(neigh *Neigh, mode int) error {
-	return pkgHandle.neighAdd(neigh, mode)
+	return pkgHandle().neighAdd(neigh, mode)
 }
 
 // NeighAppend will append an entry to FDB
@@ -136,7 +136,7 @@ func (h *Handle) neighAdd(neigh *Neigh, mode int) error {
 // NeighDel will delete an IP address from a link device.
 // Equivalent to: `ip addr del $addr dev $link`
 func NeighDel(neigh *Neigh) error {
-	return pkgHandle.NeighDel(neigh)
+	return pkgHandle().NeighDel(neigh)
 }
 
 // NeighDel will delete an IP address from a link device.
@@ -211,7 +211,7 @@ func neighHandle(neigh *Neigh, req *nl.NetlinkRequest) error {
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func NeighList(linkIndex, family int) ([]Neigh, error) {
-	return pkgHandle.NeighList(linkIndex, family)
+	return pkgHandle().NeighList(linkIndex, family)
 }
 
 // NeighProxyList returns a list of neighbor proxies in the system.
@@ -221,7 +221,7 @@ func NeighList(linkIndex, family int) ([]Neigh, error) {
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func NeighProxyList(linkIndex, family int) ([]Neigh, error) {
-	return pkgHandle.NeighProxyList(linkIndex, family)
+	return pkgHandle().NeighProxyList(linkIndex, family)
 }
 
 // NeighList returns a list of IP-MAC mappings in the system (ARP table).
@@ -256,7 +256,7 @@ func (h *Handle) NeighProxyList(linkIndex, family int) ([]Neigh, error) {
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func NeighListExecute(msg Ndmsg) ([]Neigh, error) {
-	return pkgHandle.NeighListExecute(msg)
+	return pkgHandle().NeighListExecute(msg)
 }
 
 // NeighListExecute returns a list of neighbour entries filtered by link, ip family, flag and state.
@@ -404,7 +404,7 @@ func neighSubscribeAt(newNs, curNs netns.NsHandle, ch chan<- NeighUpdate, done <
 	rcvbuf int, rcvTimeout *unix.Timeval, rcvbufForce bool) error {
 	s, err := nl.SubscribeAt(newNs, curNs, unix.NETLINK_ROUTE, unix.RTNLGRP_NEIGH)
 	makeRequest := func(family int) error {
-		req := pkgHandle.newNetlinkRequest(unix.RTM_GETNEIGH, unix.NLM_F_DUMP)
+		req := pkgHandle().newNetlinkRequest(unix.RTM_GETNEIGH, unix.NLM_F_DUMP)
 		ndmsg := &Ndmsg{Family: uint8(family)}
 		req.AddData(ndmsg)
 		if err := s.Send(req); err != nil {

--- a/netlink_test.go
+++ b/netlink_test.go
@@ -81,12 +81,6 @@ func setUpNetlinkTest(t testing.TB) tearDownNetlinkTest {
 		runtime.UnlockOSThread()
 		t.Fatal("Failed to create new namespace:", err)
 	}
-	// Reinitialize the package-level handle in this namespace
-	if pkgHandle != nil {
-		// ensure all sockets from the previous Handle are closed
-		_ = pkgHandle.Close()
-	}
-	pkgHandle = &Handle{}
 
 	return func() {
 		// Close the new namespace handle

--- a/netns_linux.go
+++ b/netns_linux.go
@@ -36,7 +36,7 @@ func (h *Handle) GetNetNsIdByPid(pid int) (int, error) {
 // GetNetNsIdByPid looks up the network namespace ID for a given pid (really thread id).
 // Returns -1 if the namespace does not have an ID set.
 func GetNetNsIdByPid(pid int) (int, error) {
-	return pkgHandle.GetNetNsIdByPid(pid)
+	return pkgHandle().GetNetNsIdByPid(pid)
 }
 
 // SetNetNSIdByPid sets the ID of the network namespace for a given pid (really thread id).
@@ -48,7 +48,7 @@ func (h *Handle) SetNetNsIdByPid(pid, nsid int) error {
 // SetNetNSIdByPid sets the ID of the network namespace for a given pid (really thread id).
 // The ID can only be set for namespaces without an ID already set.
 func SetNetNsIdByPid(pid, nsid int) error {
-	return pkgHandle.SetNetNsIdByPid(pid, nsid)
+	return pkgHandle().SetNetNsIdByPid(pid, nsid)
 }
 
 // GetNetNsIdByFd looks up the network namespace ID for a given fd.
@@ -62,7 +62,7 @@ func (h *Handle) GetNetNsIdByFd(fd int) (int, error) {
 // fd must be an open file descriptor to a namespace file.
 // Returns -1 if the namespace does not have an ID set.
 func GetNetNsIdByFd(fd int) (int, error) {
-	return pkgHandle.GetNetNsIdByFd(fd)
+	return pkgHandle().GetNetNsIdByFd(fd)
 }
 
 // SetNetNSIdByFd sets the ID of the network namespace for a given fd.
@@ -76,7 +76,7 @@ func (h *Handle) SetNetNsIdByFd(fd, nsid int) error {
 // fd must be an open file descriptor to a namespace file.
 // The ID can only be set for namespaces without an ID already set.
 func SetNetNsIdByFd(fd, nsid int) error {
-	return pkgHandle.SetNetNsIdByFd(fd, nsid)
+	return pkgHandle().SetNetNsIdByFd(fd, nsid)
 }
 
 // getNetNsId requests the netnsid for a given type-val pair

--- a/nexthop_linux.go
+++ b/nexthop_linux.go
@@ -11,7 +11,7 @@ import (
 // NexthopAdd will add a nexthop to the system.
 // Equivalent to: `ip nexthop add $nexthop`
 func NexthopAdd(nh *Nexthop) error {
-	return pkgHandle.NexthopAdd(nh)
+	return pkgHandle().NexthopAdd(nh)
 }
 
 // NexthopAdd will add a nexthop to the system.
@@ -29,7 +29,7 @@ func (h *Handle) NexthopAdd(nh *Nexthop) error {
 // NexthopReplace will replace a nexthop in the system.
 // Equivalent to: `ip nexthop replace $nexthop`
 func NexthopReplace(nh *Nexthop) error {
-	return pkgHandle.NexthopReplace(nh)
+	return pkgHandle().NexthopReplace(nh)
 }
 
 // NexthopReplace will replace a nexthop in the system.
@@ -47,7 +47,7 @@ func (h *Handle) NexthopReplace(nh *Nexthop) error {
 // NexthopDel will delete a nexthop from the system.
 // Equivalent to: `ip nexthop del $nexthop`
 func NexthopDel(nh *Nexthop) error {
-	return pkgHandle.NexthopDel(nh)
+	return pkgHandle().NexthopDel(nh)
 }
 
 // NexthopDel will delete a nexthop from the system.
@@ -67,7 +67,7 @@ func (h *Handle) NexthopDel(nh *Nexthop) error {
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func NexthopList() ([]Nexthop, error) {
-	return pkgHandle.NexthopList()
+	return pkgHandle().NexthopList()
 }
 
 // NexthopList gets a list of nexthop in the system.

--- a/protinfo_linux.go
+++ b/protinfo_linux.go
@@ -12,7 +12,7 @@ import (
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func LinkGetProtinfo(link Link) (Protinfo, error) {
-	return pkgHandle.LinkGetProtinfo(link)
+	return pkgHandle().LinkGetProtinfo(link)
 }
 
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent

--- a/qdisc_linux.go
+++ b/qdisc_linux.go
@@ -84,7 +84,7 @@ func NewNetem(attrs QdiscAttrs, nattrs NetemQdiscAttrs) *Netem {
 // QdiscDel will delete a qdisc from the system.
 // Equivalent to: `tc qdisc del $qdisc`
 func QdiscDel(qdisc Qdisc) error {
-	return pkgHandle.QdiscDel(qdisc)
+	return pkgHandle().QdiscDel(qdisc)
 }
 
 // QdiscDel will delete a qdisc from the system.
@@ -97,7 +97,7 @@ func (h *Handle) QdiscDel(qdisc Qdisc) error {
 // Equivalent to: `tc qdisc change $qdisc`
 // The parent and handle MUST NOT be changed.
 func QdiscChange(qdisc Qdisc) error {
-	return pkgHandle.QdiscChange(qdisc)
+	return pkgHandle().QdiscChange(qdisc)
 }
 
 // QdiscChange will change a qdisc in place
@@ -111,7 +111,7 @@ func (h *Handle) QdiscChange(qdisc Qdisc) error {
 // Equivalent to: `tc qdisc replace $qdisc`
 // The handle MUST change.
 func QdiscReplace(qdisc Qdisc) error {
-	return pkgHandle.QdiscReplace(qdisc)
+	return pkgHandle().QdiscReplace(qdisc)
 }
 
 // QdiscReplace will replace a qdisc to the system.
@@ -127,7 +127,7 @@ func (h *Handle) QdiscReplace(qdisc Qdisc) error {
 // QdiscAdd will add a qdisc to the system.
 // Equivalent to: `tc qdisc add $qdisc`
 func QdiscAdd(qdisc Qdisc) error {
-	return pkgHandle.QdiscAdd(qdisc)
+	return pkgHandle().QdiscAdd(qdisc)
 }
 
 // QdiscAdd will add a qdisc to the system.
@@ -343,7 +343,7 @@ func qdiscPayload(req *nl.NetlinkRequest, qdisc Qdisc) error {
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func QdiscList(link Link) ([]Qdisc, error) {
-	return pkgHandle.QdiscList(link)
+	return pkgHandle().QdiscList(link)
 }
 
 // QdiscList gets a list of qdiscs in the system.

--- a/rdma_link_linux.go
+++ b/rdma_link_linux.go
@@ -96,7 +96,7 @@ func execRdmaSetLink(req *nl.NetlinkRequest) error {
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func RdmaLinkList() ([]*RdmaLink, error) {
-	return pkgHandle.RdmaLinkList()
+	return pkgHandle().RdmaLinkList()
 }
 
 // RdmaLinkList gets a list of RDMA link devices.
@@ -131,7 +131,7 @@ func (h *Handle) RdmaLinkList() ([]*RdmaLink, error) {
 // If the returned error is [ErrDumpInterrupted], the result may be missing or
 // outdated and the caller should retry.
 func RdmaLinkByName(name string) (*RdmaLink, error) {
-	return pkgHandle.RdmaLinkByName(name)
+	return pkgHandle().RdmaLinkByName(name)
 }
 
 // RdmaLinkByName finds a link by name and returns a pointer to the object if
@@ -156,7 +156,7 @@ func (h *Handle) RdmaLinkByName(name string) (*RdmaLink, error) {
 // or error otherwise.
 // Equivalent to: `rdma dev set $old_devname name $name`
 func RdmaLinkSetName(link *RdmaLink, name string) error {
-	return pkgHandle.RdmaLinkSetName(link, name)
+	return pkgHandle().RdmaLinkSetName(link, name)
 }
 
 // RdmaLinkSetName sets the name of the rdma link device. Return nil on success
@@ -215,7 +215,7 @@ func executeOneGetRdmaNetnsMode(data []byte) (string, error) {
 // otherwise.
 // Equivalent to: `rdma system show netns'
 func RdmaSystemGetNetnsMode() (string, error) {
-	return pkgHandle.RdmaSystemGetNetnsMode()
+	return pkgHandle().RdmaSystemGetNetnsMode()
 }
 
 // RdmaSystemGetNetnsMode gets the net namespace mode for RDMA subsystem
@@ -252,7 +252,7 @@ func netnsModeStringToUint8(mode string) (uint8, error) {
 // Returns nil on success or appropriate error code.
 // Equivalent to: `rdma system set netns { shared | exclusive }'
 func RdmaSystemSetNetnsMode(NewMode string) error {
-	return pkgHandle.RdmaSystemSetNetnsMode(NewMode)
+	return pkgHandle().RdmaSystemSetNetnsMode(NewMode)
 }
 
 // RdmaSystemSetNetnsMode sets the net namespace mode for RDMA subsystem
@@ -278,7 +278,7 @@ func (h *Handle) RdmaSystemSetNetnsMode(NewMode string) error {
 // fd must be an open file descriptor to a network namespace.
 // Similar to: `rdma dev set $dev netns $ns`
 func RdmaLinkSetNsFd(link *RdmaLink, fd uint32) error {
-	return pkgHandle.RdmaLinkSetNsFd(link, fd)
+	return pkgHandle().RdmaLinkSetNsFd(link, fd)
 }
 
 // RdmaLinkSetNsFd puts the RDMA device into a new network namespace. The
@@ -303,7 +303,7 @@ func (h *Handle) RdmaLinkSetNsFd(link *RdmaLink, fd uint32) error {
 // Similar to: rdma link delete NAME
 // REF: https://man7.org/linux/man-pages/man8/rdma-link.8.html
 func RdmaLinkDel(name string) error {
-	return pkgHandle.RdmaLinkDel(name)
+	return pkgHandle().RdmaLinkDel(name)
 }
 
 // RdmaLinkDel deletes an rdma link.
@@ -337,7 +337,7 @@ func (h *Handle) RdmaLinkDel(name string) error {
 //
 // REF: https://man7.org/linux/man-pages/man8/rdma-link.8.html
 func RdmaLinkAdd(linkName, linkType, netdev string) error {
-	return pkgHandle.RdmaLinkAdd(linkName, linkType, netdev)
+	return pkgHandle().RdmaLinkAdd(linkName, linkType, netdev)
 }
 
 // RdmaLinkAdd adds an rdma link for the specified type to the network device.
@@ -367,7 +367,7 @@ type RdmaResource struct {
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func RdmaResourceList() ([]*RdmaResource, error) {
-	return pkgHandle.RdmaResourceList()
+	return pkgHandle().RdmaResourceList()
 }
 
 // RdmaResourceList list rdma resource tracking information
@@ -489,7 +489,7 @@ type RdmaDeviceStatistic struct {
 // otherwise.
 // Equivalent to: `rdma statistic show link [DEV]'
 func RdmaStatistic(link *RdmaLink) (*RdmaDeviceStatistic, error) {
-	return pkgHandle.RdmaStatistic(link)
+	return pkgHandle().RdmaStatistic(link)
 }
 
 // RdmaStatistic get rdma device statistic counters
@@ -513,7 +513,7 @@ func (h *Handle) RdmaStatistic(link *RdmaLink) (*RdmaDeviceStatistic, error) {
 // otherwise.
 // Equivalent to: `rdma statistic show link [DEV/PORT]'
 func RdmaPortStatisticList(link *RdmaLink, port uint32) (*RdmaPortStatistic, error) {
-	return pkgHandle.RdmaPortStatisticList(link, port)
+	return pkgHandle().RdmaPortStatisticList(link, port)
 }
 
 // RdmaPortStatisticList get rdma device port statistic counters

--- a/route_linux.go
+++ b/route_linux.go
@@ -821,7 +821,7 @@ func (v *Via) Decode(b []byte) error {
 // RouteAdd will add a route to the system.
 // Equivalent to: `ip route add $route`
 func RouteAdd(route *Route) error {
-	return pkgHandle.RouteAdd(route)
+	return pkgHandle().RouteAdd(route)
 }
 
 // RouteAdd will add a route to the system.
@@ -836,7 +836,7 @@ func (h *Handle) RouteAdd(route *Route) error {
 // RouteAppend will append a route to the system.
 // Equivalent to: `ip route append $route`
 func RouteAppend(route *Route) error {
-	return pkgHandle.RouteAppend(route)
+	return pkgHandle().RouteAppend(route)
 }
 
 // RouteAppend will append a route to the system.
@@ -850,7 +850,7 @@ func (h *Handle) RouteAppend(route *Route) error {
 
 // RouteAddEcmp will add a route to the system.
 func RouteAddEcmp(route *Route) error {
-	return pkgHandle.RouteAddEcmp(route)
+	return pkgHandle().RouteAddEcmp(route)
 }
 
 // RouteAddEcmp will add a route to the system.
@@ -864,7 +864,7 @@ func (h *Handle) RouteAddEcmp(route *Route) error {
 // RouteChange will change an existing route in the system.
 // Equivalent to: `ip route change $route`
 func RouteChange(route *Route) error {
-	return pkgHandle.RouteChange(route)
+	return pkgHandle().RouteChange(route)
 }
 
 // RouteChange will change an existing route in the system.
@@ -879,7 +879,7 @@ func (h *Handle) RouteChange(route *Route) error {
 // RouteReplace will add a route to the system.
 // Equivalent to: `ip route replace $route`
 func RouteReplace(route *Route) error {
-	return pkgHandle.RouteReplace(route)
+	return pkgHandle().RouteReplace(route)
 }
 
 // RouteReplace will add a route to the system.
@@ -894,7 +894,7 @@ func (h *Handle) RouteReplace(route *Route) error {
 // RouteDel will delete a route from the system.
 // Equivalent to: `ip route del $route`
 func RouteDel(route *Route) error {
-	return pkgHandle.RouteDel(route)
+	return pkgHandle().RouteDel(route)
 }
 
 // RouteDel will delete a route from the system.
@@ -1223,7 +1223,7 @@ func (h *Handle) prepareRouteReq(route *Route, req *nl.NetlinkRequest, msg *nl.R
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func RouteList(link Link, family int) ([]Route, error) {
-	return pkgHandle.RouteList(link, family)
+	return pkgHandle().RouteList(link, family)
 }
 
 // RouteList gets a list of routes in the system.
@@ -1245,7 +1245,7 @@ func (h *Handle) RouteList(link Link, family int) ([]Route, error) {
 // RouteListFiltered gets a list of routes in the system filtered with specified rules.
 // All rules must be defined in RouteFilter struct
 func RouteListFiltered(family int, filter *Route, filterMask uint64) ([]Route, error) {
-	return pkgHandle.RouteListFiltered(family, filter, filterMask)
+	return pkgHandle().RouteListFiltered(family, filter, filterMask)
 }
 
 // RouteListFiltered gets a list of routes in the system filtered with specified rules.
@@ -1271,7 +1271,7 @@ func (h *Handle) RouteListFiltered(family int, filter *Route, filterMask uint64)
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func RouteListFilteredIter(family int, filter *Route, filterMask uint64, f func(Route) (cont bool)) error {
-	return pkgHandle.RouteListFilteredIter(family, filter, filterMask, f)
+	return pkgHandle().RouteListFilteredIter(family, filter, filterMask, f)
 }
 
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
@@ -1634,13 +1634,13 @@ type RouteGetOptions struct {
 // RouteGetWithOptions gets a route to a specific destination from the host system.
 // Equivalent to: 'ip route get <> vrf <VrfName>'.
 func RouteGetWithOptions(destination net.IP, options *RouteGetOptions) ([]Route, error) {
-	return pkgHandle.RouteGetWithOptions(destination, options)
+	return pkgHandle().RouteGetWithOptions(destination, options)
 }
 
 // RouteGet gets a route to a specific destination from the host system.
 // Equivalent to: 'ip route get'.
 func RouteGet(destination net.IP) ([]Route, error) {
-	return pkgHandle.RouteGet(destination)
+	return pkgHandle().RouteGet(destination)
 }
 
 // RouteGetWithOptions gets a route to a specific destination from the host system.
@@ -1833,7 +1833,7 @@ func routeSubscribeAt(newNs, curNs netns.NsHandle, ch chan<- RouteUpdate, done <
 		}()
 	}
 	if listExisting {
-		req := pkgHandle.newNetlinkRequest(unix.RTM_GETROUTE,
+		req := pkgHandle().newNetlinkRequest(unix.RTM_GETROUTE,
 			unix.NLM_F_DUMP)
 		infmsg := nl.NewIfInfomsg(unix.AF_UNSPEC)
 		req.AddData(infmsg)

--- a/route_test.go
+++ b/route_test.go
@@ -1088,7 +1088,7 @@ func BenchmarkRouteListFilteredNew(b *testing.B) {
 	b.ReportAllocs()
 	var routes []Route
 	for i := 0; i < b.N; i++ {
-		routes, err = pkgHandle.RouteListFiltered(FAMILY_V4, &Route{
+		routes, err = RouteListFiltered(FAMILY_V4, &Route{
 			LinkIndex: link.Attrs().Index,
 		}, RT_FILTER_OIF)
 		if err != nil {

--- a/rule_linux.go
+++ b/rule_linux.go
@@ -15,7 +15,7 @@ const FibRuleInvert = 0x2
 // RuleAdd adds a rule to the system.
 // Equivalent to: ip rule add
 func RuleAdd(rule *Rule) error {
-	return pkgHandle.RuleAdd(rule)
+	return pkgHandle().RuleAdd(rule)
 }
 
 // RuleAdd adds a rule to the system.
@@ -28,7 +28,7 @@ func (h *Handle) RuleAdd(rule *Rule) error {
 // RuleDel deletes a rule from the system.
 // Equivalent to: ip rule del
 func RuleDel(rule *Rule) error {
-	return pkgHandle.RuleDel(rule)
+	return pkgHandle().RuleDel(rule)
 }
 
 // RuleDel deletes a rule from the system.
@@ -188,7 +188,7 @@ func ruleHandle(rule *Rule, req *nl.NetlinkRequest) error {
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func RuleList(family int) ([]Rule, error) {
-	return pkgHandle.RuleList(family)
+	return pkgHandle().RuleList(family)
 }
 
 // RuleList lists rules in the system.
@@ -207,7 +207,7 @@ func (h *Handle) RuleList(family int) ([]Rule, error) {
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func RuleListFiltered(family int, filter *Rule, filterMask uint64) ([]Rule, error) {
-	return pkgHandle.RuleListFiltered(family, filter, filterMask)
+	return pkgHandle().RuleListFiltered(family, filter, filterMask)
 }
 
 // RuleListFiltered lists rules in the system.

--- a/socket_linux.go
+++ b/socket_linux.go
@@ -242,7 +242,7 @@ func (h *Handle) SocketGet(local, remote net.Addr) (*Socket, error) {
 // If the returned error is [ErrDumpInterrupted], the search for a result may
 // be incomplete and the caller should retry.
 func SocketGet(local, remote net.Addr) (*Socket, error) {
-	return pkgHandle.SocketGet(local, remote)
+	return pkgHandle().SocketGet(local, remote)
 }
 
 // SocketDestroy kills the Socket identified by its local and remote addresses.
@@ -283,7 +283,7 @@ func (h *Handle) SocketDestroy(local, remote net.Addr) error {
 
 // SocketDestroy kills the Socket identified by its local and remote addresses.
 func SocketDestroy(local, remote net.Addr) error {
-	return pkgHandle.SocketDestroy(local, remote)
+	return pkgHandle().SocketDestroy(local, remote)
 }
 
 // SocketDiagTCPInfo requests INET_DIAG_INFO for TCP protocol for specified family type and return with extension TCP info.
@@ -333,7 +333,7 @@ func (h *Handle) SocketDiagTCPInfo(family uint8) ([]*InetDiagTCPInfoResp, error)
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func SocketDiagTCPInfo(family uint8) ([]*InetDiagTCPInfoResp, error) {
-	return pkgHandle.SocketDiagTCPInfo(family)
+	return pkgHandle().SocketDiagTCPInfo(family)
 }
 
 // SocketDiagTCP requests INET_DIAG_INFO for TCP protocol for specified family type and return related socket.
@@ -371,7 +371,7 @@ func (h *Handle) SocketDiagTCP(family uint8) ([]*Socket, error) {
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func SocketDiagTCP(family uint8) ([]*Socket, error) {
-	return pkgHandle.SocketDiagTCP(family)
+	return pkgHandle().SocketDiagTCP(family)
 }
 
 // SocketDiagUDPInfo requests INET_DIAG_INFO for UDP protocol for specified family type and return with extension info.
@@ -426,7 +426,7 @@ func (h *Handle) SocketDiagUDPInfo(family uint8) ([]*InetDiagUDPInfoResp, error)
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func SocketDiagUDPInfo(family uint8) ([]*InetDiagUDPInfoResp, error) {
-	return pkgHandle.SocketDiagUDPInfo(family)
+	return pkgHandle().SocketDiagUDPInfo(family)
 }
 
 // SocketDiagUDP requests INET_DIAG_INFO for UDP protocol for specified family type and return related socket.
@@ -464,7 +464,7 @@ func (h *Handle) SocketDiagUDP(family uint8) ([]*Socket, error) {
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func SocketDiagUDP(family uint8) ([]*Socket, error) {
-	return pkgHandle.SocketDiagUDP(family)
+	return pkgHandle().SocketDiagUDP(family)
 }
 
 // UnixSocketDiagInfo requests UNIX_DIAG_INFO for unix sockets and return with extension info.
@@ -520,7 +520,7 @@ func (h *Handle) UnixSocketDiagInfo() ([]*UnixDiagInfoResp, error) {
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func UnixSocketDiagInfo() ([]*UnixDiagInfoResp, error) {
-	return pkgHandle.UnixSocketDiagInfo()
+	return pkgHandle().UnixSocketDiagInfo()
 }
 
 // UnixSocketDiag requests UNIX_DIAG_INFO for unix sockets.
@@ -559,7 +559,7 @@ func (h *Handle) UnixSocketDiag() ([]*UnixSocket, error) {
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func UnixSocketDiag() ([]*UnixSocket, error) {
-	return pkgHandle.UnixSocketDiag()
+	return pkgHandle().UnixSocketDiag()
 }
 
 func attrsToInetDiagTCPInfoResp(attrs []syscall.NetlinkRouteAttr, sockInfo *Socket) (*InetDiagTCPInfoResp, error) {

--- a/vdpa_linux.go
+++ b/vdpa_linux.go
@@ -108,13 +108,13 @@ func IsBitSet(input uint64, pos int) bool {
 // VDPANewDev adds new VDPA device
 // Equivalent to: `vdpa dev add name <name> mgmtdev <mgmtBus>/mgmtName [params]`
 func VDPANewDev(name, mgmtBus, mgmtName string, params VDPANewDevParams) error {
-	return pkgHandle.VDPANewDev(name, mgmtBus, mgmtName, params)
+	return pkgHandle().VDPANewDev(name, mgmtBus, mgmtName, params)
 }
 
 // VDPADelDev removes VDPA device
 // Equivalent to: `vdpa dev del <name>`
 func VDPADelDev(name string) error {
-	return pkgHandle.VDPADelDev(name)
+	return pkgHandle().VDPADelDev(name)
 }
 
 // VDPAGetDevList returns list of VDPA devices
@@ -123,13 +123,13 @@ func VDPADelDev(name string) error {
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func VDPAGetDevList() ([]*VDPADev, error) {
-	return pkgHandle.VDPAGetDevList()
+	return pkgHandle().VDPAGetDevList()
 }
 
 // VDPAGetDevByName returns VDPA device selected by name
 // Equivalent to: `vdpa dev show <name>`
 func VDPAGetDevByName(name string) (*VDPADev, error) {
-	return pkgHandle.VDPAGetDevByName(name)
+	return pkgHandle().VDPAGetDevByName(name)
 }
 
 // VDPAGetDevConfigList returns list of VDPA devices configurations
@@ -138,19 +138,19 @@ func VDPAGetDevByName(name string) (*VDPADev, error) {
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func VDPAGetDevConfigList() ([]*VDPADevConfig, error) {
-	return pkgHandle.VDPAGetDevConfigList()
+	return pkgHandle().VDPAGetDevConfigList()
 }
 
 // VDPAGetDevConfigByName returns VDPA device configuration selected by name
 // Equivalent to: `vdpa dev config show <name>`
 func VDPAGetDevConfigByName(name string) (*VDPADevConfig, error) {
-	return pkgHandle.VDPAGetDevConfigByName(name)
+	return pkgHandle().VDPAGetDevConfigByName(name)
 }
 
 // VDPAGetDevVStats returns vstats for VDPA device
 // Equivalent to: `vdpa dev vstats show <name> qidx <queueIndex>`
 func VDPAGetDevVStats(name string, queueIndex uint32) (*VDPADevVStats, error) {
-	return pkgHandle.VDPAGetDevVStats(name, queueIndex)
+	return pkgHandle().VDPAGetDevVStats(name, queueIndex)
 }
 
 // VDPAGetMGMTDevList returns list of mgmt devices
@@ -159,13 +159,13 @@ func VDPAGetDevVStats(name string, queueIndex uint32) (*VDPADevVStats, error) {
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func VDPAGetMGMTDevList() ([]*VDPAMGMTDev, error) {
-	return pkgHandle.VDPAGetMGMTDevList()
+	return pkgHandle().VDPAGetMGMTDevList()
 }
 
 // VDPAGetMGMTDevByBusAndName returns mgmt devices selected by bus and name
 // Equivalent to: `vdpa mgmtdev show <bus>/<name>`
 func VDPAGetMGMTDevByBusAndName(bus, name string) (*VDPAMGMTDev, error) {
-	return pkgHandle.VDPAGetMGMTDevByBusAndName(bus, name)
+	return pkgHandle().VDPAGetMGMTDevByBusAndName(bus, name)
 }
 
 type vdpaNetlinkMessage []syscall.NetlinkRouteAttr

--- a/xfrm_policy_linux.go
+++ b/xfrm_policy_linux.go
@@ -128,7 +128,7 @@ func selFromPolicy(sel *nl.XfrmSelector, policy *XfrmPolicy) {
 // XfrmPolicyAdd will add an xfrm policy to the system.
 // Equivalent to: `ip xfrm policy add $policy`
 func XfrmPolicyAdd(policy *XfrmPolicy) error {
-	return pkgHandle.XfrmPolicyAdd(policy)
+	return pkgHandle().XfrmPolicyAdd(policy)
 }
 
 // XfrmPolicyAdd will add an xfrm policy to the system.
@@ -140,7 +140,7 @@ func (h *Handle) XfrmPolicyAdd(policy *XfrmPolicy) error {
 // XfrmPolicyUpdate will update an xfrm policy to the system.
 // Equivalent to: `ip xfrm policy update $policy`
 func XfrmPolicyUpdate(policy *XfrmPolicy) error {
-	return pkgHandle.XfrmPolicyUpdate(policy)
+	return pkgHandle().XfrmPolicyUpdate(policy)
 }
 
 // XfrmPolicyUpdate will update an xfrm policy to the system.
@@ -202,7 +202,7 @@ func (h *Handle) xfrmPolicyAddOrUpdate(policy *XfrmPolicy, nlProto int) error {
 // the Tmpls are ignored when matching the policy to delete.
 // Equivalent to: `ip xfrm policy del $policy`
 func XfrmPolicyDel(policy *XfrmPolicy) error {
-	return pkgHandle.XfrmPolicyDel(policy)
+	return pkgHandle().XfrmPolicyDel(policy)
 }
 
 // XfrmPolicyDel will delete an xfrm policy from the system. Note that
@@ -220,7 +220,7 @@ func (h *Handle) XfrmPolicyDel(policy *XfrmPolicy) error {
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func XfrmPolicyList(family int) ([]XfrmPolicy, error) {
-	return pkgHandle.XfrmPolicyList(family)
+	return pkgHandle().XfrmPolicyList(family)
 }
 
 // XfrmPolicyList gets a list of xfrm policies in the system.
@@ -256,7 +256,7 @@ func (h *Handle) XfrmPolicyList(family int) ([]XfrmPolicy, error) {
 // XfrmPolicyGet gets a the policy described by the index or selector, if found.
 // Equivalent to: `ip xfrm policy get { SELECTOR | index INDEX } dir DIR [ctx CTX ] [ mark MARK [ mask MASK ] ] [ ptype PTYPE ]`.
 func XfrmPolicyGet(policy *XfrmPolicy) (*XfrmPolicy, error) {
-	return pkgHandle.XfrmPolicyGet(policy)
+	return pkgHandle().XfrmPolicyGet(policy)
 }
 
 // XfrmPolicyGet gets a the policy described by the index or selector, if found.
@@ -268,7 +268,7 @@ func (h *Handle) XfrmPolicyGet(policy *XfrmPolicy) (*XfrmPolicy, error) {
 // XfrmPolicyFlush will flush the policies on the system.
 // Equivalent to: `ip xfrm policy flush`
 func XfrmPolicyFlush() error {
-	return pkgHandle.XfrmPolicyFlush()
+	return pkgHandle().XfrmPolicyFlush()
 }
 
 // XfrmPolicyFlush will flush the policies on the system.

--- a/xfrm_state_linux.go
+++ b/xfrm_state_linux.go
@@ -237,7 +237,7 @@ func writeReplay(r *XfrmReplayState) []byte {
 // XfrmStateAdd will add an xfrm state to the system.
 // Equivalent to: `ip xfrm state add $state`
 func XfrmStateAdd(state *XfrmState) error {
-	return pkgHandle.XfrmStateAdd(state)
+	return pkgHandle().XfrmStateAdd(state)
 }
 
 // XfrmStateAdd will add an xfrm state to the system.
@@ -249,13 +249,13 @@ func (h *Handle) XfrmStateAdd(state *XfrmState) error {
 // XfrmStateAllocSpi will allocate an xfrm state in the system.
 // Equivalent to: `ip xfrm state allocspi`
 func XfrmStateAllocSpi(state *XfrmState) (*XfrmState, error) {
-	return pkgHandle.xfrmStateAllocSpi(state)
+	return pkgHandle().xfrmStateAllocSpi(state)
 }
 
 // XfrmStateUpdate will update an xfrm state to the system.
 // Equivalent to: `ip xfrm state update $state`
 func XfrmStateUpdate(state *XfrmState) error {
-	return pkgHandle.XfrmStateUpdate(state)
+	return pkgHandle().XfrmStateUpdate(state)
 }
 
 // XfrmStateUpdate will update an xfrm state to the system.
@@ -385,7 +385,7 @@ func (h *Handle) xfrmStateAllocSpi(state *XfrmState) (*XfrmState, error) {
 // the Algos are ignored when matching the state to delete.
 // Equivalent to: `ip xfrm state del $state`
 func XfrmStateDel(state *XfrmState) error {
-	return pkgHandle.XfrmStateDel(state)
+	return pkgHandle().XfrmStateDel(state)
 }
 
 // XfrmStateDel will delete an xfrm state from the system. Note that
@@ -403,7 +403,7 @@ func (h *Handle) XfrmStateDel(state *XfrmState) error {
 // If the returned error is [ErrDumpInterrupted], results may be inconsistent
 // or incomplete.
 func XfrmStateList(family int) ([]XfrmState, error) {
-	return pkgHandle.XfrmStateList(family)
+	return pkgHandle().XfrmStateList(family)
 }
 
 // XfrmStateList gets a list of xfrm states in the system.
@@ -439,7 +439,7 @@ func (h *Handle) XfrmStateList(family int) ([]XfrmState, error) {
 // ID := [ src ADDR ] [ dst ADDR ] [ proto XFRM-PROTO ] [ spi SPI ]
 // mark is optional
 func XfrmStateGet(state *XfrmState) (*XfrmState, error) {
-	return pkgHandle.XfrmStateGet(state)
+	return pkgHandle().XfrmStateGet(state)
 }
 
 // XfrmStateGet gets the xfrm state described by the ID, if found.
@@ -622,7 +622,7 @@ func parseXfrmState(m []byte, family int) (*XfrmState, error) {
 // proto = 0 means any transformation protocols
 // Equivalent to: `ip xfrm state flush [ proto XFRM-PROTO ]`
 func XfrmStateFlush(proto Proto) error {
-	return pkgHandle.XfrmStateFlush(proto)
+	return pkgHandle().XfrmStateFlush(proto)
 }
 
 // XfrmStateFlush will flush the xfrm state on the system.


### PR DESCRIPTION
https://github.com/vishvananda/netlink/pull/1174 as it was merged had some problems. I never really vetted it against Cilium as I had to take a break from work and switch tasks. It had a few conceptual mistakes, mostly stemming from my lack of understanding of `pkgHandle`. The most problematic being ConfigureHandle() locking all global functions to the netns of the caller of ConfigureHandle, making e.g. LinkList operate in the main netns.

This PR proposes removing `pkgHandle` outright, as it only serves as a zero placeholder to promote its methods to package-global functions, and its presence being rather confusing. It also never actually holds any sockets, as doing so would break global function calls from other network namespaces, a common pattern throughout the ecosystem. Also, package-global state of this kind is not a good idea.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency by standardizing how the active handle is obtained for many networking operations (links, routes, neighbors, filters, bridges, sockets, etc.), including subscription/dump request construction.
  * Corrected several wrapper delegations to call the right operations (e.g., link setup and several VDPA queries).

* **Breaking Changes / Behavior**
  * `HandleOptions` no longer includes a `NetNS` field; namespace selection is now passed explicitly when creating handles.

* **Tests**
  * Updated affected unit tests and retry/handle setup expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->