### PR TITLE
nl: do not panic on truncated IfInfomsg

### DIFF
--- a/bridge_linux.go
+++ b/bridge_linux.go
@@ -54,6 +54,9 @@ func (h *Handle) bridgeVlanTunnelShowBy(ifindex int32) ([]nl.TunnelInfo, error) 
 	ret := make([]nl.TunnelInfo, 0)
 	for _, m := range msgs {
 		msg := nl.DeserializeIfInfomsg(m)
+		if msg == nil {
+			continue
+		}
 
 		if ifindex != 0 && msg.Index != ifindex {
 			continue
@@ -158,6 +161,9 @@ func (h *Handle) BridgeVlanList() (map[int32][]*nl.BridgeVlanInfo, error) {
 	ret := make(map[int32][]*nl.BridgeVlanInfo)
 	for _, m := range msgs {
 		msg := nl.DeserializeIfInfomsg(m)
+		if msg == nil {
+			return nil, fmt.Errorf("got short ifinfomsg from netlink")
+		}
 
 		attrs, err := nl.ParseRouteAttr(m[msg.Len():])
 		if err != nil {

--- a/link_linux.go
+++ b/link_linux.go
@@ -2141,6 +2141,9 @@ func execGetLink(req *nl.NetlinkRequest) (Link, error) {
 // a link object.
 func LinkDeserialize(hdr *unix.NlMsghdr, m []byte) (Link, error) {
 	msg := nl.DeserializeIfInfomsg(m)
+	if msg == nil {
+		return nil, fmt.Errorf("got short ifinfomsg from netlink")
+	}
 
 	attrs, err := nl.ParseRouteAttr(m[msg.Len():])
 	if err != nil {
@@ -2663,6 +2666,9 @@ func linkSubscribeAt(newNs, curNs netns.NsHandle, ch chan<- LinkUpdate, done <-c
 					continue
 				}
 				ifmsg := nl.DeserializeIfInfomsg(m.Data)
+				if ifmsg == nil {
+					continue
+				}
 				header := unix.NlMsghdr(m.Header)
 				link, err := LinkDeserialize(&header, m.Data)
 				if err != nil {

--- a/nl/nl_linux.go
+++ b/nl/nl_linux.go
@@ -178,6 +178,9 @@ func NewIfInfomsg(family int) *IfInfomsg {
 }
 
 func DeserializeIfInfomsg(b []byte) *IfInfomsg {
+	if len(b) < unix.SizeofIfInfomsg {
+		return nil
+	}
 	return (*IfInfomsg)(unsafe.Pointer(&b[0:unix.SizeofIfInfomsg][0]))
 }
 

--- a/nl/nl_linux_test.go
+++ b/nl/nl_linux_test.go
@@ -63,6 +63,15 @@ func TestIfInfomsgDeserializeSerialize(t *testing.T) {
 	testDeserializeSerialize(t, orig, safemsg, msg)
 }
 
+// Truncated IfInfomsg (e.g. 4-byte NLMSG_DONE/ERROR payload) must not panic.
+func TestDeserializeIfInfomsgShortBuffer(t *testing.T) {
+	b := make([]byte, 4)
+	msg := DeserializeIfInfomsg(b)
+	if msg != nil {
+		t.Fatalf("expected nil for %d-byte IfInfomsg (need %d)", len(b), unix.SizeofIfInfomsg)
+	}
+}
+
 func TestIfSocketCloses(t *testing.T) {
 	nlSock, err := Subscribe(unix.NETLINK_ROUTE, unix.RTNLGRP_NEIGH)
 	if err != nil {

--- a/protinfo_linux.go
+++ b/protinfo_linux.go
@@ -31,6 +31,9 @@ func (h *Handle) LinkGetProtinfo(link Link) (Protinfo, error) {
 
 	for _, m := range msgs {
 		ans := nl.DeserializeIfInfomsg(m)
+		if ans == nil {
+			continue
+		}
 		if int(ans.Index) != base.Index {
 			continue
 		}


### PR DESCRIPTION
DeserializeIfInfomsg used to slice the payload to `unix.SizeofIfInfomsg` unconditionally. A 4-byte `NLMSG_DONE`/`NLMSG_ERROR` payload (seen on UniFi Cloud Gateway Fiber) panics:

```
panic: runtime error: slice bounds out of range [:16] with capacity 4
```

Return nil when the buffer is too short (same as `DeserializeNhmsg`), and nil-check every caller so a short message is skipped or returned as an error instead of a nil-pointer dereference.

Fixes #1099

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when processing truncated or malformed network messages.
  * Prevented potential crashes while inspecting bridge, link, VLAN, and protocol information.
  * Invalid messages are now safely skipped or reported with an explicit error.

* **Tests**
  * Added regression coverage for truncated network message payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->