### PR TITLE
nl80211: add wiphy network namespace support

### DIFF
--- a/wiphy_linux.go
+++ b/wiphy_linux.go
@@ -1,0 +1,49 @@
+//go:build linux
+// +build linux
+
+package netlink
+
+import (
+	"github.com/vishvananda/netlink/nl"
+	"golang.org/x/sys/unix"
+)
+
+// Values from include/uapi/linux/nl80211.h in the Linux kernel source.
+const (
+	nl80211GenlName    = "nl80211"
+	nl80211GenlVersion = 1
+
+	nl80211CmdSetWiphyNetns = 49
+	nl80211AttrWiphy        = 1
+	nl80211AttrNetnsFD      = 219
+)
+
+// WiphySetNsFd moves a wireless PHY to the network namespace specified by fd.
+// All interfaces associated with the wiphy must be down before it can be moved.
+func WiphySetNsFd(wiphy, fd int) error {
+	return pkgHandle.WiphySetNsFd(wiphy, fd)
+}
+
+// WiphySetNsFd moves a wireless PHY to the network namespace specified by fd.
+// All interfaces associated with the wiphy must be down before it can be moved.
+func (h *Handle) WiphySetNsFd(wiphy, fd int) error {
+	family, err := h.GenlFamilyGet(nl80211GenlName)
+	if err != nil {
+		return err
+	}
+
+	req := h.newWiphySetNsFdRequest(int(family.ID), wiphy, fd)
+	_, err = req.Execute(unix.NETLINK_GENERIC, 0)
+	return err
+}
+
+func (h *Handle) newWiphySetNsFdRequest(family, wiphy, fd int) *nl.NetlinkRequest {
+	req := h.newNetlinkRequest(family, unix.NLM_F_ACK)
+	req.AddData(&nl.Genlmsg{
+		Command: nl80211CmdSetWiphyNetns,
+		Version: nl80211GenlVersion,
+	})
+	req.AddData(nl.NewRtAttr(nl80211AttrWiphy, nl.Uint32Attr(uint32(wiphy))))
+	req.AddData(nl.NewRtAttr(nl80211AttrNetnsFD, nl.Uint32Attr(uint32(fd))))
+	return req
+}

--- a/wiphy_linux.go
+++ b/wiphy_linux.go
@@ -4,6 +4,8 @@
 package netlink
 
 import (
+	"fmt"
+
 	"github.com/vishvananda/netlink/nl"
 	"golang.org/x/sys/unix"
 )
@@ -27,6 +29,13 @@ func WiphySetNsFd(wiphy, fd int) error {
 // WiphySetNsFd moves a wireless PHY to the network namespace specified by fd.
 // All interfaces associated with the wiphy must be down before it can be moved.
 func (h *Handle) WiphySetNsFd(wiphy, fd int) error {
+	if wiphy < 0 {
+		return fmt.Errorf("wiphy index must be non-negative: %d", wiphy)
+	}
+	if fd < 0 {
+		return fmt.Errorf("network namespace fd must be non-negative: %d", fd)
+	}
+
 	family, err := h.GenlFamilyGet(nl80211GenlName)
 	if err != nil {
 		return err

--- a/wiphy_linux_test.go
+++ b/wiphy_linux_test.go
@@ -10,6 +10,25 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+func TestWiphySetNsFdRejectsNegativeArguments(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		wiphy int
+		fd    int
+		want  string
+	}{
+		{name: "negative wiphy", wiphy: -1, fd: 42, want: "wiphy index must be non-negative: -1"},
+		{name: "negative namespace fd", wiphy: 7, fd: -1, want: "network namespace fd must be non-negative: -1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := (&Handle{}).WiphySetNsFd(tc.wiphy, tc.fd)
+			if err == nil || err.Error() != tc.want {
+				t.Fatalf("unexpected error: got %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
 func TestNewWiphySetNsFdRequest(t *testing.T) {
 	const (
 		family = 0x23

--- a/wiphy_linux_test.go
+++ b/wiphy_linux_test.go
@@ -1,0 +1,50 @@
+//go:build linux
+// +build linux
+
+package netlink
+
+import (
+	"testing"
+
+	"github.com/vishvananda/netlink/nl"
+	"golang.org/x/sys/unix"
+)
+
+func TestNewWiphySetNsFdRequest(t *testing.T) {
+	const (
+		family = 0x23
+		wiphy  = 7
+		fd     = 42
+	)
+
+	req := (&Handle{}).newWiphySetNsFdRequest(family, wiphy, fd)
+	if req.Type != family {
+		t.Fatalf("unexpected netlink message type: got %d, want %d", req.Type, family)
+	}
+	if want := uint16(unix.NLM_F_REQUEST | unix.NLM_F_ACK); req.Flags != want {
+		t.Fatalf("unexpected netlink flags: got %#x, want %#x", req.Flags, want)
+	}
+
+	data := req.Serialize()[unix.SizeofNlMsghdr:]
+	genl := nl.DeserializeGenlmsg(data)
+	if genl.Command != nl80211CmdSetWiphyNetns {
+		t.Fatalf("unexpected generic netlink command: got %d, want %d", genl.Command, nl80211CmdSetWiphyNetns)
+	}
+	if genl.Version != nl80211GenlVersion {
+		t.Fatalf("unexpected generic netlink version: got %d, want %d", genl.Version, nl80211GenlVersion)
+	}
+
+	attrs, err := nl.ParseRouteAttr(data[nl.SizeofGenlmsg:])
+	if err != nil {
+		t.Fatalf("failed to parse attributes: %v", err)
+	}
+	if len(attrs) != 2 {
+		t.Fatalf("unexpected attribute count: got %d, want 2", len(attrs))
+	}
+	if attrs[0].Attr.Type != nl80211AttrWiphy || native.Uint32(attrs[0].Value) != wiphy {
+		t.Fatalf("unexpected wiphy attribute: type=%d value=%d", attrs[0].Attr.Type, native.Uint32(attrs[0].Value))
+	}
+	if attrs[1].Attr.Type != nl80211AttrNetnsFD || native.Uint32(attrs[1].Value) != fd {
+		t.Fatalf("unexpected netns fd attribute: type=%d value=%d", attrs[1].Attr.Type, native.Uint32(attrs[1].Value))
+	}
+}


### PR DESCRIPTION
## Summary

Add Linux-only helpers for moving a wireless PHY to another network namespace through the `nl80211` generic-netlink family.

This provides the dependency-layer API needed by `containernetworking/plugins#957`, where `host-device` currently cannot move wireless devices with `RTM_SETLINK`/`LinkSetNsFd`.

The implementation sends `NL80211_CMD_SET_WIPHY_NETNS` with:

- `NL80211_ATTR_WIPHY`
- `NL80211_ATTR_NETNS_FD`

Both package-level and `Handle` methods are provided, following existing netlink API patterns.

## Testing

- `go build .` — passed
- `go test ./nl` — passed
- `go vet ./nl` — passed
- In-memory request serialization tests were added; no real wireless device or host networking is required.
- The root package test suite is currently blocked by a pre-existing compile error in `handle_retry_linux_test.go` referencing the missing `Handle.RetryInterrupted` method; this change does not reference that symbol.

Related downstream integration: https://github.com/containernetworking/plugins/issues/957


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Linux support for moving a wireless device into a specified network namespace.
  * Introduced package-level and handle-based APIs to set the wireless device’s target namespace.

* **Tests**
  * Added coverage to ensure namespace-change requests are validated for invalid inputs and are built with the expected netlink/genetlink command, flags, and attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->