### PR TITLE
fix: wrap formatted errors with %w

### DIFF
--- a/addr_linux.go
+++ b/addr_linux.go
@@ -398,7 +398,7 @@ func addrSubscribeAt(newNs, curNs netns.NsHandle, ch chan<- AddrUpdate, done <-c
 			msgs, from, err := s.Receive()
 			if err != nil {
 				if cberr != nil {
-					cberr(fmt.Errorf("Receive failed: %v",
+					cberr(fmt.Errorf("Receive failed: %w",
 						err))
 				}
 				return
@@ -419,7 +419,7 @@ func addrSubscribeAt(newNs, curNs netns.NsHandle, ch chan<- AddrUpdate, done <-c
 						continue
 					}
 					if cberr != nil {
-						cberr(fmt.Errorf("error message: %v",
+						cberr(fmt.Errorf("error message: %w",
 							syscall.Errno(-error)))
 					}
 					continue
@@ -435,7 +435,7 @@ func addrSubscribeAt(newNs, curNs netns.NsHandle, ch chan<- AddrUpdate, done <-c
 				addr, _, err := parseAddr(m.Data)
 				if err != nil {
 					if cberr != nil {
-						cberr(fmt.Errorf("could not parse address: %v", err))
+						cberr(fmt.Errorf("could not parse address: %w", err))
 					}
 					continue
 				}

--- a/bridge_linux.go
+++ b/bridge_linux.go
@@ -68,14 +68,14 @@ func (h *Handle) bridgeVlanTunnelShowBy(ifindex int32) ([]nl.TunnelInfo, error) 
 			case unix.IFLA_AF_SPEC:
 				nestedAttrs, err := nl.ParseRouteAttr(attr.Value)
 				if err != nil {
-					return nil, fmt.Errorf("failed to parse nested attr %v", err)
+					return nil, fmt.Errorf("failed to parse nested attr %w", err)
 				}
 				for _, nestAttr := range nestedAttrs {
 					switch nestAttr.Attr.Type {
 					case nl.IFLA_BRIDGE_VLAN_TUNNEL_INFO:
 						ret, err = parseTunnelInfo(&nestAttr, ret)
 						if err != nil {
-							return nil, fmt.Errorf("failed to parse tunnelinfo %v", err)
+							return nil, fmt.Errorf("failed to parse tunnelinfo %w", err)
 						}
 					}
 				}
@@ -93,7 +93,7 @@ func (h *Handle) bridgeVlanTunnelShowBy(ifindex int32) ([]nl.TunnelInfo, error) 
 func parseTunnelInfo(nestAttr *syscall.NetlinkRouteAttr, results []nl.TunnelInfo) ([]nl.TunnelInfo, error) {
 	tunnelInfos, err := nl.ParseRouteAttr(nestAttr.Value)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse nested attr %v", err)
+		return nil, fmt.Errorf("failed to parse nested attr %w", err)
 	}
 	var tunnelId uint32
 	var vid uint16
@@ -169,7 +169,7 @@ func (h *Handle) BridgeVlanList() (map[int32][]*nl.BridgeVlanInfo, error) {
 				//nested attr
 				nestAttrs, err := nl.ParseRouteAttr(attr.Value)
 				if err != nil {
-					return nil, fmt.Errorf("failed to parse nested attr %v", err)
+					return nil, fmt.Errorf("failed to parse nested attr %w", err)
 				}
 				for _, nestAttr := range nestAttrs {
 					switch nestAttr.Attr.Type {
@@ -434,7 +434,7 @@ func (h *Handle) BridgeVniList() (map[int32][]*nl.BridgeVniInfo, error) {
 			if attr.Attr.Type&nl.NLA_TYPE_MASK == nl.VXLAN_VNIFILTER_ENTRY {
 				vniInfo, err := nl.DeserializeBridgeVniInfo(attr.Value)
 				if err != nil {
-					return nil, fmt.Errorf("failed to parse vni info: %v", err)
+					return nil, fmt.Errorf("failed to parse vni info: %w", err)
 				}
 				ret[ifindex] = append(ret[ifindex], vniInfo)
 			}

--- a/class_linux.go
+++ b/class_linux.go
@@ -381,22 +381,22 @@ func parseTcStats2(data []byte) (*ClassStatistics, error) {
 		switch datum.Attr.Type {
 		case nl.TCA_STATS_BASIC:
 			if err := parseGnetStats(datum.Value, stats.Basic); err != nil {
-				return nil, fmt.Errorf("Failed to parse ClassStatistics.Basic with: %v\n%s",
+				return nil, fmt.Errorf("Failed to parse ClassStatistics.Basic with: %w\n%s",
 					err, hex.Dump(datum.Value))
 			}
 		case nl.TCA_STATS_QUEUE:
 			if err := parseGnetStats(datum.Value, stats.Queue); err != nil {
-				return nil, fmt.Errorf("Failed to parse ClassStatistics.Queue with: %v\n%s",
+				return nil, fmt.Errorf("Failed to parse ClassStatistics.Queue with: %w\n%s",
 					err, hex.Dump(datum.Value))
 			}
 		case nl.TCA_STATS_RATE_EST:
 			if err := parseGnetStats(datum.Value, stats.RateEst); err != nil {
-				return nil, fmt.Errorf("Failed to parse ClassStatistics.RateEst with: %v\n%s",
+				return nil, fmt.Errorf("Failed to parse ClassStatistics.RateEst with: %w\n%s",
 					err, hex.Dump(datum.Value))
 			}
 		case nl.TCA_STATS_BASIC_HW:
 			if err := parseGnetStats(datum.Value, stats.BasicHw); err != nil {
-				return nil, fmt.Errorf("Failed to parse ClassStatistics.BasicHw with: %v\n%s",
+				return nil, fmt.Errorf("Failed to parse ClassStatistics.BasicHw with: %w\n%s",
 					err, hex.Dump(datum.Value))
 			}
 		}

--- a/devlink_linux.go
+++ b/devlink_linux.go
@@ -765,7 +765,7 @@ func (h *Handle) DevlinkSetDeviceParam(bus string, device string, param string, 
 	// retrive the param type
 	p, err := h.DevlinkGetDeviceParamByName(bus, device, param)
 	if err != nil {
-		return fmt.Errorf("failed to get device param: %v", err)
+		return fmt.Errorf("failed to get device param: %w", err)
 	}
 	paramType := p.Type
 

--- a/link_linux.go
+++ b/link_linux.go
@@ -1530,19 +1530,19 @@ func (h *Handle) linkModify(link Link, flags int) error {
 				unix.Close(fd)
 				// and the already opened ones
 				cleanupFds(fds)
-				return fmt.Errorf("Tuntap IOCTL TUNSETIFF failed [%d], errno %v", i, errno)
+				return fmt.Errorf("Tuntap IOCTL TUNSETIFF failed [%d], errno %w", i, errno)
 			}
 
 			_, _, errno = syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), syscall.TUNSETOWNER, uintptr(tuntap.Owner))
 			if errno != 0 {
 				cleanupFds(fds)
-				return fmt.Errorf("Tuntap IOCTL TUNSETOWNER failed [%d], errno %v", i, errno)
+				return fmt.Errorf("Tuntap IOCTL TUNSETOWNER failed [%d], errno %w", i, errno)
 			}
 
 			_, _, errno = syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), syscall.TUNSETGROUP, uintptr(tuntap.Group))
 			if errno != 0 {
 				cleanupFds(fds)
-				return fmt.Errorf("Tuntap IOCTL TUNSETGROUP failed [%d], errno %v", i, errno)
+				return fmt.Errorf("Tuntap IOCTL TUNSETGROUP failed [%d], errno %w", i, errno)
 			}
 
 			// Set the tun device to non-blocking before use. The below comment
@@ -1566,7 +1566,7 @@ func (h *Handle) linkModify(link Link, flags int) error {
 			err = unix.SetNonblock(fd, true)
 			if err != nil {
 				cleanupFds(fds)
-				return fmt.Errorf("Tuntap set to non-blocking failed [%d], err %v", i, err)
+				return fmt.Errorf("Tuntap set to non-blocking failed [%d], err %w", i, err)
 			}
 
 			// create the file from the file descriptor and store it
@@ -1590,10 +1590,10 @@ func (h *Handle) linkModify(link Link, flags int) error {
 			name := file.Name()
 			conn, err := file.SyscallConn()
 			if err != nil {
-				return fmt.Errorf("SyscallConn() failed on %s: %v", name, err)
+				return fmt.Errorf("SyscallConn() failed on %s: %w", name, err)
 			}
 			if err := conn.Control(f); err != nil {
-				return fmt.Errorf("Failed to get file descriptor for %s: %v", name, err)
+				return fmt.Errorf("Failed to get file descriptor for %s: %w", name, err)
 			}
 			return nil
 		}
@@ -1608,7 +1608,7 @@ func (h *Handle) linkModify(link Link, flags int) error {
 			}
 			if errno != 0 {
 				cleanupFds(fds)
-				return fmt.Errorf("Tuntap IOCTL TUNSETPERSIST failed, errno %v", errno)
+				return fmt.Errorf("Tuntap IOCTL TUNSETPERSIST failed, errno %w", errno)
 			}
 		}
 
@@ -2633,7 +2633,7 @@ func linkSubscribeAt(newNs, curNs netns.NsHandle, ch chan<- LinkUpdate, done <-c
 			msgs, from, err := s.Receive()
 			if err != nil {
 				if cberr != nil {
-					cberr(fmt.Errorf("Receive failed: %v",
+					cberr(fmt.Errorf("Receive failed: %w",
 						err))
 				}
 				return
@@ -2657,7 +2657,7 @@ func linkSubscribeAt(newNs, curNs netns.NsHandle, ch chan<- LinkUpdate, done <-c
 						continue
 					}
 					if cberr != nil {
-						cberr(fmt.Errorf("error message: %v",
+						cberr(fmt.Errorf("error message: %w",
 							syscall.Errno(-error)))
 					}
 					continue
@@ -4086,7 +4086,7 @@ func ioctlBondSlave(cmd uintptr, link Link, master *Bond) error {
 	ifreq := newIocltSlaveReq(link.Attrs().Name, master.Attrs().Name)
 	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), cmd, uintptr(unsafe.Pointer(ifreq)))
 	if errno != 0 {
-		return fmt.Errorf("errno=%v", errno)
+		return fmt.Errorf("errno=%w", errno)
 	}
 	return nil
 }
@@ -4097,7 +4097,7 @@ func ioctlBondSlave(cmd uintptr, link Link, master *Bond) error {
 func LinkSetBondSlaveActive(link Link, master *Bond) error {
 	err := ioctlBondSlave(unix.SIOCBONDCHANGEACTIVE, link, master)
 	if err != nil {
-		return fmt.Errorf("Failed to set slave %q active in %q, %v", link.Attrs().Name, master.Attrs().Name, err)
+		return fmt.Errorf("Failed to set slave %q active in %q, %w", link.Attrs().Name, master.Attrs().Name, err)
 	}
 	return nil
 }
@@ -4106,7 +4106,7 @@ func LinkSetBondSlaveActive(link Link, master *Bond) error {
 func LinkSetBondSlave(link Link, master *Bond) error {
 	err := ioctlBondSlave(unix.SIOCBONDENSLAVE, link, master)
 	if err != nil {
-		return fmt.Errorf("Failed to enslave %q to %q, %v", link.Attrs().Name, master.Attrs().Name, err)
+		return fmt.Errorf("Failed to enslave %q to %q, %w", link.Attrs().Name, master.Attrs().Name, err)
 	}
 	return nil
 }
@@ -4115,7 +4115,7 @@ func LinkSetBondSlave(link Link, master *Bond) error {
 func LinkDelBondSlave(link Link, master *Bond) error {
 	err := ioctlBondSlave(unix.SIOCBONDRELEASE, link, master)
 	if err != nil {
-		return fmt.Errorf("Failed to del slave %q from %q, %v", link.Attrs().Name, master.Attrs().Name, err)
+		return fmt.Errorf("Failed to del slave %q from %q, %w", link.Attrs().Name, master.Attrs().Name, err)
 	}
 	return nil
 }
@@ -4177,7 +4177,7 @@ func VethPeerIndex(link *Veth) (int, error) {
 	ifreq, sSet := newIocltStringSetReq(link.Name)
 	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), SIOCETHTOOL, uintptr(unsafe.Pointer(ifreq)))
 	if errno != 0 {
-		return -1, fmt.Errorf("SIOCETHTOOL request for %q failed, errno=%v", link.Attrs().Name, errno)
+		return -1, fmt.Errorf("SIOCETHTOOL request for %q failed, errno=%w", link.Attrs().Name, errno)
 	}
 
 	stats := ethtoolStats{
@@ -4193,7 +4193,7 @@ func VethPeerIndex(link *Veth) (int, error) {
 	ifreq.Data = uintptr(unsafe.Pointer(&buffer[0]))
 	_, _, errno = syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), SIOCETHTOOL, uintptr(unsafe.Pointer(ifreq)))
 	if errno != 0 {
-		return -1, fmt.Errorf("SIOCETHTOOL request for %q failed, errno=%v", link.Attrs().Name, errno)
+		return -1, fmt.Errorf("SIOCETHTOOL request for %q failed, errno=%w", link.Attrs().Name, errno)
 	}
 
 	vstats, err := vethStatsDeserialize(buffer)

--- a/nl/nl_linux.go
+++ b/nl/nl_linux.go
@@ -810,13 +810,13 @@ func executeInNetns(newNs, curNs netns.NsHandle) (func(), error) {
 		if !curNs.IsOpen() {
 			if curNs, err = netns.Get(); err != nil {
 				restore()
-				return nil, fmt.Errorf("could not get current namespace while creating netlink socket: %v", err)
+				return nil, fmt.Errorf("could not get current namespace while creating netlink socket: %w", err)
 			}
 			closeNs = curNs.Close
 		}
 		if err := netns.Set(newNs); err != nil {
 			restore()
-			return nil, fmt.Errorf("failed to set into network namespace %d while creating netlink socket: %v", newNs, err)
+			return nil, fmt.Errorf("failed to set into network namespace %d while creating netlink socket: %w", newNs, err)
 		}
 		moveBack = netns.Set
 	}

--- a/route_linux.go
+++ b/route_linux.go
@@ -552,7 +552,7 @@ func (e *BpfEncap) Decode(buf []byte) error {
 	native := nl.NativeEndian()
 	attrs, err := nl.ParseRouteAttr(buf)
 	if err != nil {
-		return fmt.Errorf("lwt bpf decode: failed parsing attribute. err: %v", err)
+		return fmt.Errorf("lwt bpf decode: failed parsing attribute. err: %w", err)
 	}
 	for _, attr := range attrs {
 		if int(attr.Attr.Type) < 1 {
@@ -1013,7 +1013,7 @@ func (h *Handle) prepareRouteReq(route *Route, req *nl.NetlinkRequest, msg *nl.R
 	if route.Via != nil {
 		buf, err := route.Via.Encode()
 		if err != nil {
-			return fmt.Errorf("failed to encode RTA_VIA: %v", err)
+			return fmt.Errorf("failed to encode RTA_VIA: %w", err)
 		}
 		rtAttrs = append(rtAttrs, nl.NewRtAttr(unix.RTA_VIA, buf))
 	}
@@ -1847,7 +1847,7 @@ func routeSubscribeAt(newNs, curNs netns.NsHandle, ch chan<- RouteUpdate, done <
 			msgs, from, err := s.Receive()
 			if err != nil {
 				if cberr != nil {
-					cberr(fmt.Errorf("Receive failed: %v",
+					cberr(fmt.Errorf("Receive failed: %w",
 						err))
 				}
 				return
@@ -1871,7 +1871,7 @@ func routeSubscribeAt(newNs, curNs netns.NsHandle, ch chan<- RouteUpdate, done <
 						continue
 					}
 					if cberr != nil {
-						cberr(fmt.Errorf("error message: %v",
+						cberr(fmt.Errorf("error message: %w",
 							syscall.Errno(-error)))
 					}
 					continue


### PR DESCRIPTION
  Replace formatted error wrapping that used `%v` with `%w` so callers can inspect the underlying errors with `errors.Is` and `errors.As`.

  This updates error paths across address, bridge, class, devlink, link, route, and netlink namespace handling, plus the retry test helper.

  ## Example

  Previously, callers could receive an error message that included a syscall error, but the original error was flattened into text:

  ```go
  err := LinkSetBondSlave(link, master)
  if errors.Is(err, syscall.EPERM) {
      // This would not match when EPERM was formatted with %v.
  }

  With %w, the wrapped error remains available to consumers:

  err := LinkSetBondSlave(link, master)
  if errors.Is(err, syscall.EPERM) {
      // Handle permission errors directly.
  }

  ## Testing

  - gofmt
  - git diff --check
  - Rescanned for remaining %v wrappers involving err, errno, or Err
  - go test ./nl
  - go test ./cmd/ipset-test

  go test ./... does not currently complete on main because handle_retry_linux_test.go:60 calls dumpHandle.RetryInterrupted(), but Handle has no such method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting across networking operations by preserving underlying errors for more reliable diagnosis and programmatic inspection.
  * Enhanced details included with certain traffic-control parsing failures, making malformed data easier to identify.
  * Maintained existing networking behavior and control flow while improving the consistency of returned errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->