### PR TITLE
Add RuleSubscribe support

### DIFF
--- a/rule.go
+++ b/rule.go
@@ -80,3 +80,9 @@ type RuleUIDRange struct {
 	Start uint32
 	End   uint32
 }
+
+// RuleUpdate is sent when a rule changes - type is RTM_NEWRULE or RTM_DELRULE.
+type RuleUpdate struct {
+	Type uint16
+	Rule
+}

--- a/rule_linux.go
+++ b/rule_linux.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"syscall"
 
 	"github.com/vishvananda/netlink/nl"
+	"github.com/vishvananda/netns"
 	"golang.org/x/sys/unix"
 )
 
@@ -119,8 +121,8 @@ func ruleHandle(rule *Rule, req *nl.NetlinkRequest) error {
 		req.AddData(nl.NewRtAttr(nl.FRA_FLOW, b))
 	}
 	if rule.TunID > 0 {
-		b := make([]byte, 4)
-		native.PutUint32(b, uint32(rule.TunID))
+		b := make([]byte, 8)
+		networkOrder.PutUint64(b, uint64(rule.TunID))
 		req.AddData(nl.NewRtAttr(nl.FRA_TUN_ID, b))
 	}
 	if rule.Table >= 256 {
@@ -154,9 +156,7 @@ func ruleHandle(rule *Rule, req *nl.NetlinkRequest) error {
 	}
 
 	if rule.IPProto > 0 {
-		b := make([]byte, 4)
-		native.PutUint32(b, uint32(rule.IPProto))
-		req.AddData(nl.NewRtAttr(nl.FRA_IP_PROTO, b))
+		req.AddData(nl.NewRtAttr(nl.FRA_IP_PROTO, nl.Uint8Attr(uint8(rule.IPProto))))
 	}
 
 	if rule.Dport != nil {
@@ -227,71 +227,9 @@ func (h *Handle) RuleListFiltered(family int, filter *Rule, filterMask uint64) (
 
 	var res = make([]Rule, 0)
 	for i := range msgs {
-		msg := nl.DeserializeRtMsg(msgs[i])
-		attrs, err := nl.ParseRouteAttr(msgs[i][msg.Len():])
+		rule, err := deserializeRule(msgs[i])
 		if err != nil {
 			return nil, err
-		}
-
-		rule := NewRule()
-		rule.Priority = 0 // The default priority from kernel
-
-		rule.Invert = msg.Flags&FibRuleInvert > 0
-		rule.Family = int(msg.Family)
-		rule.Tos = uint(msg.Tos)
-
-		for j := range attrs {
-			switch attrs[j].Attr.Type {
-			case unix.RTA_TABLE:
-				rule.Table = int(native.Uint32(attrs[j].Value[0:4]))
-			case nl.FRA_SRC:
-				rule.Src = &net.IPNet{
-					IP:   attrs[j].Value,
-					Mask: net.CIDRMask(int(msg.Src_len), 8*len(attrs[j].Value)),
-				}
-			case nl.FRA_DST:
-				rule.Dst = &net.IPNet{
-					IP:   attrs[j].Value,
-					Mask: net.CIDRMask(int(msg.Dst_len), 8*len(attrs[j].Value)),
-				}
-			case nl.FRA_FWMARK:
-				rule.Mark = native.Uint32(attrs[j].Value[0:4])
-			case nl.FRA_FWMASK:
-				mask := native.Uint32(attrs[j].Value[0:4])
-				rule.Mask = &mask
-			case nl.FRA_TUN_ID:
-				rule.TunID = uint(native.Uint64(attrs[j].Value[0:8]))
-			case nl.FRA_IIFNAME:
-				rule.IifName = string(attrs[j].Value[:len(attrs[j].Value)-1])
-			case nl.FRA_OIFNAME:
-				rule.OifName = string(attrs[j].Value[:len(attrs[j].Value)-1])
-			case nl.FRA_SUPPRESS_PREFIXLEN:
-				i := native.Uint32(attrs[j].Value[0:4])
-				if i != 0xffffffff {
-					rule.SuppressPrefixlen = int(i)
-				}
-			case nl.FRA_SUPPRESS_IFGROUP:
-				i := native.Uint32(attrs[j].Value[0:4])
-				if i != 0xffffffff {
-					rule.SuppressIfgroup = int(i)
-				}
-			case nl.FRA_FLOW:
-				rule.Flow = int(native.Uint32(attrs[j].Value[0:4]))
-			case nl.FRA_GOTO:
-				rule.Goto = int(native.Uint32(attrs[j].Value[0:4]))
-			case nl.FRA_PRIORITY:
-				rule.Priority = int(native.Uint32(attrs[j].Value[0:4]))
-			case nl.FRA_IP_PROTO:
-				rule.IPProto = int(native.Uint32(attrs[j].Value[0:4]))
-			case nl.FRA_DPORT_RANGE:
-				rule.Dport = NewRulePortRange(native.Uint16(attrs[j].Value[0:2]), native.Uint16(attrs[j].Value[2:4]))
-			case nl.FRA_SPORT_RANGE:
-				rule.Sport = NewRulePortRange(native.Uint16(attrs[j].Value[0:2]), native.Uint16(attrs[j].Value[2:4]))
-			case nl.FRA_UID_RANGE:
-				rule.UIDRange = NewRuleUIDRange(native.Uint32(attrs[j].Value[0:4]), native.Uint32(attrs[j].Value[4:8]))
-			case nl.FRA_PROTOCOL:
-				rule.Protocol = uint8(attrs[j].Value[0])
-			}
 		}
 
 		if filter != nil {
@@ -316,10 +254,208 @@ func (h *Handle) RuleListFiltered(family int, filter *Rule, filterMask uint64) (
 			}
 		}
 
-		res = append(res, *rule)
+		res = append(res, rule)
 	}
 
 	return res, executeErr
+}
+
+func deserializeRule(m []byte) (Rule, error) {
+	msg := nl.DeserializeRtMsg(m)
+	attrs, err := nl.ParseRouteAttr(m[msg.Len():])
+	if err != nil {
+		return Rule{}, err
+	}
+
+	rule := NewRule()
+
+	rule.Invert = msg.Flags&FibRuleInvert > 0
+	rule.Tos = uint(msg.Tos)
+	// The kernel returns the table id in rtmsg.table for values < 256 and as
+	// the RTA_TABLE attribute for larger values. Start with the header value.
+	rule.Table = int(msg.Table)
+
+	for j := range attrs {
+		switch attrs[j].Attr.Type {
+		case unix.RTA_TABLE:
+			rule.Table = int(native.Uint32(attrs[j].Value[0:4]))
+		case nl.FRA_SRC:
+			rule.Src = &net.IPNet{
+				IP:   attrs[j].Value,
+				Mask: net.CIDRMask(int(msg.Src_len), 8*len(attrs[j].Value)),
+			}
+		case nl.FRA_DST:
+			rule.Dst = &net.IPNet{
+				IP:   attrs[j].Value,
+				Mask: net.CIDRMask(int(msg.Dst_len), 8*len(attrs[j].Value)),
+			}
+		case nl.FRA_FWMARK:
+			rule.Mark = native.Uint32(attrs[j].Value[0:4])
+		case nl.FRA_FWMASK:
+			mask := native.Uint32(attrs[j].Value[0:4])
+			rule.Mask = &mask
+		case nl.FRA_TUN_ID:
+			rule.TunID = uint(networkOrder.Uint64(attrs[j].Value[0:8]))
+		case nl.FRA_IIFNAME:
+			rule.IifName = string(attrs[j].Value[:len(attrs[j].Value)-1])
+		case nl.FRA_OIFNAME:
+			rule.OifName = string(attrs[j].Value[:len(attrs[j].Value)-1])
+		case nl.FRA_SUPPRESS_PREFIXLEN:
+			i := native.Uint32(attrs[j].Value[0:4])
+			if i != 0xffffffff {
+				rule.SuppressPrefixlen = int(i)
+			}
+		case nl.FRA_SUPPRESS_IFGROUP:
+			i := native.Uint32(attrs[j].Value[0:4])
+			if i != 0xffffffff {
+				rule.SuppressIfgroup = int(i)
+			}
+		case nl.FRA_FLOW:
+			rule.Flow = int(native.Uint32(attrs[j].Value[0:4]))
+		case nl.FRA_GOTO:
+			rule.Goto = int(native.Uint32(attrs[j].Value[0:4]))
+		case nl.FRA_PRIORITY:
+			rule.Priority = int(native.Uint32(attrs[j].Value[0:4]))
+		case nl.FRA_IP_PROTO:
+			rule.IPProto = int(attrs[j].Value[0])
+		case nl.FRA_DPORT_RANGE:
+			rule.Dport = NewRulePortRange(native.Uint16(attrs[j].Value[0:2]), native.Uint16(attrs[j].Value[2:4]))
+		case nl.FRA_SPORT_RANGE:
+			rule.Sport = NewRulePortRange(native.Uint16(attrs[j].Value[0:2]), native.Uint16(attrs[j].Value[2:4]))
+		case nl.FRA_UID_RANGE:
+			rule.UIDRange = NewRuleUIDRange(native.Uint32(attrs[j].Value[0:4]), native.Uint32(attrs[j].Value[4:8]))
+		case nl.FRA_PROTOCOL:
+			rule.Protocol = uint8(attrs[j].Value[0])
+		}
+	}
+
+	// Some kernels omit FRA_PRIORITY when the rule priority is 0. Since 0 is a
+	// valid priority (e.g. the local-table rule), default to 0 if no attribute
+	// was present.
+	if rule.Priority < 0 {
+		rule.Priority = 0
+	}
+
+	rule.Family = int(msg.Family)
+	rule.Type = msg.Type
+
+	return *rule, nil
+}
+
+// RuleSubscribe takes a chan down which notifications will be sent
+// when rules are added or deleted. The 'done' chan must be closed to stop the
+// subscription and release the underlying socket/goroutine.
+func RuleSubscribe(ch chan<- RuleUpdate, done <-chan struct{}) error {
+	return ruleSubscribeAt(netns.None(), netns.None(), ch, done, nil, false, 0, nil, false)
+}
+
+// RuleSubscribeAt works like RuleSubscribe plus it allows the caller
+// to choose the network namespace in which to subscribe (ns).
+// The 'done' chan must be closed to stop the subscription and release resources.
+func RuleSubscribeAt(ns netns.NsHandle, ch chan<- RuleUpdate, done <-chan struct{}) error {
+	return ruleSubscribeAt(ns, netns.None(), ch, done, nil, false, 0, nil, false)
+}
+
+// RuleSubscribeOptions contains a set of options to use with
+// RuleSubscribeWithOptions.
+type RuleSubscribeOptions struct {
+	Namespace              *netns.NsHandle
+	ErrorCallback          func(error)
+	ListExisting           bool
+	ReceiveBufferSize      int
+	ReceiveBufferForceSize bool
+	ReceiveTimeout         *unix.Timeval
+}
+
+// RuleSubscribeWithOptions works like RuleSubscribe but enables
+// additional options to modify the behavior.
+func RuleSubscribeWithOptions(ch chan<- RuleUpdate, done <-chan struct{}, options RuleSubscribeOptions) error {
+	if options.Namespace == nil {
+		none := netns.None()
+		options.Namespace = &none
+	}
+	return ruleSubscribeAt(*options.Namespace, netns.None(), ch, done, options.ErrorCallback, options.ListExisting,
+		options.ReceiveBufferSize, options.ReceiveTimeout, options.ReceiveBufferForceSize)
+}
+
+func ruleSubscribeAt(newNs, curNs netns.NsHandle, ch chan<- RuleUpdate, done <-chan struct{}, cberr func(error), listExisting bool,
+	rcvbuf int, rcvTimeout *unix.Timeval, rcvBufForce bool) error {
+	s, err := nl.SubscribeAt(newNs, curNs, unix.NETLINK_ROUTE, unix.RTNLGRP_IPV4_RULE, unix.RTNLGRP_IPV6_RULE)
+	if err != nil {
+		return err
+	}
+	if rcvTimeout != nil {
+		if err := s.SetReceiveTimeout(rcvTimeout); err != nil {
+			return err
+		}
+	}
+	if rcvbuf != 0 {
+		err = s.SetReceiveBufferSize(rcvbuf, rcvBufForce)
+		if err != nil {
+			return err
+		}
+	}
+	if done != nil {
+		go func() {
+			<-done
+			s.Close()
+		}()
+	}
+	if listExisting {
+		req := pkgHandle().newNetlinkRequest(unix.RTM_GETRULE, unix.NLM_F_DUMP)
+		infmsg := nl.NewIfInfomsg(unix.AF_UNSPEC)
+		req.AddData(infmsg)
+		if err := s.Send(req); err != nil {
+			s.Close()
+			return err
+		}
+	}
+	go func() {
+		defer close(ch)
+		for {
+			msgs, from, err := s.Receive()
+			if err != nil {
+				if cberr != nil {
+					cberr(fmt.Errorf("Receive failed: %v", err))
+				}
+				return
+			}
+			if from.Pid != nl.PidKernel {
+				if cberr != nil {
+					cberr(fmt.Errorf("Wrong sender portid %d, expected %d", from.Pid, nl.PidKernel))
+				}
+				continue
+			}
+			for _, m := range msgs {
+				if m.Header.Flags&unix.NLM_F_DUMP_INTR != 0 && cberr != nil {
+					cberr(ErrDumpInterrupted)
+				}
+				if m.Header.Type == unix.NLMSG_DONE {
+					continue
+				}
+				if m.Header.Type == unix.NLMSG_ERROR {
+					error := int32(native.Uint32(m.Data[0:4]))
+					if error == 0 {
+						continue
+					}
+					if cberr != nil {
+						cberr(fmt.Errorf("error message: %v", syscall.Errno(-error)))
+					}
+					continue
+				}
+				rule, err := deserializeRule(m.Data)
+				if err != nil {
+					if cberr != nil {
+						cberr(err)
+					}
+					continue
+				}
+				ch <- RuleUpdate{Type: m.Header.Type, Rule: rule}
+			}
+		}
+	}()
+
+	return nil
 }
 
 func (pr *RulePortRange) toRtAttrData() []byte {

--- a/rule_test.go
+++ b/rule_test.go
@@ -5,9 +5,11 @@ package netlink
 
 import (
 	"net"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/vishvananda/netns"
 	"golang.org/x/sys/unix"
 )
 
@@ -50,6 +52,9 @@ func TestRuleAddDel(t *testing.T) {
 	if len(rules) != len(rulesBegin)+1 {
 		t.Fatal("Rule not added properly")
 	}
+
+	// The kernel normalizes an unset (RTN_UNSPEC) type to RTN_UNICAST.
+	rule.Type = unix.RTN_UNICAST
 
 	// find this rule
 	found := ruleExists(rules, *rule)
@@ -586,6 +591,10 @@ func runRuleListFiltered(t *testing.T, family int, srcNet, dstNet *net.IPNet) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Cleanup(setUpNetlinkTest(t))
 			rule := tt.preRun()
+			if rule != nil && rule.Type == 0 {
+				// The kernel normalizes an unset (RTN_UNSPEC) type to RTN_UNICAST.
+				rule.Type = unix.RTN_UNICAST
+			}
 			wantRules, wantErr := tt.setupWant(rule)
 
 			rules, err := RuleListFiltered(family, tt.ruleFilter, tt.filterMask)
@@ -666,6 +675,219 @@ func TestRuleString(t *testing.T) {
 	}
 }
 
+func expectRuleUpdate(ch <-chan RuleUpdate, t uint16, want Rule) bool {
+	timeout := time.After(time.Minute)
+	for {
+		select {
+		case update, ok := <-ch:
+			if !ok {
+				return false
+			}
+			if update.Type != t {
+				continue
+			}
+			if update.Rule.Priority != want.Priority {
+				continue
+			}
+			if update.Rule.Table != want.Table {
+				continue
+			}
+			if (update.Rule.Src == nil) != (want.Src == nil) {
+				continue
+			}
+			if update.Rule.Src != nil && !update.Rule.Src.IP.Equal(want.Src.IP) {
+				continue
+			}
+			return true
+		case <-timeout:
+			return false
+		}
+	}
+}
+
+func TestRuleSubscribe(t *testing.T) {
+	skipUnlessRoot(t)
+	defer setUpNetlinkTest(t)()
+
+	ch := make(chan RuleUpdate)
+	done := make(chan struct{})
+	defer close(done)
+	if err := RuleSubscribe(ch, done); err != nil {
+		t.Fatal(err)
+	}
+
+	src := &net.IPNet{
+		IP:   net.IPv4(192, 168, 1, 0),
+		Mask: net.CIDRMask(24, 32),
+	}
+	rule := NewRule()
+	rule.Src = src
+	rule.Table = unix.RT_TABLE_MAIN
+	rule.Priority = 1000
+	if err := RuleAdd(rule); err != nil {
+		t.Fatal(err)
+	}
+	if !expectRuleUpdate(ch, unix.RTM_NEWRULE, *rule) {
+		t.Fatal("Add update not received as expected")
+	}
+	if err := RuleDel(rule); err != nil {
+		t.Fatal(err)
+	}
+	if !expectRuleUpdate(ch, unix.RTM_DELRULE, *rule) {
+		t.Fatal("Del update not received as expected")
+	}
+}
+
+func TestRuleSubscribeWithOptions(t *testing.T) {
+	skipUnlessRoot(t)
+	defer setUpNetlinkTest(t)()
+
+	ch := make(chan RuleUpdate)
+	done := make(chan struct{})
+	defer close(done)
+	var lastError atomic.Value
+	defer func() {
+		if err, ok := lastError.Load().(error); ok && err != nil {
+			t.Fatalf("Fatal error received during subscription: %v", err)
+		}
+	}()
+	if err := RuleSubscribeWithOptions(ch, done, RuleSubscribeOptions{
+		ErrorCallback: func(err error) {
+			lastError.Store(err)
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	src := &net.IPNet{
+		IP:   net.IPv4(192, 168, 2, 0),
+		Mask: net.CIDRMask(24, 32),
+	}
+	rule := NewRule()
+	rule.Src = src
+	rule.Table = unix.RT_TABLE_MAIN
+	rule.Priority = 1001
+	if err := RuleAdd(rule); err != nil {
+		t.Fatal(err)
+	}
+	if !expectRuleUpdate(ch, unix.RTM_NEWRULE, *rule) {
+		t.Fatal("Add update not received as expected")
+	}
+}
+
+func TestRuleSubscribeAt(t *testing.T) {
+	skipUnlessRoot(t)
+
+	newNs, err := netns.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer newNs.Close()
+
+	nh, err := NewHandleAt(newNs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer nh.Close()
+
+	ch := make(chan RuleUpdate)
+	done := make(chan struct{})
+	defer close(done)
+	if err := RuleSubscribeAt(newNs, ch, done); err != nil {
+		t.Fatal(err)
+	}
+
+	src := &net.IPNet{
+		IP:   net.IPv4(192, 169, 1, 0),
+		Mask: net.CIDRMask(24, 32),
+	}
+	rule := NewRule()
+	rule.Src = src
+	rule.Table = unix.RT_TABLE_MAIN
+	rule.Priority = 1002
+	if err := nh.RuleAdd(rule); err != nil {
+		t.Fatal(err)
+	}
+	if !expectRuleUpdate(ch, unix.RTM_NEWRULE, *rule) {
+		t.Fatal("Add update not received as expected")
+	}
+	if err := nh.RuleDel(rule); err != nil {
+		t.Fatal(err)
+	}
+	if !expectRuleUpdate(ch, unix.RTM_DELRULE, *rule) {
+		t.Fatal("Del update not received as expected")
+	}
+}
+
+func TestRuleSubscribeListExisting(t *testing.T) {
+	skipUnlessRoot(t)
+
+	newNs, err := netns.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer newNs.Close()
+
+	nh, err := NewHandleAt(newNs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer nh.Close()
+
+	src := &net.IPNet{
+		IP:   net.IPv4(10, 10, 10, 0),
+		Mask: net.CIDRMask(24, 32),
+	}
+	rule10 := NewRule()
+	rule10.Src = src
+	rule10.Table = unix.RT_TABLE_MAIN
+	rule10.Priority = 1010
+	if err := nh.RuleAdd(rule10); err != nil {
+		t.Fatal(err)
+	}
+
+	ch := make(chan RuleUpdate)
+	done := make(chan struct{})
+	defer close(done)
+	if err := RuleSubscribeWithOptions(ch, done, RuleSubscribeOptions{
+		Namespace:    &newNs,
+		ListExisting: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if !expectRuleUpdate(ch, unix.RTM_NEWRULE, *rule10) {
+		t.Fatal("Existing add update not received as expected")
+	}
+
+	src2 := &net.IPNet{
+		IP:   net.IPv4(192, 169, 2, 0),
+		Mask: net.CIDRMask(24, 32),
+	}
+	rule := NewRule()
+	rule.Src = src2
+	rule.Table = unix.RT_TABLE_MAIN
+	rule.Priority = 1011
+	if err := nh.RuleAdd(rule); err != nil {
+		t.Fatal(err)
+	}
+	if !expectRuleUpdate(ch, unix.RTM_NEWRULE, *rule) {
+		t.Fatal("Add update not received as expected")
+	}
+	if err := nh.RuleDel(rule); err != nil {
+		t.Fatal(err)
+	}
+	if !expectRuleUpdate(ch, unix.RTM_DELRULE, *rule) {
+		t.Fatal("Del update not received as expected")
+	}
+	if err := nh.RuleDel(rule10); err != nil {
+		t.Fatal(err)
+	}
+	if !expectRuleUpdate(ch, unix.RTM_DELRULE, *rule10) {
+		t.Fatal("Del update not received as expected")
+	}
+}
+
 func ruleExists(rules []Rule, rule Rule) bool {
 	for i := range rules {
 		if ruleEquals(rules[i], rule) {
@@ -695,3 +917,4 @@ func ruleEquals(a, b Rule) bool {
 		(ptrEqual(a.Mask, b.Mask) || (a.Mark != 0 &&
 			(a.Mask == nil && *b.Mask == 0xFFFFFFFF || b.Mask == nil && *a.Mask == 0xFFFFFFFF)))
 }
+


### PR DESCRIPTION
This change adds the ability to subscribe to netlink rule (policy routing) change events, mirroring the existing `RouteSubscribe` API.

## What's new

### Public API

- `RuleSubscribe(ch chan<- RuleUpdate, done <-chan struct{}) error`
- `RuleSubscribeAt(ns netns.NsHandle, ch chan<- RuleUpdate, done <-chan struct{}) error`
- `RuleSubscribeWithOptions(ch chan<- RuleUpdate, done <-chan struct{}, options RuleSubscribeOptions) error`
- `type RuleSubscribeOptions struct`
- `type RuleUpdate struct`

The API and behavior are intentionally aligned with `RouteSubscribe`:

- Subscribes to `RTNLGRP_IPV4_RULE` and `RTNLGRP_IPV6_RULE` multicast groups.
- Emits `RTM_NEWRULE` / `RTM_DELRULE` updates on the provided channel.
- Supports optional namespace selection, error callback, and listing existing rules via `ListExisting`.
- Closes the netlink socket when the `done` channel is closed.

### Internal changes

- Extracted `deserializeRule` from the inline parsing in `RuleListFiltered` so the same decoding logic is reused for both dump results and live subscription messages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for subscribing to network rule changes, including new and deleted rules.
  - Added subscription options for network namespaces, existing-rule listings, receive settings, and error handling.
  - Added rule update notifications with change type and rule details.

- **Bug Fixes**
  - Improved rule decoding to correctly handle table, type, and unset priority values.
  - Updated rule handling for normalized default rule types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->