### PR TITLE
handle: update retry test for HandleOptions

### DIFF
--- a/handle_retry_linux_test.go
+++ b/handle_retry_linux_test.go
@@ -57,9 +57,17 @@ func TestExecuteIterRetryInterruptedRetriesDumpInterrupted(t *testing.T) {
 
 	// RouteListFiltered uses the same ExecuteIter path. Exercise it directly
 	// because link dumps trigger NLM_F_DUMP_INTR more reliably in a test netns.
-	dumpHandle.RetryInterrupted()
+	retryHandle, err := NewHandleWithOptions(
+		HandleOptions{RetryInterrupted: true},
+		unix.NETLINK_ROUTE,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { retryHandle.Close() })
+
 	for deadline := time.Now().Add(5 * time.Second); time.Now().Before(deadline); {
-		err := executeIterLinkDump(dumpHandle)
+		err := executeIterLinkDump(retryHandle)
 		switch {
 		case err == ErrDumpInterrupted:
 			t.Fatalf("raw ErrDumpInterrupted escaped; ExecuteIter did not retry")


### PR DESCRIPTION
PR #1174 removed Handle.RetryInterrupted() in favor of setting RetryInterrupted when a handle is created. The retry test landed while that PR was still open, after its last CI run, so it was left calling the old method when #1174 was merged.

Create a separate retry-enabled handle with NewHandleWithOptions and use it for the retry portion of the test.

This unbreaks the main branch which currently won't build:

```
# github.com/vishvananda/netlink [github.com/vishvananda/netlink.test]
Error: ./handle_retry_linux_test.go:60:13: dumpHandle.RetryInterrupted undefined (type *Handle has no field or method RetryInterrupted)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Linux retry testing to use a dedicated retry-enabled handle.
  * Continued validating link dumps through retry exhaustion or successful completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->