### PR TITLE
ethtool: add feature bindings over netlink

### DIFF
--- a/ethtool_features_linux.go
+++ b/ethtool_features_linux.go
@@ -1,0 +1,276 @@
+package netlink
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"syscall"
+
+	"github.com/vishvananda/netlink/nl"
+	"golang.org/x/sys/unix"
+)
+
+// NetDevFeature contains the state of one netdevice feature.
+type NetDevFeature struct {
+	Hardware bool
+	Wanted   bool
+	Active   bool
+	NoChange bool
+}
+
+func parseNetDevFeatureBitset(attr syscall.NetlinkRouteAttr) (map[string]bool, error) {
+	attrs, err := nl.ParseRouteAttr(attr.Value)
+	if err != nil {
+		return nil, err
+	}
+
+	noMask := false
+	var bits *syscall.NetlinkRouteAttr
+	for i := range attrs {
+		typeID := attrs[i].Attr.Type & nl.NLA_TYPE_MASK
+		switch typeID {
+		case nl.ETHTOOL_A_BITSET_NOMASK:
+			if len(attrs[i].Value) != 0 {
+				return nil, fmt.Errorf("netlink: ethtool bitset nomask flag has %d bytes, want 0", len(attrs[i].Value))
+			}
+			noMask = true
+		case nl.ETHTOOL_A_BITSET_BITS:
+			bits = &attrs[i]
+		case nl.ETHTOOL_A_BITSET_VALUE, nl.ETHTOOL_A_BITSET_MASK:
+			return nil, fmt.Errorf("netlink: compact ethtool feature bitset is not supported")
+		}
+	}
+	if bits == nil {
+		return nil, fmt.Errorf("netlink: ethtool feature bitset has no named bits")
+	}
+
+	entries, err := nl.ParseRouteAttr(bits.Value)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string]bool, len(entries))
+	for _, entry := range entries {
+		if entry.Attr.Type&nl.NLA_TYPE_MASK != nl.ETHTOOL_A_BITSET_BITS_BIT {
+			continue
+		}
+		fields, err := nl.ParseRouteAttr(entry.Value)
+		if err != nil {
+			return nil, err
+		}
+		name := ""
+		namePresent := false
+		value := noMask
+		for _, field := range fields {
+			switch field.Attr.Type & nl.NLA_TYPE_MASK {
+			case nl.ETHTOOL_A_BITSET_BIT_NAME:
+				namePresent = true
+				nameBytes := field.Value
+				if len(nameBytes) != 0 && nameBytes[len(nameBytes)-1] == 0 {
+					nameBytes = nameBytes[:len(nameBytes)-1]
+				}
+				if strings.IndexByte(string(nameBytes), 0) >= 0 {
+					return nil, fmt.Errorf("netlink: malformed ethtool feature name %x", field.Value)
+				}
+				name = string(nameBytes)
+			case nl.ETHTOOL_A_BITSET_BIT_VALUE:
+				if len(field.Value) != 0 {
+					return nil, fmt.Errorf("netlink: ethtool feature value flag has %d bytes, want 0", len(field.Value))
+				}
+				value = true
+			}
+		}
+		if !namePresent {
+			return nil, fmt.Errorf("netlink: ethtool feature bit has no name")
+		}
+		if name == "" {
+			continue
+		}
+		if _, exists := result[name]; exists {
+			return nil, fmt.Errorf("netlink: duplicate ethtool feature %q", name)
+		}
+		result[name] = value
+	}
+	return result, nil
+}
+
+func parseNetDevFeatures(attrs []syscall.NetlinkRouteAttr) (map[string]NetDevFeature, error) {
+	result := make(map[string]NetDevFeature)
+	for _, attr := range attrs {
+		typeID := attr.Attr.Type & nl.NLA_TYPE_MASK
+		if typeID < nl.ETHTOOL_A_FEATURES_HW || typeID > nl.ETHTOOL_A_FEATURES_NOCHANGE {
+			continue
+		}
+		values, err := parseNetDevFeatureBitset(attr)
+		if err != nil {
+			return nil, err
+		}
+		for name, value := range values {
+			feature := result[name]
+			switch typeID {
+			case nl.ETHTOOL_A_FEATURES_HW:
+				feature.Hardware = value
+			case nl.ETHTOOL_A_FEATURES_WANTED:
+				feature.Wanted = value
+			case nl.ETHTOOL_A_FEATURES_ACTIVE:
+				feature.Active = value
+			case nl.ETHTOOL_A_FEATURES_NOCHANGE:
+				feature.NoChange = value
+			}
+			result[name] = feature
+		}
+	}
+	return result, nil
+}
+
+func netDevFeaturesSetError(unapplied map[string]bool) error {
+	if len(unapplied) == 0 {
+		return nil
+	}
+
+	names := make([]string, 0, len(unapplied))
+	for name := range unapplied {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	changes := make([]string, 0, len(names))
+	for _, name := range names {
+		state := "off"
+		if unapplied[name] {
+			state = "on"
+		}
+		changes = append(changes, name+"="+state)
+	}
+	return fmt.Errorf("netlink: ethtool did not apply requested feature changes: %s", strings.Join(changes, ", "))
+}
+
+func verifyNetDevFeatureStates(config map[string]bool, features map[string]NetDevFeature) error {
+	unapplied := make(map[string]bool)
+	for name, requested := range config {
+		feature, exists := features[name]
+		if !exists || feature.Active != requested {
+			unapplied[name] = requested
+		}
+	}
+	return netDevFeaturesSetError(unapplied)
+}
+
+func parseNetDevFeaturesSetReply(attrs []syscall.NetlinkRouteAttr) error {
+	var unapplied map[string]bool
+	wantedSeen := false
+	activeSeen := false
+	for _, attr := range attrs {
+		typeID := attr.Attr.Type & nl.NLA_TYPE_MASK
+		switch typeID {
+		case nl.ETHTOOL_A_FEATURES_WANTED:
+			if wantedSeen {
+				return fmt.Errorf("netlink: duplicate ethtool features set wanted bitset")
+			}
+			wantedSeen = true
+			values, err := parseNetDevFeatureBitset(attr)
+			if err != nil {
+				return err
+			}
+			unapplied = values
+		case nl.ETHTOOL_A_FEATURES_ACTIVE:
+			if activeSeen {
+				return fmt.Errorf("netlink: duplicate ethtool features set active bitset")
+			}
+			activeSeen = true
+			if _, err := parseNetDevFeatureBitset(attr); err != nil {
+				return err
+			}
+		}
+	}
+	if !wantedSeen {
+		return fmt.Errorf("netlink: ethtool features set reply has no wanted bitset")
+	}
+	if !activeSeen {
+		return fmt.Errorf("netlink: ethtool features set reply has no active bitset")
+	}
+	return netDevFeaturesSetError(unapplied)
+}
+
+// NetDevFeaturesGet returns the named feature states for ifIndex.
+func NetDevFeaturesGet(ifIndex int) (map[string]NetDevFeature, error) {
+	return pkgHandle().NetDevFeaturesGet(ifIndex)
+}
+
+// NetDevFeaturesGet returns the named feature states for ifIndex.
+func (h *Handle) NetDevFeaturesGet(ifIndex int) (map[string]NetDevFeature, error) {
+	header, err := newEthtoolHeader(nl.ETHTOOL_A_FEATURES_HEADER, ifIndex)
+	if err != nil {
+		return nil, err
+	}
+	msgs, err := h.ethtoolRequest(nl.ETHTOOL_MSG_FEATURES_GET, unix.NLM_F_ACK, []*nl.RtAttr{header})
+	if err != nil {
+		return nil, err
+	}
+	if len(msgs) != 1 {
+		return nil, fmt.Errorf("netlink: expected one ethtool features response, got %d", len(msgs))
+	}
+	return parseNetDevFeatures(msgs[0])
+}
+
+func newNetDevFeaturesSetAttrs(ifIndex int, config map[string]bool) ([]*nl.RtAttr, error) {
+	header, err := newEthtoolHeader(nl.ETHTOOL_A_FEATURES_HEADER, ifIndex)
+	if err != nil {
+		return nil, err
+	}
+	if len(config) == 0 {
+		return nil, fmt.Errorf("netlink: ethtool feature configuration is empty")
+	}
+
+	names := make([]string, 0, len(config))
+	for name := range config {
+		if name == "" || strings.IndexByte(name, 0) >= 0 {
+			return nil, fmt.Errorf("netlink: invalid ethtool feature name %q", name)
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	wanted := nl.NewRtAttr(unix.NLA_F_NESTED|nl.ETHTOOL_A_FEATURES_WANTED, nil)
+	bits := wanted.AddRtAttr(unix.NLA_F_NESTED|nl.ETHTOOL_A_BITSET_BITS, nil)
+	for _, name := range names {
+		bit := bits.AddRtAttr(unix.NLA_F_NESTED|nl.ETHTOOL_A_BITSET_BITS_BIT, nil)
+		bit.AddRtAttr(nl.ETHTOOL_A_BITSET_BIT_NAME, nl.ZeroTerminated(name))
+		if config[name] {
+			bit.AddRtAttr(nl.ETHTOOL_A_BITSET_BIT_VALUE, nil)
+		}
+	}
+	return []*nl.RtAttr{header, wanted}, nil
+}
+
+// NetDevFeaturesSet applies named feature changes to ifIndex. It returns an
+// error if any requested state is not active. Features absent from config are
+// left unchanged.
+func NetDevFeaturesSet(ifIndex int, config map[string]bool) error {
+	return pkgHandle().NetDevFeaturesSet(ifIndex, config)
+}
+
+// NetDevFeaturesSet applies named feature changes to ifIndex. It returns an
+// error if any requested state is not active. Features absent from config are
+// left unchanged.
+func (h *Handle) NetDevFeaturesSet(ifIndex int, config map[string]bool) error {
+	attrs, err := newNetDevFeaturesSetAttrs(ifIndex, config)
+	if err != nil {
+		return err
+	}
+	msgs, err := h.ethtoolRequest(nl.ETHTOOL_MSG_FEATURES_SET, unix.NLM_F_ACK, attrs)
+	if err != nil {
+		return err
+	}
+	switch len(msgs) {
+	case 0:
+		// Older kernels omit the reply when the wanted bitmap is unchanged.
+		features, err := h.NetDevFeaturesGet(ifIndex)
+		if err != nil {
+			return fmt.Errorf("netlink: verify ethtool feature changes: %w", err)
+		}
+		return verifyNetDevFeatureStates(config, features)
+	case 1:
+		return parseNetDevFeaturesSetReply(msgs[0])
+	default:
+		return fmt.Errorf("netlink: expected at most one ethtool features set response, got %d", len(msgs))
+	}
+}

--- a/ethtool_features_linux_test.go
+++ b/ethtool_features_linux_test.go
@@ -1,0 +1,257 @@
+package netlink
+
+import (
+	"reflect"
+	"syscall"
+	"testing"
+
+	"github.com/vishvananda/netlink/nl"
+	"golang.org/x/sys/unix"
+)
+
+func featureBitsetAttr(t *testing.T, attrType int, values map[string]bool, noMask bool) syscall.NetlinkRouteAttr {
+	t.Helper()
+	bitset := nl.NewRtAttr(unix.NLA_F_NESTED|attrType, nil)
+	if noMask {
+		bitset.AddRtAttr(nl.ETHTOOL_A_BITSET_NOMASK, nil)
+	}
+	bits := bitset.AddRtAttr(unix.NLA_F_NESTED|nl.ETHTOOL_A_BITSET_BITS, nil)
+	index := uint32(0)
+	for name, value := range values {
+		bit := bits.AddRtAttr(unix.NLA_F_NESTED|nl.ETHTOOL_A_BITSET_BITS_BIT, nil)
+		bit.AddRtAttr(nl.ETHTOOL_A_BITSET_BIT_INDEX, nl.Uint32Attr(index))
+		bit.AddRtAttr(nl.ETHTOOL_A_BITSET_BIT_NAME, nl.ZeroTerminated(name))
+		if value {
+			bit.AddRtAttr(nl.ETHTOOL_A_BITSET_BIT_VALUE, nil)
+		}
+		index++
+	}
+	return parseSerializedAttrs(t, []*nl.RtAttr{bitset})[0]
+}
+
+func TestParseNetDevFeatures(t *testing.T) {
+	attrs := []syscall.NetlinkRouteAttr{
+		featureBitsetAttr(t, nl.ETHTOOL_A_FEATURES_HW, map[string]bool{
+			"rx-gro-hw":               true,
+			"tx-generic-segmentation": true,
+		}, true),
+		featureBitsetAttr(t, nl.ETHTOOL_A_FEATURES_WANTED, map[string]bool{
+			"rx-gro-hw":               false,
+			"tx-generic-segmentation": true,
+		}, false),
+		featureBitsetAttr(t, nl.ETHTOOL_A_FEATURES_ACTIVE, map[string]bool{
+			"rx-gro-hw":               false,
+			"tx-generic-segmentation": true,
+		}, false),
+		featureBitsetAttr(t, nl.ETHTOOL_A_FEATURES_NOCHANGE, map[string]bool{
+			"tx-generic-segmentation": true,
+		}, true),
+	}
+
+	got, err := parseNetDevFeatures(attrs)
+	if err != nil {
+		t.Fatalf("parseNetDevFeatures failed: %v", err)
+	}
+	want := map[string]NetDevFeature{
+		"rx-gro-hw": {
+			Hardware: true,
+		},
+		"tx-generic-segmentation": {
+			Hardware: true,
+			Wanted:   true,
+			Active:   true,
+			NoChange: true,
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("features = %#v, want %#v", got, want)
+	}
+}
+
+func TestParseNetDevFeaturesSetReply(t *testing.T) {
+	attrs := []syscall.NetlinkRouteAttr{
+		featureBitsetAttr(t, nl.ETHTOOL_A_FEATURES_WANTED, nil, false),
+		featureBitsetAttr(t, nl.ETHTOOL_A_FEATURES_ACTIVE, map[string]bool{
+			"rx-gro-hw": true,
+		}, false),
+	}
+	if err := parseNetDevFeaturesSetReply(attrs); err != nil {
+		t.Fatalf("parseNetDevFeaturesSetReply failed: %v", err)
+	}
+
+	attrs = []syscall.NetlinkRouteAttr{
+		featureBitsetAttr(t, nl.ETHTOOL_A_FEATURES_WANTED, map[string]bool{
+			"tx-checksum-ipv4": false,
+			"rx-gro-hw":        true,
+		}, false),
+		featureBitsetAttr(t, nl.ETHTOOL_A_FEATURES_ACTIVE, nil, false),
+	}
+	err := parseNetDevFeaturesSetReply(attrs)
+	const want = "netlink: ethtool did not apply requested feature changes: rx-gro-hw=on, tx-checksum-ipv4=off"
+	if err == nil || err.Error() != want {
+		t.Fatalf("error = %v, want %q", err, want)
+	}
+}
+
+func TestVerifyNetDevFeatureStates(t *testing.T) {
+	features := map[string]NetDevFeature{
+		"rx-gro-hw": {Active: true},
+	}
+	if err := verifyNetDevFeatureStates(map[string]bool{"rx-gro-hw": true}, features); err != nil {
+		t.Fatalf("verifyNetDevFeatureStates failed: %v", err)
+	}
+
+	err := verifyNetDevFeatureStates(map[string]bool{
+		"tx-checksum-ipv4": false,
+		"rx-gro-hw":        false,
+	}, features)
+	const want = "netlink: ethtool did not apply requested feature changes: rx-gro-hw=off, tx-checksum-ipv4=off"
+	if err == nil || err.Error() != want {
+		t.Fatalf("error = %v, want %q", err, want)
+	}
+}
+
+func TestParseNetDevFeaturesSetReplyRejectsMalformedData(t *testing.T) {
+	tests := []struct {
+		name  string
+		attrs []syscall.NetlinkRouteAttr
+	}{
+		{
+			name: "missing wanted bitset",
+			attrs: []syscall.NetlinkRouteAttr{
+				featureBitsetAttr(t, nl.ETHTOOL_A_FEATURES_ACTIVE, nil, false),
+			},
+		},
+		{
+			name: "missing active bitset",
+			attrs: []syscall.NetlinkRouteAttr{
+				featureBitsetAttr(t, nl.ETHTOOL_A_FEATURES_WANTED, nil, false),
+			},
+		},
+		{
+			name: "malformed active bitset",
+			attrs: []syscall.NetlinkRouteAttr{
+				featureBitsetAttr(t, nl.ETHTOOL_A_FEATURES_WANTED, nil, false),
+				routeAttr(nl.ETHTOOL_A_FEATURES_ACTIVE, nil),
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := parseNetDevFeaturesSetReply(test.attrs); err == nil {
+				t.Fatal("accepted a malformed features set reply")
+			}
+		})
+	}
+}
+
+func TestParseNetDevFeatureBitsetAcceptsNonTerminatedName(t *testing.T) {
+	bitset := nl.NewRtAttr(unix.NLA_F_NESTED|nl.ETHTOOL_A_FEATURES_ACTIVE, nil)
+	bits := bitset.AddRtAttr(unix.NLA_F_NESTED|nl.ETHTOOL_A_BITSET_BITS, nil)
+	bit := bits.AddRtAttr(unix.NLA_F_NESTED|nl.ETHTOOL_A_BITSET_BITS_BIT, nil)
+	bit.AddRtAttr(nl.ETHTOOL_A_BITSET_BIT_NAME, []byte("rx-gro-hw"))
+	bit.AddRtAttr(nl.ETHTOOL_A_BITSET_BIT_VALUE, nil)
+
+	attr := parseSerializedAttrs(t, []*nl.RtAttr{bitset})[0]
+	got, err := parseNetDevFeatureBitset(attr)
+	if err != nil {
+		t.Fatalf("parseNetDevFeatureBitset failed: %v", err)
+	}
+	want := map[string]bool{"rx-gro-hw": true}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("features = %v, want %v", got, want)
+	}
+}
+
+func TestParseNetDevFeatureBitsetSkipsUnnamedBits(t *testing.T) {
+	attr := featureBitsetAttr(t, nl.ETHTOOL_A_FEATURES_ACTIVE, map[string]bool{"": true}, true)
+	got, err := parseNetDevFeatureBitset(attr)
+	if err != nil {
+		t.Fatalf("parseNetDevFeatureBitset failed: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("features = %v, want empty", got)
+	}
+}
+
+func TestParseNetDevFeatureBitsetRejectsMalformedData(t *testing.T) {
+	compact := nl.NewRtAttr(unix.NLA_F_NESTED|nl.ETHTOOL_A_FEATURES_ACTIVE, nil)
+	compact.AddRtAttr(nl.ETHTOOL_A_BITSET_VALUE, []byte{1, 0, 0, 0})
+	tests := []struct {
+		name string
+		attr syscall.NetlinkRouteAttr
+	}{
+		{
+			name: "compact",
+			attr: parseSerializedAttrs(t, []*nl.RtAttr{compact})[0],
+		},
+		{
+			name: "missing bits",
+			attr: routeAttr(nl.ETHTOOL_A_FEATURES_ACTIVE, nil),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := parseNetDevFeatureBitset(test.attr); err == nil {
+				t.Fatal("accepted malformed feature bitset")
+			}
+		})
+	}
+}
+
+func TestNewNetDevFeaturesSetAttrs(t *testing.T) {
+	attrs, err := newNetDevFeaturesSetAttrs(7, map[string]bool{
+		"tx-checksum-ipv4": false,
+		"rx-gro-hw":        true,
+	})
+	if err != nil {
+		t.Fatalf("newNetDevFeaturesSetAttrs failed: %v", err)
+	}
+	top := attrsByType(parseSerializedAttrs(t, attrs))
+	wanted := top[nl.ETHTOOL_A_FEATURES_WANTED]
+	wantedAttrs, err := nl.ParseRouteAttr(wanted.Value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bits := attrsByType(wantedAttrs)[nl.ETHTOOL_A_BITSET_BITS]
+	entries, err := nl.ParseRouteAttr(bits.Value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("encoded %d feature entries, want 2", len(entries))
+	}
+
+	names := make([]string, 0, 2)
+	values := make(map[string]bool)
+	for _, entry := range entries {
+		fields, err := nl.ParseRouteAttr(entry.Value)
+		if err != nil {
+			t.Fatal(err)
+		}
+		byType := attrsByType(fields)
+		nameValue := byType[nl.ETHTOOL_A_BITSET_BIT_NAME].Value
+		name := string(nameValue[:len(nameValue)-1])
+		names = append(names, name)
+		_, values[name] = byType[nl.ETHTOOL_A_BITSET_BIT_VALUE]
+	}
+	if !reflect.DeepEqual(names, []string{"rx-gro-hw", "tx-checksum-ipv4"}) {
+		t.Fatalf("feature order = %v", names)
+	}
+	if !values["rx-gro-hw"] || values["tx-checksum-ipv4"] {
+		t.Fatalf("feature values = %v", values)
+	}
+}
+
+func TestNewNetDevFeaturesSetAttrsRejectsInvalidConfig(t *testing.T) {
+	tests := []map[string]bool{
+		nil,
+		{"": true},
+		{"bad\x00name": true},
+	}
+	for _, config := range tests {
+		if _, err := newNetDevFeaturesSetAttrs(1, config); err == nil {
+			t.Fatalf("accepted invalid feature config %#v", config)
+		}
+	}
+}

--- a/nl/ethtool_linux.go
+++ b/nl/ethtool_linux.go
@@ -2,7 +2,7 @@ package nl
 
 // Constants for the "ethtool" generic netlink family, mirroring
 // include/uapi/linux/ethtool_netlink_generated.h. Only the subset used for
-// ring parameters and RSS configuration is defined here.
+// feature, ring parameter, and RSS configuration is defined here.
 
 const (
 	ETHTOOL_GENL_NAME    = "ethtool"
@@ -12,10 +12,12 @@ const (
 // ethtool message commands. Values are explicit because RSS_SET was appended
 // to the UAPI after RSS_GET.
 const (
-	ETHTOOL_MSG_RINGS_GET = 15
-	ETHTOOL_MSG_RINGS_SET = 16
-	ETHTOOL_MSG_RSS_GET   = 38
-	ETHTOOL_MSG_RSS_SET   = 48
+	ETHTOOL_MSG_FEATURES_GET = 11
+	ETHTOOL_MSG_FEATURES_SET = 12
+	ETHTOOL_MSG_RINGS_GET    = 15
+	ETHTOOL_MSG_RINGS_SET    = 16
+	ETHTOOL_MSG_RSS_GET      = 38
+	ETHTOOL_MSG_RSS_SET      = 48
 )
 
 // Common request header attributes.
@@ -25,6 +27,38 @@ const (
 	ETHTOOL_A_HEADER_DEV_NAME
 	ETHTOOL_A_HEADER_FLAGS
 	ETHTOOL_A_HEADER_PHY_INDEX
+)
+
+// Generic bitset attributes.
+const (
+	ETHTOOL_A_BITSET_UNSPEC = iota
+	ETHTOOL_A_BITSET_NOMASK
+	ETHTOOL_A_BITSET_SIZE
+	ETHTOOL_A_BITSET_BITS
+	ETHTOOL_A_BITSET_VALUE
+	ETHTOOL_A_BITSET_MASK
+)
+
+const (
+	ETHTOOL_A_BITSET_BITS_UNSPEC = iota
+	ETHTOOL_A_BITSET_BITS_BIT
+)
+
+const (
+	ETHTOOL_A_BITSET_BIT_UNSPEC = iota
+	ETHTOOL_A_BITSET_BIT_INDEX
+	ETHTOOL_A_BITSET_BIT_NAME
+	ETHTOOL_A_BITSET_BIT_VALUE
+)
+
+// Feature attributes.
+const (
+	ETHTOOL_A_FEATURES_UNSPEC = iota
+	ETHTOOL_A_FEATURES_HEADER
+	ETHTOOL_A_FEATURES_HW
+	ETHTOOL_A_FEATURES_WANTED
+	ETHTOOL_A_FEATURES_ACTIVE
+	ETHTOOL_A_FEATURES_NOCHANGE
 )
 
 // Ring parameter attributes.


### PR DESCRIPTION
## Description

Expose named feature state and partial wanted-state updates through the ethtool generic netlink API. Named bitsets allow features to be addressed by name, so callers can update specific features directly without first looking up their numeric bit positions. Features omitted from an update remain unchanged.

This lets callers configure driver prerequisites such as rx-gro-hw on mlx5, where the setup needed by io_uring zero-copy receive is exposed as a feature rather than a ring parameter.

These changes will help Cilium take advantage of the zero-copy networking features added in Linux 7.1—see the [upstream queue-leasing merge](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=15089225889ba4b29f0263757cd66932fa676cb0).

## Testing

Example usage:

```
const (
         hardwareGROFeature      = "rx-gro-hw"
)

var hardwareGRO netlink.NetDevFeature
requiresHardwareGRO := rings.TCPDataSplit == netlink.NetDevTCPDataSplitUnknown
if requiresHardwareGRO {
        features, err := netlinkNetDevFeaturesGet(link.Attrs().Index)
        if err != nil {
                return nil, fmt.Errorf("failed to read features on %s: %w", dev.PhysicalIfName, err)
        }
        var ok bool
        hardwareGRO, ok = features[hardwareGROFeature]
        if !ok || !hardwareGRO.Hardware || (!hardwareGRO.Active && (hardwareGRO.NoChange || hardwareGRO.Wanted))
                return nil, fmt.Errorf("TCP data splitting is not supported on %s: %w", dev.PhysicalIfName, unix.EOPNOTSUPP)
        }
 }

...

if requiresHardwareGRO {
        if !hardwareGRO.Active {
                if err := netlinkNetDevFeaturesSet(state.ifIndex, map[string]bool{hardwareGROFeature: true}); err != nil {
                        return nil, fmt.Errorf("failed to enable hardware GRO on %s: %w", state.ifName, err)
                }
                state.hardwareGROChanged = true
        }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Linux network device feature support, including retrieving feature states and applying requested enable/disable changes.
  * Reports hardware, active, requested, and unchanged feature states.
  * Preserves unspecified features when updating selected settings.
  * Provides reliable validation and deterministic handling of feature data and responses.

* **Tests**
  * Added comprehensive coverage for feature parsing, validation, retrieval, updates, malformed data, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->