### PR TITLE
link: reject oversized TUN/TAP names in LinkAdd

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -1493,47 +1493,48 @@ func (h *Handle) linkModify(link Link, flags int) error {
 		}
 
 		queues := tuntap.Queues
-
-		var fds []*os.File
-		var req ifReq
-		copy(req.Name[:15], base.Name)
-
-		req.Flags = uint16(tuntap.Flags)
+		flags := uint16(tuntap.Flags)
 
 		if queues == 0 { //Legacy compatibility
 			queues = 1
 			if tuntap.Flags == 0 {
-				req.Flags = uint16(TUNTAP_DEFAULTS)
+				flags = uint16(TUNTAP_DEFAULTS)
 			}
 		} else {
 			// For best peformance set Flags to TUNTAP_MULTI_QUEUE_DEFAULTS | TUNTAP_VNET_HDR
 			// when a) KVM has support for this ABI and
 			//      b) the value of the flag is queryable using the TUNGETIFF ioctl
 			if tuntap.Flags == 0 {
-				req.Flags = uint16(TUNTAP_MULTI_QUEUE_DEFAULTS)
+				flags = uint16(TUNTAP_MULTI_QUEUE_DEFAULTS)
 			}
 		}
+		flags |= uint16(tuntap.Mode)
 
-		req.Flags |= uint16(tuntap.Mode)
+		req, err := unix.NewIfreq(base.Name)
+		if err != nil {
+			return fmt.Errorf("tuntap name %q is invalid: %w", base.Name, err)
+		}
+		req.SetUint16(flags)
+
+		var fds []*os.File
 		const TUN = "/dev/net/tun"
 		for i := 0; i < queues; i++ {
-			localReq := req
+			iterReq := *req
 			fd, err := unix.Open(TUN, os.O_RDWR|syscall.O_CLOEXEC, 0)
 			if err != nil {
 				cleanupFds(fds)
 				return err
 			}
 
-			_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), uintptr(unix.TUNSETIFF), uintptr(unsafe.Pointer(&localReq)))
-			if errno != 0 {
+			if err := unix.IoctlIfreq(fd, unix.TUNSETIFF, &iterReq); err != nil {
 				// close the new fd
 				unix.Close(fd)
 				// and the already opened ones
 				cleanupFds(fds)
-				return fmt.Errorf("Tuntap IOCTL TUNSETIFF failed [%d], errno %v", i, errno)
+				return fmt.Errorf("Tuntap IOCTL TUNSETIFF failed [%d]: %w", i, err)
 			}
 
-			_, _, errno = syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), syscall.TUNSETOWNER, uintptr(tuntap.Owner))
+			_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), syscall.TUNSETOWNER, uintptr(tuntap.Owner))
 			if errno != 0 {
 				cleanupFds(fds)
 				return fmt.Errorf("Tuntap IOCTL TUNSETOWNER failed [%d], errno %v", i, errno)
@@ -1574,14 +1575,14 @@ func (h *Handle) linkModify(link Link, flags int) error {
 			fds = append(fds, file)
 
 			// 1) we only care for the name of the first tap in the multi queue set
-			// 2) if the original name was empty, the localReq has now the actual name
+			// 2) if the original name was empty, iterReq has now the actual name
 			//
 			// In addition:
 			// This ensures that the link name is always identical to what the kernel returns.
 			// Not only in case of an empty name, but also when using name templates.
 			// e.g. when the provided name is "tap%d", the kernel replaces %d with the next available number.
 			if i == 0 {
-				link.Attrs().Name = strings.Trim(string(localReq.Name[:]), "\x00")
+				link.Attrs().Name = strings.Trim(iterReq.Name(), "\x00")
 			}
 
 		}

--- a/link_test.go
+++ b/link_test.go
@@ -3424,6 +3424,22 @@ func TestLinkByAliasWhenLinkIsNotFound(t *testing.T) {
 	}
 }
 
+func TestLinkAddTuntapNameTooLong(t *testing.T) {
+	// unix.NewIfreq rejects names of IFNAMSIZ bytes or more before any
+	// ioctl, so this does not need CAP_NET_ADMIN or a netns.
+	tap := &Tuntap{
+		LinkAttrs: LinkAttrs{Name: strings.Repeat("x", unix.IFNAMSIZ)},
+		Mode:      TUNTAP_MODE_TAP,
+	}
+	err := LinkAdd(tap)
+	if err == nil {
+		t.Fatal("LinkAdd succeeded for a name that does not fit in IFNAMSIZ")
+	}
+	if !errors.Is(err, unix.EINVAL) {
+		t.Fatalf("LinkAdd error = %v, want EINVAL from unix.NewIfreq", err)
+	}
+}
+
 func TestLinkAddDelTuntap(t *testing.T) {
 	t.Cleanup(setUpNetlinkTest(t))
 

--- a/link_tuntap_linux.go
+++ b/link_tuntap_linux.go
@@ -9,20 +9,14 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// ideally golang.org/x/sys/unix would define IfReq but it only has
-// IFNAMSIZ, hence this minimalistic implementation
+// IFNAMSIZ is the kernel limit on interface name length, including the
+// trailing NUL. User-visible names are at most IFNAMSIZ-1 bytes.
 const (
 	SizeOfIfReq = 40
 	IFNAMSIZ    = 16
 )
 
 const TUN = "/dev/net/tun"
-
-type ifReq struct {
-	Name  [IFNAMSIZ]byte
-	Flags uint16
-	pad   [SizeOfIfReq - IFNAMSIZ - 2]byte
-}
 
 // AddQueues opens and attaches multiple queue file descriptors to an existing
 // TUN/TAP interface in multi-queue mode.


### PR DESCRIPTION
## Summary

`LinkAdd` for TUN/TAP devices silently truncated interface names longer than 15 bytes. Callers then stored a name that did not match the device the kernel actually created, and later lookups/ioctls failed with confusing errors (`ERANGE` / `EINVAL`) instead of failing at create time.

This change rejects those names up front, the same way `Tuntap.AddQueues` and `unix.NewIfreq` already do.

## Problem

Linux `IFNAMSIZ` is 16, including a trailing NUL, so a user-visible name may be at most 15 bytes. `ip link add` reports `"name" too long`.

TUN/TAP `LinkAdd` did not follow that. It built a local `ifReq` and copied the name with:

```go
copy(req.Name[:15], base.Name)
```

For a 16-byte name such as `z192.168.195.183`:

1. `LinkAdd` succeeds.
2. The kernel device is actually `z192.168.195.18` (last byte dropped).
3. `link.Attrs().Name` is later refreshed from the ioctl result, but many callers keep the original string they passed in.
4. A later `LinkByName` / `unix.NewIfreq` / `TUNSETIFF` using the original 16-byte name fails. `unix.NewIfreq` returns `EINVAL` because `len(name) >= IFNAMSIZ`. Netlink `IFLA_IFNAME` is limited to `IFNAMSIZ-1`, so the kernel can also return `ERANGE` (`numerical result out of range`).

That split is hard to debug: create looked fine, and the failure showed up on a completely different path (for example reopening a pooled TAP fd).

The same repository already avoids this in `Tuntap.AddQueues` by calling `unix.NewIfreq`, which documents that a trailing NUL must fit.

## Change

In `linkModify`’s TUN/TAP branch:

- Validate the name with `unix.NewIfreq` and return an error if it does not fit (`EINVAL`, wrapped with the invalid name).
- Issue `TUNSETIFF` via `unix.IoctlIfreq` instead of a hand-rolled `ifReq` + `copy(Name[:15], …)`.
- Keep a per-queue copy of the `Ifreq` (same idea as the old `localReq` value copy) so one `TUNSETIFF` cannot leak flags into the next queue.
- Still write the kernel-returned name back onto `link.Attrs().Name` for empty names and templates such as `tap%d`.

Empty names (kernel-assigned) and names of length 1–15 are unchanged.

The unexported `ifReq` type is removed; it is unused after this. Exported `IFNAMSIZ` / `SizeOfIfReq` stay as part of the public API.

## Test

`TestLinkAddTuntapNameTooLong` asserts that a 16-byte TUN/TAP name fails `LinkAdd` with `unix.EINVAL`. `unix.NewIfreq` rejects the name before any ioctl, so the test does not need `CAP_NET_ADMIN` or a netns.

## Compatibility

This is a behavior change for invalid names only: `LinkAdd` now returns an error instead of creating a truncated device. Truncation was never documented, and callers that relied on it already had a name mismatch with the kernel.

Bond/ethtool ioctl helpers that still `copy(..., [:IFNAMSIZ-1])` are left alone; they are not the TUN/TAP create path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TUN/TAP interface creation reliability on Linux.
  - Interface names that exceed the supported length are now rejected with a clear validation error before setup begins.
  - Errors during multi-queue interface setup now include the affected queue index, making failures easier to diagnose.
  - Interface names are now reported consistently after successful creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->