### PR TITLE
addr: propagate Protocol field in AddrUpdate subscriptions

### DIFF
--- a/addr_linux.go
+++ b/addr_linux.go
@@ -322,6 +322,7 @@ type AddrUpdate struct {
 	Scope       int
 	PreferedLft int
 	ValidLft    int
+	Protocol    int
 	NewAddr     bool // true=added false=deleted
 }
 
@@ -446,7 +447,8 @@ func addrSubscribeAt(newNs, curNs netns.NsHandle, ch chan<- AddrUpdate, done <-c
 					Flags:       addr.Flags,
 					Scope:       addr.Scope,
 					PreferedLft: addr.PreferedLft,
-					ValidLft:    addr.ValidLft}
+					ValidLft:    addr.ValidLft,
+					Protocol:    addr.Protocol}
 			}
 		}
 	}()

--- a/addr_linux.go
+++ b/addr_linux.go
@@ -323,6 +323,7 @@ type AddrUpdate struct {
 	PreferedLft int
 	ValidLft    int
 	NewAddr     bool // true=added false=deleted
+	Protocol    int
 }
 
 // AddrSubscribe takes a chan down which notifications will be sent
@@ -446,7 +447,8 @@ func addrSubscribeAt(newNs, curNs netns.NsHandle, ch chan<- AddrUpdate, done <-c
 					Flags:       addr.Flags,
 					Scope:       addr.Scope,
 					PreferedLft: addr.PreferedLft,
-					ValidLft:    addr.ValidLft}
+					ValidLft:    addr.ValidLft,
+					Protocol:    addr.Protocol}
 			}
 		}
 	}()


### PR DESCRIPTION
The IFA_PROTO attribute was parsed in parseAddr but not included in the AddrUpdate struct or its construction in addrSubscribeAt, so address subscription consumers never saw the protocol value.

IFA_PROTO support added in https://github.com/vishvananda/netlink/pull/1157

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Address-change notifications now include the protocol value associated with each address update.
  * Applications can read this protocol metadata for both address additions and deletions, providing additional context when processing network address events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->