### PR TITLE
ipset: avoid panic on non-errno errors

### DIFF
--- a/ipset_linux.go
+++ b/ipset_linux.go
@@ -470,13 +470,15 @@ func getIpsetDefaultRevision(typename string, featureFlags uint32) uint8 {
 
 func ipsetExecute(req *nl.NetlinkRequest) (msgs [][]byte, err error) {
 	msgs, err = req.Execute(unix.NETLINK_NETFILTER, 0)
+	return msgs, ipsetError(err)
+}
 
-	if err != nil {
-		if errno := int(err.(syscall.Errno)); errno >= nl.IPSET_ERR_PRIVATE {
-			err = nl.IPSetError(uintptr(errno))
-		}
+func ipsetError(err error) error {
+	errno, ok := err.(syscall.Errno)
+	if !ok || int(errno) < nl.IPSET_ERR_PRIVATE {
+		return err
 	}
-	return
+	return nl.IPSetError(uintptr(errno))
 }
 
 func ipsetUnserialize(msgs [][]byte) (result IPSetResult) {

--- a/ipset_linux_test.go
+++ b/ipset_linux_test.go
@@ -2,13 +2,66 @@ package netlink
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"net"
 	"os"
+	"syscall"
 	"testing"
 
 	"github.com/vishvananda/netlink/nl"
 	"golang.org/x/sys/unix"
 )
+
+func TestIpsetError(t *testing.T) {
+	ordinaryErr := errors.New("ordinary error")
+	privateErrno := syscall.Errno(nl.IPSET_ERR_EXIST)
+	wrappedErrno := fmt.Errorf("extended acknowledgment: %w", privateErrno)
+
+	tests := []struct {
+		name string
+		err  error
+		want error
+	}{
+		{name: "nil", err: nil, want: nil},
+		{name: "ordinary errno", err: syscall.EINVAL, want: syscall.EINVAL},
+		{name: "private ipset errno", err: privateErrno, want: nl.IPSetError(privateErrno)},
+		{name: "ordinary error", err: ordinaryErr, want: ordinaryErr},
+		{name: "wrapped private errno", err: wrappedErrno, want: wrappedErrno},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ipsetError(tt.err); got != tt.want {
+				t.Fatalf("ipsetError(%v) = %v; want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIpsetExecuteReturnsNonErrno(t *testing.T) {
+	sock, err := nl.Subscribe(unix.NETLINK_NETFILTER)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sock.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	req := nl.NewNetlinkRequest(0, 0)
+	req.Sockets = map[int]*nl.SocketHandle{
+		unix.NETLINK_NETFILTER: {Socket: sock},
+	}
+
+	_, err = ipsetExecute(req)
+	if err == nil {
+		t.Fatal("expected closed socket error")
+	}
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		t.Fatalf("expected non-errno error, got %T: %v", err, err)
+	}
+}
 
 func TestParseIpsetProtocolResult(t *testing.T) {
 	msgBytes, err := os.ReadFile("testdata/ipset_protocol_result")


### PR DESCRIPTION
## Summary

Avoid an unchecked `syscall.Errno` assertion in `ipsetExecute`.

`NetlinkRequest.Execute` may also return dump-interruption errors,
validation errors, socket/file errors, or wrapped errno values carrying
extended acknowledgment text. The previous assertion panicked for those
errors.

Only direct private ipset errno values are now converted to
`nl.IPSetError`. All other errors are returned unchanged.

## Testing

- Added coverage for private and ordinary errno values.
- Added coverage ensuring wrapped and ordinary errors retain their identity.
- Added a closed-netlink-socket regression test reproducing the previous panic.
- Ran the complete privileged ipset test suite, including IPv4 and IPv6 cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented certain network configuration errors from causing application crashes.
  * Improved handling and reporting of unexpected error types.
  * Preserved the original error when it cannot be converted to a recognized IP set error.

* **Tests**
  * Added coverage for standard, wrapped, and unexpected error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->